### PR TITLE
FIX: Build & run up to title screen without errors on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,8 @@ else
 endif
 
 ifeq ($(OSTYPE),mac)
-  CFLAGS +=  -std=c++11 -stdlib=libstdc++
-  LDFLAGS += -stdlib=libstdc++
+  CFLAGS +=  -std=c++11 -stdlib=libc++
+  LDFLAGS += -stdlib=libc++
 endif
 
 ifeq ($(OSTYPE), mingw64)
@@ -514,7 +514,7 @@ endif
 ifeq ($(BACKEND),sdl)
   SOURCES += simsys_s.cc
   ifeq ($(OSTYPE),mac)
-		ifeq ($(AV_FOUNDATION),1)
+		ifeq ($(shell expr $(AV_FOUNDATION) \>= 1), 1)
 			# Core Audio (AVFoundation) base sound system routines
 			SOURCES += sound/AVF_core-audio_sound.mm
 			SOURCES += music/AVF_core-audio_midi.mm
@@ -556,7 +556,7 @@ endif
 ifeq ($(BACKEND),sdl2)
   SOURCES += simsys_s2.cc
   ifeq ($(OSTYPE),mac)
-		ifeq ($(AV_FOUNDATION),1)
+		ifeq ($(shell expr $(AV_FOUNDATION) \>= 1), 1)
 			# Core Audio (AVFoundation) base sound system routines
 			SOURCES += sound/AVF_core-audio_sound.mm
 			SOURCES += music/AVF_core-audio_midi.mm
@@ -578,7 +578,7 @@ ifeq ($(BACKEND),sdl2)
   ifeq ($(SDL2_CONFIG),)
     ifeq ($(OSTYPE),mac)
       SDL_CFLAGS  := -I/Library/Frameworks/SDL2.framework/Headers
-      SDL_LDFLAGS := -framework SDL2
+      SDL_LDFLAGS := -F/Library/Frameworks -framework SDL2
     else
       SDL_CFLAGS  := -I$(MINGDIR)/include/SDL2 -Dmain=SDL_main
       SDL_LDFLAGS := -lSDL2main -lSDL2
@@ -614,7 +614,7 @@ endif
 ifeq ($(BACKEND),opengl)
   SOURCES += simsys_opengl.cc
   ifeq ($(OSTYPE),mac)
-		ifeq ($(AV_FOUNDATION),1)
+		ifeq ($(shell expr $(AV_FOUNDATION) \>= 1), 1)
 			# Core Audio (AVFoundation) base sound system routines
 			SOURCES += sound/AVF_core-audio_sound.mm
 			SOURCES += music/AVF_core-audio_midi.mm

--- a/boden/wege/weg.cc
+++ b/boden/wege/weg.cc
@@ -357,6 +357,7 @@ void weg_t::init()
 	remaining_wear_capacity = 100000000;
 	replacement_way = NULL;
 #ifdef MULTI_THREAD
+	pthread_mutexattr_init(&mutex_attributes);
 	pthread_mutex_init(&private_car_store_route_mutex, &mutex_attributes);
 #endif
 }

--- a/boden/wege/weg.cc
+++ b/boden/wege/weg.cc
@@ -367,7 +367,9 @@ weg_t::~weg_t()
 {
 	if (!welt->is_destroying())
 	{
+#ifdef MULTI_THREAD
 		welt->await_private_car_threads();
+#endif
 		delete_all_routes_from_here();
 		
 		alle_wege.remove(this);

--- a/convoy.cc
+++ b/convoy.cc
@@ -440,7 +440,14 @@ void convoy_t::calc_move(const settings_t &settings, long delta_t, const weight_
 				}
 			}
 			dx = x;
-			delta_s -= dt_s; // another time slice passed
+			if (delta_s == dt_s) {
+				// Fix strange bug (macOS, clang LLVM v9.0.0): when compiled without -fno-inline (DEBUG <= 1),
+				// and when delta_s == dt_s, delta_s - dt_s equals some positive number instead of zero, which
+				// causes the while loop & this function to run forever.
+				delta_s = float32e8_t::zero;
+			} else {
+				delta_s -= dt_s; // another time slice passed
+			}
 		}
 		akt_v = v;
 		akt_speed = v_to_speed(v); // akt_speed in simutrans vehicle speed, v in m/s

