### PR TITLE
FIX: minor bugs in the city road removal code

### DIFF
--- a/boden/grund.h
+++ b/boden/grund.h
@@ -765,6 +765,8 @@ public:
 	 */
 	sint32 weg_entfernen(waytype_t wegtyp, bool ribi_rem);
 
+	bool removing_road_would_disconnect_city_building();
+
 	/**
 	 * Description;
 	 *      Look for an adjacent way in the given direction. Think of an object

--- a/simcity.cc
+++ b/simcity.cc
@@ -4428,6 +4428,7 @@ bool stadt_t::baue_strasse(const koord k, spieler_t* sp, bool forced)
 			// Hajo: city roads should not belong to any player => so we can ignore any contruction costs ...
 			weg->set_besch(welt->get_city_road());
 			weg->set_gehweg(true);
+			weg->set_public_right_of_way();
 			bd->neuen_weg_bauen(weg, connection_roads, sp);
 			bd->calc_bild();
 		}

--- a/simwerkz.cc
+++ b/simwerkz.cc
@@ -780,58 +780,12 @@ DBG_MESSAGE("wkz_remover()", "removing way");
 		if(w->get_waytype() == road_wt)
 		{
 			const koord pos = gr->get_pos().get_2d();
-			if(welt->get_city(pos) && !sp->is_public_service())
-			{
-				// Players other than the public player cannot delete a road leaving no access to any city building.
-				for(int n = 0; n < 8; n ++)
-				{
-					const koord k = pos.neighbours[n] + pos;
-					const grund_t* gr = welt->lookup_kartenboden(k);
-					const gebaeude_t* gb = gr ? gr->find<gebaeude_t>() : NULL;
-					if(gb && gb->get_besitzer() == NULL)
-					{
-						// This is a city building - check for other road connexion. 
-						bool unconnected_city_buildings = true;
-						for(int m = 0; m < 8; m ++)
-						{
-							const koord kx = k.neighbours[m] + k;
-							const grund_t* grx = welt->lookup_kartenboden(kx);
-							if (grx == gr) 
-							{
-								// The road being deleted does not count - but others
-								// at different heights DO count.
-								continue;
-							}
-							const weg_t* w = grx ? grx->get_weg(road_wt) : NULL;
-							if(w && w->get_ribi() > 2)
-							{
-								// We must check that the road is itself connected to somewhere other
-								// than the road that we are trying to delete.
-								for(int q = 0; q < 4; q ++)
-								{
-									const koord ky = kx.nsow[q] + kx; 
-									const grund_t* gry = welt->lookup_kartenboden(ky);
-									if (gry == gr)
-									{
-										// The road being deleted does not count - but others
-										// at different heights DO count.
-										continue;
-									}
-									const weg_t* wy = gry ? gry->get_weg(road_wt) : NULL;
-									if(wy && wy->get_ribi() > 2)
-									{
-										unconnected_city_buildings = false;
-										break;
-									}
-								}
-							}
-						}
-						if(unconnected_city_buildings)
-						{
-							msg = "Cannot delete a road where to do so would leave a city building unconnected by road.";
-							return false;
-						}
-					}
+			stadt_t *city = welt->get_city(pos);
+			
+			if(city && !sp->is_public_service()) {
+				if (gr->removing_road_would_disconnect_city_building()) {
+					msg = "Cannot delete a road where to do so would leave a city building unconnected by road.";
+					return false;
 				}
 			}
 			welt->set_recheck_road_connexions();
@@ -3469,61 +3423,11 @@ const char *wkz_wayremover_t::do_work( spieler_t *sp, const koord3d &start, cons
 			if(wt == road_wt)
 			{
 				const koord pos = gr->get_pos().get_2d();
-				if(welt->get_city(pos) && !sp->is_public_service())
-				{
-					// Players other than the public player cannot delete a road leaving no access to any city building.
-					for(int n = 0; n < 8; n ++)
-					{
-						const koord k = pos.neighbours[n] + pos;
-						const sint8 height = welt->lookup_hgt(k);
-						const koord3d k3(k.x, k.y, height);
-						const grund_t* gr = welt->lookup(k3); 
-						const gebaeude_t* gb = gr ? gr->find<gebaeude_t>() : NULL;
-						if(gb && gb->get_besitzer() == NULL)
-						{
-							// This is a city building - check for other road connexion. 
-							bool unconnected_city_buildings = true;
-							for(int m = 0; m < 8; m ++)
-							{
-								const koord kx = k.neighbours[m] + k;
-								const sint8 heightx = welt->lookup_hgt(kx);
-								const koord3d k3x(kx.x, kx.y, heightx);
-								const grund_t* grx = welt->lookup(k3x); 
-								if (grx == gr) {
-									// The road being deleted does not count -- but others
-									// at different heights DO count.
-									continue;
-								}
-								const weg_t* w = grx ? grx->get_weg(road_wt) : NULL;
-								if(w && w->get_ribi() > 2)
-								{
-									// We must check that the road is itself connected to somewhere other
-									// than the road that we are trying to delete.
-									for(int q = 0; q < 4; q ++)
-									{
-										const koord ky = kx.nsow[q] + kx; 
-										const sint8 heighty = welt->lookup_hgt(ky);
-										const koord3d k3y(ky.x, ky.y, heighty);
-										const grund_t* gry = welt->lookup(k3y); 
-										if (gry == gr) {
-											// The road being deleted does not count -- but others
-											// at different heights DO count.
-											continue;
-										}
-										const weg_t* wy = gry ? gry->get_weg(road_wt) : NULL;
-										if(wy && wy->get_ribi() > 2)
-										{
-											unconnected_city_buildings = false;
-											break;
-										}
-									}
-								}
-							}
-							if(unconnected_city_buildings)
-							{
-								return "Cannot delete a road where to do so would leave a city building unconnected by road.";
-							}
-						}
+				stadt_t *city = welt->get_city(pos);
+
+				if(city && !sp->is_public_service()) {
+					if (gr->removing_road_would_disconnect_city_building()) {
+						return "Cannot delete a road where to do so would leave a city building unconnected by road.";
 					}
 				}
 				welt->set_recheck_road_connexions();


### PR DESCRIPTION
James,
there were a few minor bugs in the checks we perform before deleting city roads:
- get_ribi() > 2 doesn't guarantee more than one ribi bit is actually set--the ribis might be 4 or 8.
- gr was shadowed by a locally-scoped variable
- we didn't allow deleting a "double cul-de-sac" like this:
  hhh
  shs
  hhh

The consequence was you could delete most cities' road network if you started in the northeast and worked your way forward from there.

This patch (against the way-improvements branch which I gather is the currently active one) also moves the code to avoid duplication and makes city roads be public right of ways, which enables the diversionary route check, which I think is more realistic than being able to delete your city centre intersection because the rest of the road network is still connected.

I've tested it a little, and I think it should be fine.
