### PR TITLE
fix potential overflow in inauguration_time

### DIFF
--- a/simhalt.h
+++ b/simhalt.h
@@ -479,7 +479,7 @@ private:
 	// Purpose	: To store the time at which this halt is created
 	//			  This is *not* saved in save games.
 	//			  When loading halts from save game, this is set to 0
-	uint32 inauguration_time;
+	sint64 inauguration_time;
 
 	/**
 	* Arrival times of convoys bound for this stop, estimated based on 
@@ -939,7 +939,7 @@ public:
 
 	// Addedy by : Knightly
 	// Purpose	 : Return the time at which the halt was first created
-	uint32 get_inauguration_time() { return inauguration_time; }
+	sint64 get_inauguration_time() { return inauguration_time; }
 
 	/*
 	* deletes factory references so map rotation won't segfault


### PR DESCRIPTION
inauguration_time is an unsigned 32 bit value but it's being set from
get_zeit_ms() which returns a 64bit signed value.  If the 64bit signed
value won't fit into the 32 bit type (>4294967291) then it will overflow
and wrap to 0.  This could lead to odd behaviour with industries not
registering with stops midway through a long running game.

Diagnosed here:
http://forum.simutrans.com/index.php?topic=16673.msg160669#msg160669