--- a/gui/settings_stats.cc
+++ b/gui/settings_stats.cc
@@ -218,7 +218,9 @@ void settings_extended_general_stats_t::init( settings_t *sets )
 	}
 	SEPERATOR;
 
+#ifdef MULTI_THREAD
 	world()->await_private_car_threads();
+#endif
 
 	INIT_NUM( "city_threshold_size", sets->get_city_threshold_size(), 1000, 100000, gui_numberinput_t::AUTOLINEAR, false );
 	INIT_NUM( "capital_threshold_size", sets->get_capital_threshold_size(), 10000, 1000000, gui_numberinput_t::AUTOLINEAR, false );
@@ -331,7 +333,9 @@ void settings_extended_general_stats_t::init( settings_t *sets )
 
 void settings_extended_general_stats_t::read(settings_t *sets)
 {
+#ifdef MULTI_THREAD
 	world()->await_private_car_threads();
+#endif
 	READ_INIT;
 
 	READ_NUM( sets->set_tpo_min_minutes );

--- a/music/AVF_core-audio_midi.mm
+++ b/music/AVF_core-audio_midi.mm
@@ -46,9 +46,11 @@ void dr_play_midi(int const key)
 
 void dr_stop_midi()
 {
-	// We assume the 'nowPlaying' key holds the most recently started track.
-	AVMIDIPlayer* const player = [players objectAtIndex: nowPlaying];
-	[player stop];
+	if (nowPlaying != -1) {
+		// We assume the 'nowPlaying' key holds the most recently started track.
+		AVMIDIPlayer* const player = [players objectAtIndex: nowPlaying];
+		[player stop];
+	}
 }
 
 

--- a/obj/roadsign.cc
+++ b/obj/roadsign.cc
@@ -116,7 +116,9 @@ roadsign_t::roadsign_t(player_t *player, koord3d pos, ribi_t::ribi dir, const ro
 		world()->await_convoy_threads();
 	}
 #endif
+#ifdef MULTI_THREAD
 	welt->await_private_car_threads();
+#endif
 	this->desc = desc;
 	this->dir = dir;
 	this->preview = preview;

--- a/simcity.cc
+++ b/simcity.cc
@@ -2827,8 +2827,11 @@ void stadt_t::new_month()
 
 	uint16 congestion_density_factor = s.get_congestion_density_factor();
 
+#ifdef MULTI_THREAD
 	int error = pthread_mutex_lock(&karte_t::private_car_route_mutex);
 	assert(error == 0);
+#endif
+
 	if(congestion_density_factor < 32)
 	{
 		// Old method - congestion density factor
@@ -2897,8 +2900,11 @@ void stadt_t::new_month()
 	}
 
 	incoming_private_cars = 0;
+
+#ifdef MULTI_THREAD
 	error = pthread_mutex_unlock(&karte_t::private_car_route_mutex);
 	assert(error == 0);
+#endif
 }
 
 void stadt_t::calc_growth()


### PR DESCRIPTION
This PR fixes a few compilation errors on macOS, as well as run-time crashes and freeze-ups, both for MULTI_THREAD = 0 and 1.

--------------------------------

One perplexing bug I found causes `convoy_t::calc_move` to get stuck in an infinite loop. Specifically, it happens when I compile without `-fno-inline` (i.e. DEBUG < 2 or PROFILE = 2) using clang v9.0.0 on a Mac.

I dug deeper and the problem appears to be how my compiler compiled float32e8_t subtraction in the case where both operands are equal. Here's an example:

```
float32e8_t a(123, 1000);
cout << "a = " << a << endl;
cout << "a - a = " << (a - a) << endl;
// a = 0.123
// a - a = 0.960938
```

This meant the stopping condition for the while loop in `convoy_t::calc_move` could never be reached. Note that this behavior doesn't happen when compiled with `-fno-inline`.

I worked around the bug in this PR by explicitly checking when the two operands are the same and hard-coding the result to zero. I'm open to better ideas for how to fix this.