### PR TITLE
FIX: avoid use-after-free error caused by a static iterator

### DIFF
--- a/simhalt.cc
+++ b/simhalt.cc
@@ -498,6 +498,7 @@ haltestelle_t::haltestelle_t(loadsave_t* file)
 	rdwr(file);
 
 	alle_haltestellen.append(self);
+	restart_halt_iterator = true;
 
 	// Added by : Knightly
 	inauguration_time = 0;
@@ -509,6 +510,7 @@ haltestelle_t::haltestelle_t(koord k, spieler_t* sp)
 	self = halthandle_t(this);
 	assert( !alle_haltestellen.is_contained(self) );
 	alle_haltestellen.append(self);
+	restart_halt_iterator = true;
 
 	//markers[ self.get_id() ] = current_marker;
 


### PR DESCRIPTION
James,
I think this one-liner might fix the crash upon building the second halt (counting fisheries as halts), as described in http://forum.simutrans.com/index.php?topic=13799.msg137484#msg137484
