### PR TITLE
Mitigate negative in-transit

### DIFF
--- a/simfab.cc
+++ b/simfab.cc
@@ -1578,7 +1578,15 @@ sint32 fabrik_t::liefere_an(const ware_desc_t *typ, sint32 menge)
 			if(  ware.get_typ() == typ  ) {
 				// Can't use update_transit for interface reasons; we don't take a ware argument.
 				// We should, however.
-				ware.book_stat( -menge, FAB_GOODS_TRANSIT );
+
+				// A.Badger: Avoid negative in_transit (and underflow if this
+				// changes to unsigned)
+				const sint32 current_in_transit_amt = ware.get_stat(0, FAB_GOODS_TRANSIT);
+				if (current_in_transit_amt < menge) {
+					ware.book_stat( -current_in_transit_amt, FAB_GOODS_TRANSIT );
+				} else {
+					ware.book_stat( -menge, FAB_GOODS_TRANSIT );
+				}
 				// Hajo: avoid overflow
 				if(  ware.menge < (FAB_MAX_INPUT - menge) << precision_bits  ) {
 					ware.menge += menge << precision_bits;


### PR DESCRIPTION
Note: Compiled on Linux x86_64 with SDL2 and tested with save games here: http://forum.simutrans.com/index.php?topic=16804.msg160136#msg160136

For an unknown reason, simutrans sometimes records more goods being
delivered than were expected to be delivered.  This leads to a negative
in-transit amount.  Since the game calculates whether more goods are
allowed to be shipped from a supplier by seeing if the currently
in-transit amount is less than the maximum in transit amount, a negative
in-transit inflates the amount of goods that can be sent.

Note that this doesn't solve the reason that the game is recording more
goods delivered than expected, it merely mitigates the problem once it
occurs.