### PR TITLE
FIX: make sure we call register_stops when changing schedules

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -2605,11 +2605,18 @@ bool convoi_t::set_schedule(schedule_t * f)
 		}
 	}
 
+	if (fpl == f && old_fpl) {
+		fpl = old_fpl;
+	}
+	
 	// happens to be identical?
 	if(fpl!=f) {
 		// now check, we we have been bond to a line we are about to lose:
 		bool changed = false;
 		if(  line.is_bound()  ) {
+			if(  !f->matches(welt, fpl)) {
+				changed = true;
+			}
 			if(  !f->matches( welt, line->get_schedule() )  ) {
 				// change from line to individual schedule
 				//		-> unset line now and register stops from new schedule later


### PR DESCRIPTION
This one is slightly tricky: when closing the schedule window, convoi_t::step calls set_schedule with fpl == f, but the schedule has still changed; a copy of the old schedule is stored in old_fpl, and this patch very temporarily restores it to compare against that instead.

Without the patch, you could cause a fatal index error by doing this:
- create three stops: A, B, and C
- create a line connecting A to B
- create a convoy with a schedule containing A, B, and C
- wait for the convoy to visit C
- edit the convoy's schedule to consist only of A and B (it will automatically revert to being on the line)
- wait for the convoy to visit the next stop

At that point, the departures map would contain an entry with iter.key.entry == 2, but the schedule would contain only two stops. This line in convoi_t::laden would then cause the error:

```
const koord3d halt_position = fpl->eintrag.get_element(iter.key.entry).pos;
```

A better fix might be to make the schedule window operate on a copy of the schedule, not the actual convoy's schedule, but I've gone for the easiest fix.

I'm pretty sure this isn't present in Standard.
