### PR TITLE
CHANGE: make 45 degree turns free under some circumstances

### DIFF
--- a/vehicle/simvehikel.cc
+++ b/vehicle/simvehikel.cc
@@ -1783,7 +1783,9 @@ sint32 vehikel_t::calc_speed_limit(const weg_t *w, const weg_t *weg_previous, fi
 		}
 
 		// Now apply the adjusted corner limit
-		corner_speed_limit = min((averaged_base_limit * limit_adjustment_percentage) / 100, hard_limit);
+		if (direction_difference > 45) {
+			corner_speed_limit = min((averaged_base_limit * limit_adjustment_percentage) / 100, hard_limit);
+		}
 
 #ifndef debug_corners
 	}


### PR DESCRIPTION
James,
this is the more extensive version of the "cornering" fix, making 45 degree turns free if there's no left-right-right-left (or right-left-left-right) sequence within the stretch we're considering. The version that's just the bug fix is at james-fix-debug-corners (15763b79018dc00fd5df6811) (that bug is only a problem if debug_corners is #defined, so it's not much of an issue).

Obviously I can create pull requests for any code you like, but I think the other fixes aren't quite there yet—Jonna's issue is still there, and there seems to be consensus that a way object is a better way of implementing protected roads than barriers. Forward-porting the bridge fixes is going to take a few minutes, and the fix for way tooltips isn't really required without the signal indication arrows, which prissi asked be reimplemented with pak set support.

Do let me know if there's anything you want, I'm more than happy to isolate changes and create a pull request if it's any help whatsoever.

Philip
