### PR TITLE
FIX: minor bug in factory location finder code

### DIFF
--- a/bauer/fabrikbauer.cc
+++ b/bauer/fabrikbauer.cc
@@ -145,7 +145,7 @@ public:
 						return false;
 					}
 				}
-				else if (  !next_to_road  &&  (-1 < x && x < b) || (-1 < y && y < h)  ) {
+				else if (  !next_to_road  &&  ((-1 < x && x < b) || (-1 < y && y < h))  ) {
 					// Border (because previous clause didn't trigger) but not corner.
 					// Look for a road.
 					next_to_road = gr->hat_weg(road_wt);


### PR DESCRIPTION
James,
this is independent of the issue Junna reported. I believe it's a bug in the factory placement code, which would effectively result in some city factories only appearing if there's a road at the corner of the building site, rather than anywhere near the margin.

This code is also broken in Standard, but in a different way.

However, I believe that the trick of checking welt->lookup(pos+koord3d(0,0,1)) to see whether we can build on a square is generally dodgy: there might be a bridge without pillars at height pos+koord3d(0,0,2), or pos+koord3d(0,0,5) for that matter. karte_t::square_is_free checks the first possibility, but not the second, and a few places appear to be doing the check by hand rather than calling square_is_free.

Am I right in thinking that the intention is for there not to be any bridges over city factories at all?

Philip
