### PR TITLE
FIX: incorrect schedule edited from depot on high latency games

### DIFF
--- a/gui/depot_frame.cc
+++ b/gui/depot_frame.cc
@@ -847,16 +847,7 @@ void depot_frame_t::open_schedule_editor()
 			create_win( new line_management_gui_t( selected_line, depot->get_owner() ), w_info, (ptrdiff_t)selected_line.get_rep() );
 		}
 		else { // edit individual schedule
-			// this can happen locally, since any update of the schedule is done during closing window
-			schedule_t *schedule = cnv->create_schedule();
-			assert(schedule!=NULL);
-			gui_frame_t *fplwin = win_get_magic( (ptrdiff_t)schedule );
-			if(  fplwin == NULL  ) {
-				cnv->open_schedule_window( welt->get_active_player() == cnv->get_owner() );
-			}
-			else {
-				top_win( fplwin );
-			}
+			cnv->call_convoi_tool( 'f', NULL );
 		}
 	}
 	else {

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5219,17 +5219,15 @@ void convoi_t::open_schedule_window( bool show )
 	if (schedule)
 	{
 		old_schedule = schedule->copy();
+	} else {
+		schedule = create_schedule();
 	}
-
 	if(  show  ) {
 		// Open schedule dialog
 		create_win( new schedule_gui_t(schedule,get_owner(),self), w_info, (ptrdiff_t)schedule );
 		// TODO: what happens if no client opens the window??
 	}
-	if(schedule)
-	{
-		schedule->start_editing();
-	}
+	schedule->start_editing();
 }
 
 


### PR DESCRIPTION
This uses call_convoi_tool instead attempting to derive schedule from convoy, which caused buggy behaviour when this was being updated.