### PR TITLE
MSVC pre-build script always generate revision.h

### DIFF
--- a/revision.jse
+++ b/revision.jse
@@ -4,42 +4,60 @@ var ForWriting = 2;
 var fso   = new ActiveXObject("Scripting.FileSystemObject");
 var shell = new ActiveXObject("WScript.Shell");
 
-//var svnRevNum	= shell.Exec("svnversion");
-//var rev			= svnRevNum.StdOut.ReadAll();
-var gitRevNum	= shell.Exec("git rev-parse --short HEAD");
-var rev			= gitRevNum.StdOut.ReadAll();
-var filename	= "revision.h";
+var rev;
+var filename = "revision.h";
 var file;
 var file_ts;
+var errorcode;
 
 // First, get the file, if it doesn't exist create it.
-if( ! fso.FileExists(filename) ) {
+if (!fso.FileExists(filename)) {
 	fso.CreateTextFile(filename);
 	file = fso.GetFile(filename);
-	file_ts = file.OpenAsTextStream(ForWriting,-2);
+	file_ts = file.OpenAsTextStream(ForWriting, -2);
 	file_ts.WriteLine("#define REVISION   UNDEFINED");
 	file_ts.Close();
+	errorcode = 0;
 }
 else {
 	file = fso.GetFile(filename);
+	errorcode = 1;
 }
 
-// read it
+var errormsg = !errorcode
+               ? " Revision number will be set to zero. You won't be able to play online with this build."
+               : " A revision file already exists and its revision number won't be updated. Make sure the revision number is correct or you won't be able to play online with this build.";
 
-file_ts = file.OpenAsTextStream(ForReading,-2);
-current_line = file_ts.ReadLine() + "\r\n";
+// Try to get revision number
+try {
+	var gitRevNum = shell.Exec("git rev-parse --short HEAD");
+	rev           = gitRevNum.StdOut.ReadAll();
+
+	// Check if Git output is valid
+	if (rev.length !== 9) {
+		WSH.Echo("git : Not a git repository warning GitNR" + errorcode + ":Git output not valid! Check if the folder is actually versioned." + errormsg);
+		rev = 0;
+	}
+}
+catch (e) {
+	WSH.Echo("git : Git not found warning GitNF" + errorcode + ":Git could not be found!" + errormsg);
+	rev = 0;
+}
+
+// Read revision.h
+
+file_ts = file.OpenAsTextStream(ForReading, -2);
+var current_line = file_ts.ReadLine() + "\r\n";
 file_ts.Close();
 
-new_line = "#define REVISION   " + String(rev);
+var new_line = !rev ? "" : "#define REVISION   " + String(rev);
 
-if (new_line != current_line) {
-
+if (!errorcode || (!!rev && new_line !== current_line)) {
 	// It has changed, update the .h
 
-	WSH.Echo("Svn version updated! " + String(rev));
+	WSH.Echo("revision.h(0) : info GitUPD:" + (!rev ? "No revision number set!" : "Git version updated! " + String(rev)));
 
-	file_ts = file.OpenAsTextStream(ForWriting,-2);
+	file_ts = file.OpenAsTextStream(ForWriting, -2);
 	file_ts.WriteLine(new_line);
 	file_ts.Close();
-
 }


### PR DESCRIPTION
This is a fix to go along with commit r8425 from Standard that helps people to always be able to compile Simutrans even if they don't have Git to generate a revision number [as discussed on the forums](https://forum.simutrans.com/index.php/topic,18150.0.html).

The script will now generate an empty `revision.h` file that will allow MSVC to accept compilation but compile with `REVISION` macro undefined instead of randomly showing a crash log and failing to compile.

It will also, hopefully, output warnings on Visual Studio output to make it easier to let people know the consequences of not having a revision number.