### PR TITLE
FIX: translation of Prohibitive %i at tooltips

### DIFF
--- a/simtool.cc
+++ b/simtool.cc
@@ -2440,7 +2440,7 @@ const char* tool_build_way_t::get_tooltip(const player_t *) const
 			}
 			any_prohibitive = true;
 			char tmpbuf[30];
-			sprintf(tmpbuf, "Prohibitive %i", i);
+			sprintf(tmpbuf, "Prohibitive %i-%i", desc->get_wtyp(), i);
 			n += sprintf(toolstr + n, " ");
 			n += sprintf(toolstr + n, translator::translate(tmpbuf));
 		}


### PR DESCRIPTION
This is the translation fix pointed out by Vladki in https://forum.simutrans.com/index.php/topic,17889.0.html .