### PR TITLE
FIX: crash after deleting a city

### DIFF
--- a/simcity.cc
+++ b/simcity.cc
@@ -1685,6 +1685,8 @@ stadt_t::~stadt_t()
 			}
 		}
 	}
+
+	check_city_tiles(true);
 }
 
 


### PR DESCRIPTION
I've run into this problem when deleting a city as the public player: the city destructor calls check_city_tiles(true), but then remove_gebaeude_from_stadt calls check_city_tiles(false), leaving an invalid city pointer for tiles with buildings on it. The easiest fix seems to be just to call check_city_tiles again at the end of the destructor (you might also want to remove the first call).
