### PR TITLE
FIX: stack overflow when running in network mode

### DIFF
--- a/simworld.cc
+++ b/simworld.cc
@@ -9015,7 +9015,8 @@ bool karte_t::interactive(uint32 quit_month)
 
 #ifdef DEBUG_SIMRAND_CALLS
 					char buf[2048];
-					LCHKLST(sync_steps).print(buf, "chklist");
+					const int offset = LCHKLST(sync_steps).print(buf, "chklist");
+					assert(offset<2048);
 					dbg->warning("karte_t::interactive", "sync_step=%u  %s", sync_steps, buf);
 #endif
 


### PR DESCRIPTION
James,
I ran into problems with random stack corruption when running in network mode; the culprit appears to be code calling checklist_t::print with a buffer that's too small—256 bytes isn't even enough for one checklist (275 bytes), nevermind the second checklist that's printed there.

It's probably too much to hope that this might fix the random network desynchs that have been plaguing people, but I'm pretty sure it was causing some desynchs.

I hope your move is going well,
Philip
