### PR TITLE
Few cleanups to comments so gcc spews less warnings

### DIFF
--- a/boden/grund.h
+++ b/boden/grund.h
@@ -239,8 +239,6 @@ public:
 	void set_all_obj_dirty() { objlist.set_all_dirty(); }
 
 	/**
-
-	/**
 	 * Dient zur Neuberechnung des Bildes, wenn sich die Umgebung
 	 * oder die Lage (Hang) des grundes geaendert hat.
 	 * @author Hj. Malthaner

--- a/gui/depot_frame.cc
+++ b/gui/depot_frame.cc
@@ -227,6 +227,7 @@ void depot_frame_t::layout(scr_size *size)
 	placement.y = depot->get_y_placement() * get_base_tile_raster_width() / 64 + 2;
 	grid_dx = depot->get_x_grid() * get_base_tile_raster_width() / 64 / 2;
 	placement_dx = depot->get_x_grid() * get_base_tile_raster_width() / 64 / 4;
+	*/
 
 	/*
 	*	Dialog format:

--- a/player/finance.h
+++ b/player/finance.h
@@ -11,7 +11,7 @@
 #include "../simtypes.h"
 #include "../simworld.h"
 
- /****************************************** notification strings ************************************** /
+ /****************************************** notification strings **************************************/
 
  /**
  * Translated notification text identifiers used by tools are placed here.


### PR DESCRIPTION
Minor cleanup: make sure opened comments are closed so that gcc emits fewer warnings.

Reduces output of compile with gcc by almost 2000 lines:

```
$ wc -l compile*log             *[master]  (11:36:10)
  3408 compile-cleanup.log
  5380 compile-upstream.log
```