### PR TITLE
Clean up include guards

### DIFF
--- a/bauer/brueckenbauer.h
+++ b/bauer/brueckenbauer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __simbridge_h
-#define __simbridge_h
+#ifndef BAUER_BRUECKENBAUER_H
+#define BAUER_BRUECKENBAUER_H
+
 
 #include "../simtypes.h"
 #include "../dataobj/koord.h"

--- a/bauer/fabrikbauer.h
+++ b/bauer/fabrikbauer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef fabrikbauer_t_h
-#define fabrikbauer_t_h
+#ifndef BAUER_FABRIKBAUER_H
+#define BAUER_FABRIKBAUER_H
+
 
 #include "../tpl/stringhashtable_tpl.h"
 #include "../tpl/weighted_vector_tpl.h"

--- a/bauer/goods_manager.h
+++ b/bauer/goods_manager.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef goods_manager_t_h
-#define goods_manager_t_h
+#ifndef BAUER_GOODS_MANAGER_H
+#define BAUER_GOODS_MANAGER_H
+
 
 #include "../tpl/vector_tpl.h"
 #include "../tpl/stringhashtable_tpl.h"

--- a/bauer/hausbauer.h
+++ b/bauer/hausbauer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef HAUSBAUER_H
-#define HAUSBAUER_H
+#ifndef BAUER_HAUSBAUER_H
+#define BAUER_HAUSBAUER_H
+
 
 #include "../descriptor/building_desc.h"
 #include "../dataobj/koord3d.h"

--- a/bauer/tunnelbauer.h
+++ b/bauer/tunnelbauer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __simtunnel_h
-#define __simtunnel_h
+#ifndef BAUER_TUNNELBAUER_H
+#define BAUER_TUNNELBAUER_H
+
 
 #include "../simtypes.h"
 #include "../dataobj/koord.h"

--- a/bauer/vehikelbauer.h
+++ b/bauer/vehikelbauer.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef vehicle_builder_t_h
-#define vehicle_builder_t_h
+#ifndef BAUER_VEHIKELBAUER_H
+#define BAUER_VEHIKELBAUER_H
 
 
 #include "../dataobj/koord3d.h"

--- a/bauer/wegbauer.h
+++ b/bauer/wegbauer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simbau_h
-#define simbau_h
+#ifndef BAUER_WEGBAUER_H
+#define BAUER_WEGBAUER_H
+
 
 #include "../boden/wege/weg.h"
 #include "../tpl/vector_tpl.h"

--- a/boden/boden.h
+++ b/boden/boden.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef boden_boden_h
-#define boden_boden_h
+#ifndef BODEN_BODEN_H
+#define BODEN_BODEN_H
+
 
 #include "grund.h"
 

--- a/boden/brueckenboden.h
+++ b/boden/brueckenboden.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef brueckenboden_h
-#define brueckenboden_h
+#ifndef BODEN_BRUECKENBODEN_H
+#define BODEN_BRUECKENBODEN_H
+
 
 #include "grund.h"
 

--- a/boden/fundament.h
+++ b/boden/fundament.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef boden_fundament_h
-#define boden_fundament_h
+#ifndef BODEN_FUNDAMENT_H
+#define BODEN_FUNDAMENT_H
+
 
 #include "grund.h"
 

--- a/boden/grund.h
+++ b/boden/grund.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef boden_grund_h
-#define boden_grund_h
+#ifndef BODEN_GRUND_H
+#define BODEN_GRUND_H
 
 
 #include "../halthandle_t.h"

--- a/boden/monorailboden.h
+++ b/boden/monorailboden.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef monorailboden_h
-#define monorailboden_h
+#ifndef BODEN_MONORAILBODEN_H
+#define BODEN_MONORAILBODEN_H
+
 
 #include "grund.h"
 

--- a/boden/tunnelboden.h
+++ b/boden/tunnelboden.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef tunnelboden_h
-#define tunnelboden_h
+#ifndef BODEN_TUNNELBODEN_H
+#define BODEN_TUNNELBODEN_H
+
 
 #include "boden.h"
 

--- a/boden/wasser.h
+++ b/boden/wasser.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef boden_wasser_h
-#define boden_wasser_h
+#ifndef BODEN_WASSER_H
+#define BODEN_WASSER_H
+
 
 #include "grund.h"
 

--- a/boden/wege/kanal.h
+++ b/boden/wege/kanal.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef boden_wege_dock_h
-#define boden_wege_dock_h
+#ifndef BODEN_WEGE_KANAL_H
+#define BODEN_WEGE_KANAL_H
+
 
 #include "weg.h"
 #include "../../dataobj/loadsave.h"

--- a/boden/wege/maglev.h
+++ b/boden/wege/maglev.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef boden_wege_maglev_h
-#define boden_wege_maglev_h
+#ifndef BODEN_WEGE_MAGLEV_H
+#define BODEN_WEGE_MAGLEV_H
 
 
 #include "schiene.h"

--- a/boden/wege/monorail.h
+++ b/boden/wege/monorail.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef boden_wege_monorail_h
-#define boden_wege_monorail_h
+#ifndef BODEN_WEGE_MONORAIL_H
+#define BODEN_WEGE_MONORAIL_H
 
 
 #include "schiene.h"

--- a/boden/wege/narrowgauge.h
+++ b/boden/wege/narrowgauge.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef boden_wege_narrowgauge_h
-#define boden_wege_narrowgauge_h
+#ifndef BODEN_WEGE_NARROWGAUGE_H
+#define BODEN_WEGE_NARROWGAUGE_H
 
 
 #include "schiene.h"

--- a/boden/wege/runway.h
+++ b/boden/wege/runway.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef boden_wege_runway_h
-#define boden_wege_runway_h
+#ifndef BODEN_WEGE_RUNWAY_H
+#define BODEN_WEGE_RUNWAY_H
 
 
 #include "schiene.h"

--- a/boden/wege/schiene.h
+++ b/boden/wege/schiene.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef boden_wege_schiene_h
-#define boden_wege_schiene_h
+#ifndef BODEN_WEGE_SCHIENE_H
+#define BODEN_WEGE_SCHIENE_H
 
 
 #include "weg.h"

--- a/boden/wege/strasse.h
+++ b/boden/wege/strasse.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef boden_wege_strasse_h
-#define boden_wege_strasse_h
+#ifndef BODEN_WEGE_STRASSE_H
+#define BODEN_WEGE_STRASSE_H
+
 
 #include "weg.h"
 //#include "../../tpl/minivec_tpl.h"

--- a/boden/wege/weg.h
+++ b/boden/wege/weg.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef boden_wege_weg_h
-#define boden_wege_weg_h
+#ifndef BODEN_WEGE_WEG_H
+#define BODEN_WEGE_WEG_H
+
 
 #if 0
 // This was slower than the Simutrans koordhashtable

--- a/convoihandle_t.h
+++ b/convoihandle_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef convoihandle_t_h
-#define convoihandle_t_h
+#ifndef CONVOIHANDLE_T_H
+#define CONVOIHANDLE_T_H
+
 
 #include "tpl/quickstone_tpl.h"
 

--- a/convoy.h
+++ b/convoy.h
@@ -57,8 +57,9 @@ a = (Fm - Frs - cf * v^2) / m
 *******************************************************************************/
 #pragma once
 
-#ifndef convoy_h
-#define convoy_h
+#ifndef CONVOY_H
+#define CONVOY_H
+
 
 #include <limits>
 #include <math.h>

--- a/dataobj/crossing_logic.h
+++ b/dataobj/crossing_logic.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef crossing_logic_h
-#define crossing_logic_h
+#ifndef DATAOBJ_CROSSING_LOGIC_H
+#define DATAOBJ_CROSSING_LOGIC_H
+
 
 #include "../simtypes.h"
 #include "../tpl/minivec_tpl.h"

--- a/dataobj/environment.h
+++ b/dataobj/environment.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef dataobj_environment_h
-#define dataobj_environment_h
+#ifndef DATAOBJ_ENVIRONMENT_H
+#define DATAOBJ_ENVIRONMENT_H
+
 
 #include <string>
 #include "../simtypes.h"

--- a/dataobj/freelist.h
+++ b/dataobj/freelist.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef freelist_t_h
-#define freelist_t_h
+#ifndef DATAOBJ_FREELIST_H
+#define DATAOBJ_FREELIST_H
+
 
 /**
  * Helper class to organize small memory objects i.e. nodes for linked lists

--- a/dataobj/gameinfo.h
+++ b/dataobj/gameinfo.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef dataobj_gameinfo_h
-#define dataobj_gameinfo_h
+#ifndef DATAOBJ_GAMEINFO_H
+#define DATAOBJ_GAMEINFO_H
+
 
 #include <string>
 #include "../simtypes.h"

--- a/dataobj/height_map_loader.h
+++ b/dataobj/height_map_loader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef load_height_file_h
-#define load_height_file_h
+#ifndef DATAOBJ_HEIGHT_MAP_LOADER_H
+#define DATAOBJ_HEIGHT_MAP_LOADER_H
+
 
 #include "../simtypes.h"
 #include "environment.h"

--- a/dataobj/koord.h
+++ b/dataobj/koord.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef KOORD_H
-#define KOORD_H
+#ifndef DATAOBJ_KOORD_H
+#define DATAOBJ_KOORD_H
+
 
 #include "ribi.h"
 #include "../simtypes.h"

--- a/dataobj/koord3d.h
+++ b/dataobj/koord3d.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef KOORD3D_H
-#define KOORD3D_H
+#ifndef DATAOBJ_KOORD3D_H
+#define DATAOBJ_KOORD3D_H
+
 
 #include "koord.h"
 #include "ribi.h"

--- a/dataobj/livery_scheme.h
+++ b/dataobj/livery_scheme.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef dataobj_livery_scheme_h
-#define dataobj_livery_scheme_h
+#ifndef DATAOBJ_LIVERY_SCHEME_H
+#define DATAOBJ_LIVERY_SCHEME_H
+
 
 #include <string>
 

--- a/dataobj/loadsave.h
+++ b/dataobj/loadsave.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef loadsave_h
-#define loadsave_h
+#ifndef DATAOBJ_LOADSAVE_H
+#define DATAOBJ_LOADSAVE_H
+
 
 #include <stdio.h>
 #include <string>

--- a/dataobj/marker.h
+++ b/dataobj/marker.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __MARKER_H
-#define __MARKER_H
+#ifndef DATAOBJ_MARKER_H
+#define DATAOBJ_MARKER_H
+
 
 #include "../tpl/ptrhashtable_tpl.h"
 

--- a/dataobj/objlist.h
+++ b/dataobj/objlist.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef objlist_h
-#define objlist_h
+#ifndef DATAOBJ_OBJLIST_H
+#define DATAOBJ_OBJLIST_H
+
 
 #include "../simtypes.h"
 #include "../simobj.h"

--- a/dataobj/powernet.h
+++ b/dataobj/powernet.h
@@ -5,8 +5,9 @@
 
 /** @file powernet.h Data structure to manage a net of powerlines - a powernet */
 
-#ifndef powernet_t_h
-#define powernet_t_h
+#ifndef DATAOBJ_POWERNET_H
+#define DATAOBJ_POWERNET_H
+
 
 #include "../simtypes.h"
 #include "../tpl/slist_tpl.h"

--- a/dataobj/replace_data.h
+++ b/dataobj/replace_data.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef replace_data_h
-#define replace_data_h
+#ifndef DATAOBJ_REPLACE_DATA_H
+#define DATAOBJ_REPLACE_DATA_H
+
 
 #include "../simconvoi.h"
 #include "../tpl/vector_tpl.h"

--- a/dataobj/ribi.h
+++ b/dataobj/ribi.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef dataobj_ribi_t_h
-#define dataobj_ribi_t_h
+#ifndef DATAOBJ_RIBI_H
+#define DATAOBJ_RIBI_H
+
 
 #include "../simtypes.h"
 #include "../simconst.h"

--- a/dataobj/route.cc
+++ b/dataobj/route.cc
@@ -205,21 +205,7 @@ bool route_t::find_route(karte_t *welt, const koord3d start, test_driver_t *tdri
 	// nothing in lists
 	marker_t& marker = marker_t::instance(welt->get_size().x, welt->get_size().y, karte_t::marker_index);
 
-	// there are several variant for maintaining the open list
-	// however, only binary heap and HOT queue with binary heap are worth considering
-#if defined(tpl_HOT_queue_tpl_h)
-    // static
-	HOT_queue_tpl <ANode *> queue;
-#elif defined(tpl_binary_heap_tpl_h)
-    //static
 	binary_heap_tpl <ANode *> queue;
-#elif defined(tpl_sorted_heap_tpl_h)
-    //static
-	sorted_heap_tpl <ANode *> queue;
-#else
-    //static
-	prioqueue_tpl <ANode *> queue;
-#endif
 
 	// nothing in lists
 	queue.clear();
@@ -671,21 +657,7 @@ route_t::route_result_t route_t::intern_calc_route(karte_t *welt, const koord3d 
 		INIT_NODES(welt->get_settings().get_max_route_steps(), welt->get_size());
 	}
 
-	// there are several variant for maintaining the open list
-	// however, only binary heap and HOT queue with binary heap are worth considering
-#if defined(tpl_HOT_queue_tpl_h)
-    // static
-	HOT_queue_tpl <ANode *> queue;
-#elif defined(tpl_binary_heap_tpl_h)
-    //static
 	binary_heap_tpl <ANode *> queue;
-#elif defined(tpl_sorted_heap_tpl_h)
-    //static
-	sorted_heap_tpl <ANode *> queue;
-#else
-    //static
-	prioqueue_tpl <ANode *> queue;
-#endif
 
 	ANode *nodes;
 	uint8 ni = GET_NODES(&nodes);

--- a/dataobj/route.h
+++ b/dataobj/route.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef route_h
-#define route_h
+#ifndef DATAOBJ_ROUTE_H
+#define DATAOBJ_ROUTE_H
+
 
 #include "../simdebug.h"
 

--- a/dataobj/scenario.h
+++ b/dataobj/scenario.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef scenario_h
-#define scenario_h
+#ifndef DATAOBJ_SCENARIO_H
+#define DATAOBJ_SCENARIO_H
+
 
 /** @file scenario.h declarations for scenario interface */
 

--- a/dataobj/schedule.h
+++ b/dataobj/schedule.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef schedule_h
-#define schedule_h
+#ifndef DATAOBJ_SCHEDULE_H
+#define DATAOBJ_SCHEDULE_H
+
 
 #include "schedule_entry.h"
 

--- a/dataobj/schedule_entry.h
+++ b/dataobj/schedule_entry.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef schedule_entry_t_h
-#define schedule_entry_t_h
+#ifndef DATAOBJ_SCHEDULE_ENTRY_H
+#define DATAOBJ_SCHEDULE_ENTRY_H
+
 
 #include "koord3d.h"
 

--- a/dataobj/settings.h
+++ b/dataobj/settings.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef dataobj_settings_h
-#define dataobj_settings_h
+#ifndef DATAOBJ_SETTINGS_H
+#define DATAOBJ_SETTINGS_H
+
 
 #include <string>
 #include "../simtypes.h"

--- a/dataobj/tabfile.h
+++ b/dataobj/tabfile.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __tabfile_h
-#define __tabfile_h
+#ifndef DATAOBJ_TABFILE_H
+#define DATAOBJ_TABFILE_H
+
 
 #include <stdio.h>
 

--- a/dataobj/translator.h
+++ b/dataobj/translator.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef TRANSLATOR_H
-#define TRANSLATOR_H
+#ifndef DATAOBJ_TRANSLATOR_H
+#define DATAOBJ_TRANSLATOR_H
+
 
 #include <stdio.h>
 #include <string>

--- a/dataobj/way_constraints.h
+++ b/dataobj/way_constraints.h
@@ -9,8 +9,9 @@
 
 #pragma once
 
-#ifndef way_constraints_h
-#define way_constraints_h
+#ifndef DATAOBJ_WAY_CONSTRAINTS_H
+#define DATAOBJ_WAY_CONSTRAINTS_H
+
 
 #include "../simtypes.h"
 

--- a/descriptor/bridge_desc.h
+++ b/descriptor/bridge_desc.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __BRUECKE_BESCH_H
-#define __BRUECKE_BESCH_H
+#ifndef DESCRIPTOR_BRIDGE_DESC_H
+#define DESCRIPTOR_BRIDGE_DESC_H
 
 
 #include "skin_desc.h"

--- a/descriptor/building_desc.h
+++ b/descriptor/building_desc.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __HAUS_BESCH_H
-#define __HAUS_BESCH_H
+#ifndef DESCRIPTOR_BUILDING_DESC_H
+#define DESCRIPTOR_BUILDING_DESC_H
+
 
 #include <assert.h>
 #include "image_array.h"

--- a/descriptor/citycar_desc.h
+++ b/descriptor/citycar_desc.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __STADTAUTO_BESCH_H
-#define __STADTAUTO_BESCH_H
+#ifndef DESCRIPTOR_CITYCAR_DESC_H
+#define DESCRIPTOR_CITYCAR_DESC_H
+
 
 #include "obj_base_desc.h"
 #include "image_list.h"

--- a/descriptor/crossing_desc.h
+++ b/descriptor/crossing_desc.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __KREUZUNG_BESCH_H
-#define __KREUZUNG_BESCH_H
+#ifndef DESCRIPTOR_CROSSING_DESC_H
+#define DESCRIPTOR_CROSSING_DESC_H
+
 
 #include "obj_base_desc.h"
 #include "image.h"

--- a/descriptor/factory_desc.h
+++ b/descriptor/factory_desc.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __FABRIK_BESCH_H
-#define __FABRIK_BESCH_H
+#ifndef DESCRIPTOR_FACTORY_DESC_H
+#define DESCRIPTOR_FACTORY_DESC_H
+
 
 #include "obj_desc.h"
 #include "building_desc.h"

--- a/descriptor/goods_desc.h
+++ b/descriptor/goods_desc.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __WARE_BESCH_H
-#define __WARE_BESCH_H
+#ifndef DESCRIPTOR_GOODS_DESC_H
+#define DESCRIPTOR_GOODS_DESC_H
+
 
 #include "obj_base_desc.h"
 #include "../simcolor.h"

--- a/descriptor/ground_desc.h
+++ b/descriptor/ground_desc.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __GRUND_BESCH_H
-#define __GRUND_BESCH_H
+#ifndef DESCRIPTOR_GROUND_DESC_H
+#define DESCRIPTOR_GROUND_DESC_H
+
 
 #include "obj_base_desc.h"
 #include "image_array.h"

--- a/descriptor/groundobj_desc.h
+++ b/descriptor/groundobj_desc.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __GROUNDOBJ_DESC_H
-#define __GROUNDOBJ_DESC_H
+#ifndef DESCRIPTOR_GROUNDOBJ_DESC_H
+#define DESCRIPTOR_GROUNDOBJ_DESC_H
+
 
 #include "../simtypes.h"
 #include "obj_base_desc.h"

--- a/descriptor/image.h
+++ b/descriptor/image.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __BILD_BESCH_H
-#define __BILD_BESCH_H
+#ifndef DESCRIPTOR_IMAGE_H
+#define DESCRIPTOR_IMAGE_H
+
 
 #include "../display/simgraph.h"
 #include "../display/simimg.h"

--- a/descriptor/image_array.h
+++ b/descriptor/image_array.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __BILDLISTE2D_BESCH_H
-#define __BILDLISTE2D_BESCH_H
+#ifndef DESCRIPTOR_IMAGE_ARRAY_H
+#define DESCRIPTOR_IMAGE_ARRAY_H
+
 
 #include "image_list.h"
 

--- a/descriptor/image_array_3d.h
+++ b/descriptor/image_array_3d.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __BILDLISTE3D_BESCH_H
-#define __BILDLISTE3D_BESCH_H
+#ifndef DESCRIPTOR_IMAGE_ARRAY_3D_H
+#define DESCRIPTOR_IMAGE_ARRAY_3D_H
+
 
 #include "image_list.h"
 #include "image_array.h"

--- a/descriptor/image_list.h
+++ b/descriptor/image_list.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __BILDLISTE_BESCH_H
-#define __BILDLISTE_BESCH_H
+#ifndef DESCRIPTOR_IMAGE_LIST_H
+#define DESCRIPTOR_IMAGE_LIST_H
+
 
 #include "image.h"
 

--- a/descriptor/obj_base_desc.h
+++ b/descriptor/obj_base_desc.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __OBJ_BASE_DESC_H
-#define __OBJ_BASE_DESC_H
+#ifndef DESCRIPTOR_OBJ_BASE_DESC_H
+#define DESCRIPTOR_OBJ_BASE_DESC_H
+
 
 #include "text_desc.h"
 

--- a/descriptor/obj_desc.h
+++ b/descriptor/obj_desc.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __OBJ_BESCH_H
-#define __OBJ_BESCH_H
+#ifndef DESCRIPTOR_OBJ_DESC_H
+#define DESCRIPTOR_OBJ_DESC_H
+
 
 #include <cstddef>
 #include "../simtypes.h"

--- a/descriptor/obj_node_info.h
+++ b/descriptor/obj_node_info.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __OBJ_NODE_INFO_H
-#define __OBJ_NODE_INFO_H
+#ifndef DESCRIPTOR_OBJ_NODE_INFO_H
+#define DESCRIPTOR_OBJ_NODE_INFO_H
+
 
 #include "../simtypes.h"
 

--- a/descriptor/objversion.h
+++ b/descriptor/objversion.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __OBJVERSION_H
-#define __OBJVERSION_H
+#ifndef DESCRIPTOR_OBJVERSION_H
+#define DESCRIPTOR_OBJVERSION_H
+
 
 #include "../simtypes.h"
 

--- a/descriptor/pedestrian_desc.h
+++ b/descriptor/pedestrian_desc.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __PEDESTRIAN_DESC_H
-#define __PEDESTRIAN_DESC_H
+#ifndef DESCRIPTOR_PEDESTRIAN_DESC_H
+#define DESCRIPTOR_PEDESTRIAN_DESC_H
+
 
 #include "obj_base_desc.h"
 #include "image_array.h"

--- a/descriptor/reader/bridge_reader.h
+++ b/descriptor/reader/bridge_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __BRIDGE_READER_H
-#define __BRIDGE_READER_H
+#ifndef DESCRIPTOR_READER_BRIDGE_READER_H
+#define DESCRIPTOR_READER_BRIDGE_READER_H
+
 
 #include "obj_reader.h"
 

--- a/descriptor/reader/building_reader.h
+++ b/descriptor/reader/building_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __BUILDING_READER_H
-#define __BUILDING_READER_H
+#ifndef DESCRIPTOR_READER_BUILDING_READER_H
+#define DESCRIPTOR_READER_BUILDING_READER_H
+
 
 #include "obj_reader.h"
 

--- a/descriptor/reader/citycar_reader.h
+++ b/descriptor/reader/citycar_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __CITYCAR_READER_H
-#define __CITYCAR_READER_H
+#ifndef DESCRIPTOR_READER_CITYCAR_READER_H
+#define DESCRIPTOR_READER_CITYCAR_READER_H
+
 
 #include "obj_reader.h"
 

--- a/descriptor/reader/crossing_reader.h
+++ b/descriptor/reader/crossing_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __CROSSING_READER_H
-#define __CROSSING_READER_H
+#ifndef DESCRIPTOR_READER_CROSSING_READER_H
+#define DESCRIPTOR_READER_CROSSING_READER_H
+
 
 #include "obj_reader.h"
 

--- a/descriptor/reader/factory_reader.h
+++ b/descriptor/reader/factory_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __FACTORY_READER_H
-#define __FACTORY_READER_H
+#ifndef DESCRIPTOR_READER_FACTORY_READER_H
+#define DESCRIPTOR_READER_FACTORY_READER_H
+
 
 #include "obj_reader.h"
 

--- a/descriptor/reader/good_reader.h
+++ b/descriptor/reader/good_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __GOODS_READER_H
-#define __GOODS_READER_H
+#ifndef DESCRIPTOR_READER_GOOD_READER_H
+#define DESCRIPTOR_READER_GOOD_READER_H
+
 
 #include "obj_reader.h"
 

--- a/descriptor/reader/ground_reader.h
+++ b/descriptor/reader/ground_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __GROUND_READER_H
-#define __GROUND_READER_H
+#ifndef DESCRIPTOR_READER_GROUND_READER_H
+#define DESCRIPTOR_READER_GROUND_READER_H
+
 
 #include "obj_reader.h"
 

--- a/descriptor/reader/groundobj_reader.h
+++ b/descriptor/reader/groundobj_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __GROUNDOBJ_READER_H
-#define __GROUNDOBJ_READER_H
+#ifndef DESCRIPTOR_READER_GROUNDOBJ_READER_H
+#define DESCRIPTOR_READER_GROUNDOBJ_READER_H
+
 
 #include "obj_reader.h"
 

--- a/descriptor/reader/image_reader.h
+++ b/descriptor/reader/image_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __IMAGE_READER_H
-#define __IMAGE_READER_H
+#ifndef DESCRIPTOR_READER_IMAGE_READER_H
+#define DESCRIPTOR_READER_IMAGE_READER_H
+
 
 #include "obj_reader.h"
 

--- a/descriptor/reader/imagelist2d_reader.h
+++ b/descriptor/reader/imagelist2d_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __IMAGELIST2D_READER_H
-#define __IMAGELIST2D_READER_H
+#ifndef DESCRIPTOR_READER_IMAGELIST2D_READER_H
+#define DESCRIPTOR_READER_IMAGELIST2D_READER_H
+
 
 #include "obj_reader.h"
 

--- a/descriptor/reader/imagelist3d_reader.h
+++ b/descriptor/reader/imagelist3d_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __IMAGELIST3D_READER_H
-#define __IMAGELIST3D_READER_H
+#ifndef DESCRIPTOR_READER_IMAGELIST3D_READER_H
+#define DESCRIPTOR_READER_IMAGELIST3D_READER_H
+
 
 #include "obj_reader.h"
 

--- a/descriptor/reader/imagelist_reader.h
+++ b/descriptor/reader/imagelist_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __IMAGELIST_READER_H
-#define __IMAGELIST_READER_H
+#ifndef DESCRIPTOR_READER_IMAGELIST_READER_H
+#define DESCRIPTOR_READER_IMAGELIST_READER_H
+
 
 #include "obj_reader.h"
 

--- a/descriptor/reader/obj_reader.h
+++ b/descriptor/reader/obj_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __OBJ_READER_H
-#define __OBJ_READER_H
+#ifndef DESCRIPTOR_READER_OBJ_READER_H
+#define DESCRIPTOR_READER_OBJ_READER_H
+
 
 #include <stdio.h>
 

--- a/descriptor/reader/pedestrian_reader.h
+++ b/descriptor/reader/pedestrian_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __PEDESTRIAN_READER_H
-#define __PEDESTRIAN_READER_H
+#ifndef DESCRIPTOR_READER_PEDESTRIAN_READER_H
+#define DESCRIPTOR_READER_PEDESTRIAN_READER_H
+
 
 #include "obj_reader.h"
 

--- a/descriptor/reader/roadsign_reader.h
+++ b/descriptor/reader/roadsign_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __ROADSIGN_READER_H
-#define __ROADSIGN_READER_H
+#ifndef DESCRIPTOR_READER_ROADSIGN_READER_H
+#define DESCRIPTOR_READER_ROADSIGN_READER_H
+
 
 #include "obj_reader.h"
 

--- a/descriptor/reader/skin_reader.h
+++ b/descriptor/reader/skin_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __SKIN_READER_H
-#define __SKIN_READER_H
+#ifndef DESCRIPTOR_READER_SKIN_READER_H
+#define DESCRIPTOR_READER_SKIN_READER_H
+
 
 #include "obj_reader.h"
 

--- a/descriptor/reader/sound_reader.h
+++ b/descriptor/reader/sound_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __SOUND_READER_H
-#define __SOUND_READER_H
+#ifndef DESCRIPTOR_READER_SOUND_READER_H
+#define DESCRIPTOR_READER_SOUND_READER_H
+
 
 #include "obj_reader.h"
 

--- a/descriptor/reader/tree_reader.h
+++ b/descriptor/reader/tree_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __TREE_READER_H
-#define __TREE_READER_H
+#ifndef DESCRIPTOR_READER_TREE_READER_H
+#define DESCRIPTOR_READER_TREE_READER_H
+
 
 #include "obj_reader.h"
 

--- a/descriptor/reader/tunnel_reader.h
+++ b/descriptor/reader/tunnel_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __TUNNEL_READER_H
-#define __TUNNEL_READER_H
+#ifndef DESCRIPTOR_READER_TUNNEL_READER_H
+#define DESCRIPTOR_READER_TUNNEL_READER_H
+
 
 #include "obj_reader.h"
 

--- a/descriptor/reader/vehicle_reader.h
+++ b/descriptor/reader/vehicle_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __VEHICLE_READER_H
-#define __VEHICLE_READER_H
+#ifndef DESCRIPTOR_READER_VEHICLE_READER_H
+#define DESCRIPTOR_READER_VEHICLE_READER_H
+
 
 #include "obj_reader.h"
 

--- a/descriptor/reader/way_obj_reader.h
+++ b/descriptor/reader/way_obj_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __WAY_OBJ_READER_H
-#define __WAY_OBJ_READER_H
+#ifndef DESCRIPTOR_READER_WAY_OBJ_READER_H
+#define DESCRIPTOR_READER_WAY_OBJ_READER_H
+
 
 #include "obj_reader.h"
 

--- a/descriptor/reader/way_reader.h
+++ b/descriptor/reader/way_reader.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __WAY_READER_H
-#define __WAY_READER_H
+#ifndef DESCRIPTOR_READER_WAY_READER_H
+#define DESCRIPTOR_READER_WAY_READER_H
+
 
 #include "obj_reader.h"
 

--- a/descriptor/roadsign_desc.h
+++ b/descriptor/roadsign_desc.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __ROADSIGN_BESCH_H
-#define __ROADSIGN_BESCH_H
+#ifndef DESCRIPTOR_ROADSIGN_DESC_H
+#define DESCRIPTOR_ROADSIGN_DESC_H
+
 
 #include "obj_base_desc.h"
 #include "image_list.h"

--- a/descriptor/skin_desc.h
+++ b/descriptor/skin_desc.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __SKIN_BESCH_H
-#define __SKIN_BESCH_H
+#ifndef DESCRIPTOR_SKIN_DESC_H
+#define DESCRIPTOR_SKIN_DESC_H
+
 
 #include "../display/simimg.h"
 #include "obj_base_desc.h"

--- a/descriptor/sound_desc.h
+++ b/descriptor/sound_desc.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __SOUND_DESC_H
-#define __SOUND_DESC_H
+#ifndef DESCRIPTOR_SOUND_DESC_H
+#define DESCRIPTOR_SOUND_DESC_H
+
 
 #include "obj_base_desc.h"
 #include "../simtypes.h"

--- a/descriptor/spezial_obj_tpl.h
+++ b/descriptor/spezial_obj_tpl.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __SPECIAL_OBJ_TPL_H
-#define __SPECIAL_OBJ_TPL_H
+#ifndef DESCRIPTOR_SPEZIAL_OBJ_TPL_H
+#define DESCRIPTOR_SPEZIAL_OBJ_TPL_H
+
 
 #include <string.h>
 #include <typeinfo>

--- a/descriptor/text_desc.h
+++ b/descriptor/text_desc.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __TEXT_BESCH_H
-#define __TEXT_BESCH_H
+#ifndef DESCRIPTOR_TEXT_DESC_H
+#define DESCRIPTOR_TEXT_DESC_H
+
 
 #include "obj_desc.h"
 

--- a/descriptor/tree_desc.h
+++ b/descriptor/tree_desc.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __BAUM_BESCH_H
-#define __BAUM_BESCH_H
+#ifndef DESCRIPTOR_TREE_DESC_H
+#define DESCRIPTOR_TREE_DESC_H
+
 
 #include "../simtypes.h"
 #include "obj_base_desc.h"

--- a/descriptor/tunnel_desc.h
+++ b/descriptor/tunnel_desc.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __TUNNEL_BESCH_H
-#define __TUNNEL_BESCH_H
+#ifndef DESCRIPTOR_TUNNEL_DESC_H
+#define DESCRIPTOR_TUNNEL_DESC_H
+
 
 #include "../display/simimg.h"
 #include "../simtypes.h"

--- a/descriptor/way_desc.h
+++ b/descriptor/way_desc.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __WAY_DESC_H
-#define __WAY_DESC_H
+#ifndef DESCRIPTOR_WAY_DESC_H
+#define DESCRIPTOR_WAY_DESC_H
+
 
 #include "image_list.h"
 #include "obj_base_desc.h"

--- a/descriptor/way_obj_desc.h
+++ b/descriptor/way_obj_desc.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __WAY_OBJ_DESC_H
-#define __WAY_OBJ_DESC_H
+#ifndef DESCRIPTOR_WAY_OBJ_DESC_H
+#define DESCRIPTOR_WAY_OBJ_DESC_H
+
 
 #include "image_list.h"
 #include "obj_base_desc.h"

--- a/descriptor/writer/bridge_writer.h
+++ b/descriptor/writer/bridge_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef BRIDGE_WRITER_H
-#define BRIDGE_WRITER_H
+#ifndef DESCRIPTOR_WRITER_BRIDGE_WRITER_H
+#define DESCRIPTOR_WRITER_BRIDGE_WRITER_H
+
 
 #include <string>
 #include "obj_writer.h"

--- a/descriptor/writer/building_writer.h
+++ b/descriptor/writer/building_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef BUILDING_WRITER_H
-#define BUILDING_WRITER_H
+#ifndef DESCRIPTOR_WRITER_BUILDING_WRITER_H
+#define DESCRIPTOR_WRITER_BUILDING_WRITER_H
+
 
 #include <string>
 #include "obj_writer.h"

--- a/descriptor/writer/citycar_writer.h
+++ b/descriptor/writer/citycar_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef CITYCAR_WRITER_H
-#define CITYCAR_WRITER_H
+#ifndef DESCRIPTOR_WRITER_CITYCAR_WRITER_H
+#define DESCRIPTOR_WRITER_CITYCAR_WRITER_H
+
 
 #include <string>
 #include "obj_writer.h"

--- a/descriptor/writer/cluster_writer.h
+++ b/descriptor/writer/cluster_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef CLUSTER_WRITER_H
-#define CLUSTER_WRITER_H
+#ifndef DESCRIPTOR_WRITER_CLUSTER_WRITER_H
+#define DESCRIPTOR_WRITER_CLUSTER_WRITER_H
+
 
 #include <stdio.h>
 #include "obj_writer.h"

--- a/descriptor/writer/crossing_writer.h
+++ b/descriptor/writer/crossing_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef CROSSING_WRITER_H
-#define CROSSING_WRITER_H
+#ifndef DESCRIPTOR_WRITER_CROSSING_WRITER_H
+#define DESCRIPTOR_WRITER_CROSSING_WRITER_H
+
 
 #include <string>
 #include "obj_writer.h"

--- a/descriptor/writer/factory_writer.h
+++ b/descriptor/writer/factory_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef FACTORY_WRITER_H
-#define FACTORY_WRITER_H
+#ifndef DESCRIPTOR_WRITER_FACTORY_WRITER_H
+#define DESCRIPTOR_WRITER_FACTORY_WRITER_H
+
 
 #include <string>
 #include "obj_writer.h"

--- a/descriptor/writer/get_climate.h
+++ b/descriptor/writer/get_climate.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef GET_CLIMATE_H
-#define GET_CLIMATE_H
+#ifndef DESCRIPTOR_WRITER_GET_CLIMATE_H
+#define DESCRIPTOR_WRITER_GET_CLIMATE_H
+
 
 #include "../../simtypes.h"
 

--- a/descriptor/writer/get_waytype.h
+++ b/descriptor/writer/get_waytype.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef GET_WAYTYPE_H
-#define GET_WAYTYPE_H
+#ifndef DESCRIPTOR_WRITER_GET_WAYTYPE_H
+#define DESCRIPTOR_WRITER_GET_WAYTYPE_H
+
 
 #include "../../simtypes.h"
 

--- a/descriptor/writer/good_writer.h
+++ b/descriptor/writer/good_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef GOODS_WRITER_H
-#define GOODS_WRITER_H
+#ifndef DESCRIPTOR_WRITER_GOOD_WRITER_H
+#define DESCRIPTOR_WRITER_GOOD_WRITER_H
+
 
 #include <string>
 #include "obj_writer.h"

--- a/descriptor/writer/ground_writer.h
+++ b/descriptor/writer/ground_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef GROUND_WRITER_H
-#define GROUND_WRITER_H
+#ifndef DESCRIPTOR_WRITER_GROUND_WRITER_H
+#define DESCRIPTOR_WRITER_GROUND_WRITER_H
+
 
 #include <string>
 #include "obj_writer.h"

--- a/descriptor/writer/groundobj_writer.h
+++ b/descriptor/writer/groundobj_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef GROUNDOBJ_WRITER_H
-#define GROUNDOBJ_WRITER_H
+#ifndef DESCRIPTOR_WRITER_GROUNDOBJ_WRITER_H
+#define DESCRIPTOR_WRITER_GROUNDOBJ_WRITER_H
+
 
 #include <string>
 #include "obj_writer.h"

--- a/descriptor/writer/image_writer.h
+++ b/descriptor/writer/image_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef IMAGE_WRITER_H
-#define IMAGE_WRITER_H
+#ifndef DESCRIPTOR_WRITER_IMAGE_WRITER_H
+#define DESCRIPTOR_WRITER_IMAGE_WRITER_H
+
 
 #include <string>
 #include <stdio.h>

--- a/descriptor/writer/imagelist2d_writer.h
+++ b/descriptor/writer/imagelist2d_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef IMAGELIST2D_WRITER_H
-#define IMAGELIST2D_WRITER_H
+#ifndef DESCRIPTOR_WRITER_IMAGELIST2D_WRITER_H
+#define DESCRIPTOR_WRITER_IMAGELIST2D_WRITER_H
+
 
 #include <string>
 #include "obj_writer.h"

--- a/descriptor/writer/imagelist3d_writer.h
+++ b/descriptor/writer/imagelist3d_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef IMAGELIST3D_WRITER_H
-#define IMAGELIST3D_WRITER_H
+#ifndef DESCRIPTOR_WRITER_IMAGELIST3D_WRITER_H
+#define DESCRIPTOR_WRITER_IMAGELIST3D_WRITER_H
+
 
 #include <string>
 #include "obj_writer.h"

--- a/descriptor/writer/imagelist_writer.h
+++ b/descriptor/writer/imagelist_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef IMAGELIST_WRITER_H
-#define IMAGELIST_WRITER_H
+#ifndef DESCRIPTOR_WRITER_IMAGELIST_WRITER_H
+#define DESCRIPTOR_WRITER_IMAGELIST_WRITER_H
+
 
 #include <string>
 #include <stdio.h>

--- a/descriptor/writer/obj_node.h
+++ b/descriptor/writer/obj_node.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef OBJ_NODE_H
-#define OBJ_NODE_H
+#ifndef DESCRIPTOR_WRITER_OBJ_NODE_H
+#define DESCRIPTOR_WRITER_OBJ_NODE_H
+
 
 #include "../obj_node_info.h"
 #include <stdio.h>

--- a/descriptor/writer/obj_pak_exception.h
+++ b/descriptor/writer/obj_pak_exception.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef OBJ_PAK_EXCEPTION_H
-#define OBJ_PAK_EXCEPTION_H
+#ifndef DESCRIPTOR_WRITER_OBJ_PAK_EXCEPTION_H
+#define DESCRIPTOR_WRITER_OBJ_PAK_EXCEPTION_H
+
 
 #include <string>
 

--- a/descriptor/writer/obj_writer.h
+++ b/descriptor/writer/obj_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef OBJ_WRITER_H
-#define OBJ_WRITER_H
+#ifndef DESCRIPTOR_WRITER_OBJ_WRITER_H
+#define DESCRIPTOR_WRITER_OBJ_WRITER_H
+
 
 #include <stdio.h>
 #include <string>

--- a/descriptor/writer/pedestrian_writer.h
+++ b/descriptor/writer/pedestrian_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef PEDESTRIAN_WRITER_H
-#define PEDESTRIAN_WRITER_H
+#ifndef DESCRIPTOR_WRITER_PEDESTRIAN_WRITER_H
+#define DESCRIPTOR_WRITER_PEDESTRIAN_WRITER_H
+
 
 #include <string>
 #include "obj_writer.h"

--- a/descriptor/writer/roadsign_writer.h
+++ b/descriptor/writer/roadsign_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef ROADSIGN_WRITER_H
-#define ROADSIGN_WRITER_H
+#ifndef DESCRIPTOR_WRITER_ROADSIGN_WRITER_H
+#define DESCRIPTOR_WRITER_ROADSIGN_WRITER_H
+
 
 #include <string>
 #include "obj_writer.h"

--- a/descriptor/writer/root_writer.h
+++ b/descriptor/writer/root_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef ROOT_WRITER_H
-#define ROOT_WRITER_H
+#ifndef DESCRIPTOR_WRITER_ROOT_WRITER_H
+#define DESCRIPTOR_WRITER_ROOT_WRITER_H
+
 
 #include <string>
 #include <stdio.h>

--- a/descriptor/writer/skin_writer.h
+++ b/descriptor/writer/skin_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef SKIN_WRITER_H
-#define SKIN_WRITER_H
+#ifndef DESCRIPTOR_WRITER_SKIN_WRITER_H
+#define DESCRIPTOR_WRITER_SKIN_WRITER_H
+
 
 #include <string>
 #include "obj_writer.h"

--- a/descriptor/writer/sound_writer.h
+++ b/descriptor/writer/sound_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef SOUND_WRITER_H
-#define SOUND_WRITER_H
+#ifndef DESCRIPTOR_WRITER_SOUND_WRITER_H
+#define DESCRIPTOR_WRITER_SOUND_WRITER_H
+
 
 #include <string>
 #include "obj_writer.h"

--- a/descriptor/writer/text_writer.h
+++ b/descriptor/writer/text_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef TEXT_WRITER_H
-#define TEXT_WRITER_H
+#ifndef DESCRIPTOR_WRITER_TEXT_WRITER_H
+#define DESCRIPTOR_WRITER_TEXT_WRITER_H
+
 
 #include <stdio.h>
 #include "obj_writer.h"

--- a/descriptor/writer/tree_writer.h
+++ b/descriptor/writer/tree_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef TREE_WRITER_H
-#define TREE_WRITER_H
+#ifndef DESCRIPTOR_WRITER_TREE_WRITER_H
+#define DESCRIPTOR_WRITER_TREE_WRITER_H
+
 
 #include <string>
 #include "obj_writer.h"

--- a/descriptor/writer/tunnel_writer.h
+++ b/descriptor/writer/tunnel_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef TUNNEL_WRITER_H
-#define TUNNEL_WRITER_H
+#ifndef DESCRIPTOR_WRITER_TUNNEL_WRITER_H
+#define DESCRIPTOR_WRITER_TUNNEL_WRITER_H
+
 
 #include <string>
 #include "obj_writer.h"

--- a/descriptor/writer/vehicle_writer.h
+++ b/descriptor/writer/vehicle_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef VEHICLE_WRITER_H
-#define VEHICLE_WRITER_H
+#ifndef DESCRIPTOR_WRITER_VEHICLE_WRITER_H
+#define DESCRIPTOR_WRITER_VEHICLE_WRITER_H
+
 
 #include <string>
 #include "obj_writer.h"

--- a/descriptor/writer/way_obj_writer.h
+++ b/descriptor/writer/way_obj_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef WAY_OBJ_WRITER_H
-#define WAY_OBJ_WRITER_H
+#ifndef DESCRIPTOR_WRITER_WAY_OBJ_WRITER_H
+#define DESCRIPTOR_WRITER_WAY_OBJ_WRITER_H
+
 
 #include <string>
 #include "obj_writer.h"

--- a/descriptor/writer/way_writer.h
+++ b/descriptor/writer/way_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef WAY_WRITER_H
-#define WAY_WRITER_H
+#ifndef DESCRIPTOR_WRITER_WAY_WRITER_H
+#define DESCRIPTOR_WRITER_WAY_WRITER_H
+
 
 #include <string>
 #include "obj_writer.h"

--- a/descriptor/writer/xref_writer.h
+++ b/descriptor/writer/xref_writer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef XREF_WRITER_H
-#define XREF_WRITER_H
+#ifndef DESCRIPTOR_WRITER_XREF_WRITER_H
+#define DESCRIPTOR_WRITER_XREF_WRITER_H
+
 
 #include <stdio.h>
 #include "obj_writer.h"

--- a/descriptor/xref_desc.h
+++ b/descriptor/xref_desc.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef XREF_DESC_H
-#define XREF_DESC_H
+#ifndef DESCRIPTOR_XREF_DESC_H
+#define DESCRIPTOR_XREF_DESC_H
+
 
 #include "obj_desc.h"
 #include "objversion.h"

--- a/display/clip_num.h
+++ b/display/clip_num.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef clip_num_h
-#define clip_num_h
+#ifndef DISPLAY_CLIP_NUM_H
+#define DISPLAY_CLIP_NUM_H
+
 
 #include "../simtypes.h"
 /**

--- a/display/font.h
+++ b/display/font.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef FONT_H
-#define FONT_H
+#ifndef DISPLAY_FONT_H
+#define DISPLAY_FONT_H
+
 
 #include "../simtypes.h"
 

--- a/display/scr_coord.h
+++ b/display/scr_coord.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef scr_coord_h
-#define scr_coord_h
+#ifndef DISPLAY_SCR_COORD_H
+#define DISPLAY_SCR_COORD_H
+
 
 #include <assert.h>
 #include "../dataobj/loadsave.h"

--- a/display/simimg.h
+++ b/display/simimg.h
@@ -8,8 +8,9 @@
  * Hj. Malthaner, 13.07.98
  */
 
-#ifndef _simimg_h
-#define _simimg_h
+#ifndef DISPLAY_SIMIMG_H
+#define DISPLAY_SIMIMG_H
+
 
 #include "../simtypes.h"
 

--- a/display/simview.h
+++ b/display/simview.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simview_h
-#define simview_h
+#ifndef DISPLAY_SIMVIEW_H
+#define DISPLAY_SIMVIEW_H
+
 
 class karte_t;
 class viewport_t;

--- a/display/viewport.h
+++ b/display/viewport.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simviewport_h
-#define simviewport_h
+#ifndef DISPLAY_VIEWPORT_H
+#define DISPLAY_VIEWPORT_H
+
 
 #include "../simtypes.h"
 #include "scr_coord.h"

--- a/finder/building_placefinder.h
+++ b/finder/building_placefinder.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef building_placefinder_t_h
-#define building_placefinder_t_h
+#ifndef FINDER_BUILDING_PLACEFINDER_H
+#define FINDER_BUILDING_PLACEFINDER_H
+
 
 #include "placefinder.h"
 #include "../simworld.h"

--- a/finder/placefinder.h
+++ b/finder/placefinder.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __PLACEFINDER_H
-#define __PLACEFINDER_H
+#ifndef FINDER_PLACEFINDER_H
+#define FINDER_PLACEFINDER_H
+
 
 #include "../dataobj/koord.h"
 class karte_t;

--- a/freight_list_sorter.h
+++ b/freight_list_sorter.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef freight_list_sorter_h
-#define freight_list_sorter_h
+#ifndef FREIGHT_LIST_SORTER_H
+#define FREIGHT_LIST_SORTER_H
+
 
 // same sorting for stations and vehicle/convoi freight ...
 

--- a/gui/ai_option_t.h
+++ b/gui/ai_option_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef ai_option_h
-#define ai_option_h
+#ifndef GUI_AI_OPTION_T_H
+#define GUI_AI_OPTION_T_H
+
 
 #include "../simmesg.h"
 

--- a/gui/banner.h
+++ b/gui/banner.h
@@ -7,8 +7,9 @@
  * Intro banner and everything else
  */
 
-#ifndef banner_h
-#define banner_h
+#ifndef GUI_BANNER_H
+#define GUI_BANNER_H
+
 
 #include "components/gui_button.h"
 #include "components/gui_image.h"

--- a/gui/base_info.h
+++ b/gui/base_info.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef base_info_h_
-#define base_info_h_
+#ifndef GUI_BASE_INFO_H
+#define GUI_BASE_INFO_H
+
 
 #include "gui_frame.h"
 #include "components/gui_fixedwidth_textarea.h"

--- a/gui/baum_edit.h
+++ b/gui/baum_edit.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_baum_edit_h
-#define gui_baum_edit_h
+#ifndef GUI_BAUM_EDIT_H
+#define GUI_BAUM_EDIT_H
+
 
 #include "extend_edit.h"
 

--- a/gui/city_info.h
+++ b/gui/city_info.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_city_info_h
-#define gui_city_info_h
+#ifndef GUI_CITY_INFO_H
+#define GUI_CITY_INFO_H
+
 
 #include "../simcity.h"
 #include "../gui/simwin.h"

--- a/gui/citybuilding_edit.h
+++ b/gui/citybuilding_edit.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_citybuilding_edit_h
-#define gui_citybuilding_edit_h
+#ifndef GUI_CITYBUILDING_EDIT_H
+#define GUI_CITYBUILDING_EDIT_H
+
 
 #include "extend_edit.h"
 

--- a/gui/citylist_frame_t.h
+++ b/gui/citylist_frame_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef citylist_frame_t_h
-#define citylist_frame_t_h
+#ifndef GUI_CITYLIST_FRAME_T_H
+#define GUI_CITYLIST_FRAME_T_H
+
 
 #include "gui_frame.h"
 #include "citylist_stats_t.h"

--- a/gui/citylist_stats_t.h
+++ b/gui/citylist_stats_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef CITYLIST_STATS_T_H
-#define CITYLIST_STATS_T_H
+#ifndef GUI_CITYLIST_STATS_T_H
+#define GUI_CITYLIST_STATS_T_H
+
 
 #include "components/gui_component.h"
 #include "../tpl/vector_tpl.h"

--- a/gui/climates.h
+++ b/gui/climates.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef climate_gui_h
-#define climate_gui_h
+#ifndef GUI_CLIMATES_H
+#define GUI_CLIMATES_H
+
 
 #include "gui_frame.h"
 #include "components/gui_button.h"

--- a/gui/components/action_listener.h
+++ b/gui/components/action_listener.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_ifc_action_listener_h
-#define gui_ifc_action_listener_h
+#ifndef GUI_COMPONENTS_ACTION_LISTENER_H
+#define GUI_COMPONENTS_ACTION_LISTENER_H
+
 
 #include "../../simtypes.h"
 

--- a/gui/components/ding_view_t.h
+++ b/gui/components/ding_view_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef DING_VIEW_T_H
-#define DING_VIEW_T_H
+#ifndef GUI_COMPONENTS_DING_VIEW_T_H
+#define GUI_COMPONENTS_DING_VIEW_T_H
+
 
 #include "../../simdings.h"
 #include "gui_world_view_t.h"

--- a/gui/components/gui_action_creator.h
+++ b/gui/components/gui_action_creator.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_ifc_action_creator_h
-#define gui_ifc_action_creator_h
+#ifndef GUI_COMPONENTS_GUI_ACTION_CREATOR_H
+#define GUI_COMPONENTS_GUI_ACTION_CREATOR_H
+
 
 #include "action_listener.h"
 #include "../../tpl/slist_tpl.h"

--- a/gui/components/gui_button.h
+++ b/gui/components/gui_button.h
@@ -7,8 +7,9 @@
  * Defines all button types: Normal (roundbox), Checkboxes (square), Arrows, Scrollbars
  */
 
-#ifndef gui_button_h
-#define gui_button_h
+#ifndef GUI_COMPONENTS_GUI_BUTTON_H
+#define GUI_COMPONENTS_GUI_BUTTON_H
+
 
 #include "gui_action_creator.h"
 #include "gui_component.h"

--- a/gui/components/gui_chart.h
+++ b/gui/components/gui_chart.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_chart_h
-#define gui_chart_h
+#ifndef GUI_COMPONENTS_GUI_CHART_H
+#define GUI_COMPONENTS_GUI_CHART_H
+
 
 #include "../../simtypes.h"
 #include "gui_component.h"

--- a/gui/components/gui_combobox.h
+++ b/gui/components/gui_combobox.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_components_gui_combobox_h
-#define gui_components_gui_combobox_h
+#ifndef GUI_COMPONENTS_GUI_COMBOBOX_H
+#define GUI_COMPONENTS_GUI_COMBOBOX_H
+
 
 #include "../../simcolor.h"
 #include "gui_action_creator.h"

--- a/gui/components/gui_component.h
+++ b/gui/components/gui_component.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef ifc_gui_component_h
-#define ifc_gui_component_h
+#ifndef GUI_COMPONENTS_GUI_COMPONENT_H
+#define GUI_COMPONENTS_GUI_COMPONENT_H
+
 
 #include "../../display/scr_coord.h"
 #include "../../simevent.h"

--- a/gui/components/gui_component_table.h
+++ b/gui/components/gui_component_table.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_component_table_h
-#define gui_component_table_h
+#ifndef GUI_COMPONENTS_GUI_COMPONENT_TABLE_H
+#define GUI_COMPONENTS_GUI_COMPONENT_TABLE_H
+
 
 #include "gui_table.h"
 

--- a/gui/components/gui_container.h
+++ b/gui/components/gui_container.h
@@ -11,8 +11,8 @@
  * @date 03-Mar-01
  */
 
-#ifndef gui_container_h
-#define gui_container_h
+#ifndef GUI_COMPONENTS_GUI_CONTAINER_H
+#define GUI_COMPONENTS_GUI_CONTAINER_H
 
 
 #include "../../simdebug.h"

--- a/gui/components/gui_convoiinfo.h
+++ b/gui/components/gui_convoiinfo.h
@@ -7,8 +7,9 @@
  * Convoi info stats, like loading status bar
  */
 
-#ifndef gui_convoiinfo_h
-#define gui_convoiinfo_h
+#ifndef GUI_COMPONENTS_GUI_CONVOIINFO_H
+#define GUI_COMPONENTS_GUI_CONVOIINFO_H
+
 
 #include "../../display/scr_coord.h"
 #include "gui_container.h"

--- a/gui/components/gui_convoy_assembler.h
+++ b/gui/components/gui_convoy_assembler.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_convoy_assembler_h
-#define gui_convoy_assembler_h
+#ifndef GUI_COMPONENTS_GUI_CONVOY_ASSEMBLER_H
+#define GUI_COMPONENTS_GUI_CONVOY_ASSEMBLER_H
+
 
 #include "action_listener.h"
 #include "gui_button.h"

--- a/gui/components/gui_convoy_label.h
+++ b/gui/components/gui_convoy_label.h
@@ -2,8 +2,9 @@
 * just displays a label with a convoy under it, the label will be auto-translated
  */
 
-#ifndef gui_convoy_label_t_h
-#define gui_convoy_label_t_h
+#ifndef GUI_COMPONENTS_GUI_CONVOY_LABEL_H
+#define GUI_COMPONENTS_GUI_CONVOY_LABEL_H
+
 
 #include "gui_label.h"
 

--- a/gui/components/gui_divider.h
+++ b/gui/components/gui_divider.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_components_gui_divider_h
-#define gui_components_gui_divider_h
+#ifndef GUI_COMPONENTS_GUI_DIVIDER_H
+#define GUI_COMPONENTS_GUI_DIVIDER_H
+
 
 #include "gui_component.h"
 #include "../../display/simgraph.h"

--- a/gui/components/gui_fixedwidth_textarea.h
+++ b/gui/components/gui_fixedwidth_textarea.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_fixedwidth_textarea_h
-#define gui_fixedwidth_textarea_h
+#ifndef GUI_COMPONENTS_GUI_FIXEDWIDTH_TEXTAREA_H
+#define GUI_COMPONENTS_GUI_FIXEDWIDTH_TEXTAREA_H
+
 
 #include "gui_component.h"
 #include "gui_container.h"

--- a/gui/components/gui_flowtext.h
+++ b/gui/components/gui_flowtext.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef GUI_COMPONENTS_FLOWTEXT_H
-#define GUI_COMPONENTS_FLOWTEXT_H
+#ifndef GUI_COMPONENTS_GUI_FLOWTEXT_H
+#define GUI_COMPONENTS_GUI_FLOWTEXT_H
+
 
 #include <string>
 

--- a/gui/components/gui_image.h
+++ b/gui/components/gui_image.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_image_h
-#define gui_image_h
+#ifndef GUI_COMPONENTS_GUI_IMAGE_H
+#define GUI_COMPONENTS_GUI_IMAGE_H
+
 
 #include "../../display/simimg.h"
 #include "../../display/simgraph.h"

--- a/gui/components/gui_image_list.h
+++ b/gui/components/gui_image_list.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_image_list_h
-#define gui_image_list_h
+#ifndef GUI_COMPONENTS_GUI_IMAGE_LIST_H
+#define GUI_COMPONENTS_GUI_IMAGE_LIST_H
+
 
 #include "gui_action_creator.h"
 #include "gui_component.h"

--- a/gui/components/gui_label.h
+++ b/gui/components/gui_label.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_gui_label_h
-#define gui_gui_label_h
+#ifndef GUI_COMPONENTS_GUI_LABEL_H
+#define GUI_COMPONENTS_GUI_LABEL_H
+
 
 #include "gui_component.h"
 #include "../../simcolor.h"

--- a/gui/components/gui_location_view_t.h
+++ b/gui/components/gui_location_view_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef LOCATION_VIEW_T_H
-#define LOCATION_VIEW_T_H
+#ifndef GUI_COMPONENTS_GUI_LOCATION_VIEW_T_H
+#define GUI_COMPONENTS_GUI_LOCATION_VIEW_T_H
+
 
 #include "gui_world_view_t.h"
 

--- a/gui/components/gui_map_preview.h
+++ b/gui/components/gui_map_preview.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_gui_map_preview_h
-#define gui_gui_map_preview_h
+#ifndef GUI_COMPONENTS_GUI_MAP_PREVIEW_H
+#define GUI_COMPONENTS_GUI_MAP_PREVIEW_H
+
 
 #include "gui_component.h"
 #include "../../simcolor.h"

--- a/gui/components/gui_numberinput.h
+++ b/gui/components/gui_numberinput.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_components_gui_numberinput_h
-#define gui_components_gui_numberinput_h
+#ifndef GUI_COMPONENTS_GUI_NUMBERINPUT_H
+#define GUI_COMPONENTS_GUI_NUMBERINPUT_H
+
 
 #include "../../simtypes.h"
 #include "../../display/scr_coord.h"

--- a/gui/components/gui_obj_view_t.h
+++ b/gui/components/gui_obj_view_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef OBJ_VIEW_T_H
-#define OBJ_VIEW_T_H
+#ifndef GUI_COMPONENTS_GUI_OBJ_VIEW_T_H
+#define GUI_COMPONENTS_GUI_OBJ_VIEW_T_H
+
 
 #include "gui_world_view_t.h"
 

--- a/gui/components/gui_scrollbar.h
+++ b/gui/components/gui_scrollbar.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_scrollbar_h
-#define gui_scrollbar_h
+#ifndef GUI_COMPONENTS_GUI_SCROLLBAR_H
+#define GUI_COMPONENTS_GUI_SCROLLBAR_H
+
 
 #include "gui_action_creator.h"
 #include "../../simevent.h"

--- a/gui/components/gui_scrolled_list.h
+++ b/gui/components/gui_scrolled_list.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_scrolled_list_h
-#define gui_scrolled_list_h
+#ifndef GUI_COMPONENTS_GUI_SCROLLED_LIST_H
+#define GUI_COMPONENTS_GUI_SCROLLED_LIST_H
+
 
 #include "gui_scrollbar.h"
 #include "action_listener.h"

--- a/gui/components/gui_scrollpane.h
+++ b/gui/components/gui_scrollpane.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_scrollpane_h
-#define gui_scrollpane_h
+#ifndef GUI_COMPONENTS_GUI_SCROLLPANE_H
+#define GUI_COMPONENTS_GUI_SCROLLPANE_H
 
 
 #include "gui_component.h"

--- a/gui/components/gui_speedbar.h
+++ b/gui/components/gui_speedbar.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_components_gui_speedbar_h
-#define gui_components_gui_speedbar_h
+#ifndef GUI_COMPONENTS_GUI_SPEEDBAR_H
+#define GUI_COMPONENTS_GUI_SPEEDBAR_H
+
 
 #include "gui_component.h"
 #include "../../tpl/slist_tpl.h"

--- a/gui/components/gui_tab_panel.h
+++ b/gui/components/gui_tab_panel.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_tab_panel_h
-#define gui_tab_panel_h
+#ifndef GUI_COMPONENTS_GUI_TAB_PANEL_H
+#define GUI_COMPONENTS_GUI_TAB_PANEL_H
+
 
 #include "../../display/simimg.h"
 

--- a/gui/components/gui_table.h
+++ b/gui/components/gui_table.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_table_h
-#define gui_table_h
+#ifndef GUI_COMPONENTS_GUI_TABLE_H
+#define GUI_COMPONENTS_GUI_TABLE_H
+
 
 #include <string.h>
 

--- a/gui/components/gui_textarea.h
+++ b/gui/components/gui_textarea.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_textarea_h
-#define gui_textarea_h
+#ifndef GUI_COMPONENTS_GUI_TEXTAREA_H
+#define GUI_COMPONENTS_GUI_TEXTAREA_H
+
 
 #include "gui_component.h"
 

--- a/gui/components/gui_textinput.h
+++ b/gui/components/gui_textinput.h
@@ -3,9 +3,9 @@
  * (see LICENSE.txt)
  */
 
+#ifndef GUI_COMPONENTS_GUI_TEXTINPUT_H
+#define GUI_COMPONENTS_GUI_TEXTINPUT_H
 
-#ifndef gui_components_gui_textinput_h
-#define gui_components_gui_textinput_h
 
 #include "gui_action_creator.h"
 #include "gui_component.h"

--- a/gui/components/gui_world_view_t.h
+++ b/gui/components/gui_world_view_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef world_view_t_h
-#define world_view_t_h
+#ifndef GUI_COMPONENTS_GUI_WORLD_VIEW_T_H
+#define GUI_COMPONENTS_GUI_WORLD_VIEW_T_H
+
 
 #include "gui_component.h"
 

--- a/gui/components/location_view_t.h
+++ b/gui/components/location_view_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef LOCATION_VIEW_T_H
-#define LOCATION_VIEW_T_H
+#ifndef GUI_COMPONENTS_LOCATION_VIEW_T_H
+#define GUI_COMPONENTS_LOCATION_VIEW_T_H
+
 
 #include "gui_world_view_t.h"
 

--- a/gui/convoi_frame.h
+++ b/gui/convoi_frame.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __convoi_frame_h
-#define __convoi_frame_h
+#ifndef GUI_CONVOI_FRAME_H
+#define GUI_CONVOI_FRAME_H
+
 
 #include "convoi_filter_frame.h"
 #include "gui_frame.h"

--- a/gui/convoy_item.h
+++ b/gui/convoy_item.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef convoy_scrollitem_h
-#define convoy_scrollitem_h
+#ifndef GUI_CONVOY_ITEM_H
+#define GUI_CONVOY_ITEM_H
+
 
 #include "components/gui_scrolled_list.h"
 #include "../convoihandle_t.h"

--- a/gui/curiosity_edit.h
+++ b/gui/curiosity_edit.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_curiosity_edit_h
-#define gui_curiosity_edit_h
+#ifndef GUI_CURIOSITY_EDIT_H
+#define GUI_CURIOSITY_EDIT_H
+
 
 #include "extend_edit.h"
 

--- a/gui/curiositylist_frame_t.h
+++ b/gui/curiositylist_frame_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef curiositylist_frame_t_h
-#define curiositylist_frame_t_h
+#ifndef GUI_CURIOSITYLIST_FRAME_T_H
+#define GUI_CURIOSITYLIST_FRAME_T_H
+
 
 #include "../gui/gui_frame.h"
 #include "../gui/curiositylist_stats_t.h"

--- a/gui/curiositylist_stats_t.h
+++ b/gui/curiositylist_stats_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef curiositylist_stats_t_h
-#define curiositylist_stats_t_h
+#ifndef GUI_CURIOSITYLIST_STATS_T_H
+#define GUI_CURIOSITYLIST_STATS_T_H
+
 
 #include "../tpl/vector_tpl.h"
 #include "components/gui_component.h"

--- a/gui/depot_frame.h
+++ b/gui/depot_frame.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_depot_frame2_t_h
-#define gui_depot_frame2_t_h
+#ifndef GUI_DEPOT_FRAME_H
+#define GUI_DEPOT_FRAME_H
+
 
 #include "gui_frame.h"
 #include "components/gui_label.h"

--- a/gui/display_settings.h
+++ b/gui/display_settings.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _display_settings_h_
-#define _display_settings_h_
+#ifndef GUI_DISPLAY_SETTINGS_H
+#define GUI_DISPLAY_SETTINGS_H
+
 
 #include "gui_frame.h"
 #include "components/gui_divider.h"

--- a/gui/enlarge_map_frame_t.h
+++ b/gui/enlarge_map_frame_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef bigger_map_gui_h
-#define bigger_map_gui_h
+#ifndef GUI_ENLARGE_MAP_FRAME_T_H
+#define GUI_ENLARGE_MAP_FRAME_T_H
+
 
 #include "gui_frame.h"
 #include "components/gui_label.h"

--- a/gui/extend_edit.h
+++ b/gui/extend_edit.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_extend_edit_h
-#define gui_extend_edit_h
+#ifndef GUI_EXTEND_EDIT_H
+#define GUI_EXTEND_EDIT_H
+
 
 #include "gui_frame.h"
 #include "components/gui_container.h"

--- a/gui/fabrik_info.h
+++ b/gui/fabrik_info.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef fabrikinfo_t_h
-#define fabrikinfo_t_h
+#ifndef GUI_FABRIK_INFO_H
+#define GUI_FABRIK_INFO_H
+
 
 #include "../gui/simwin.h"
 

--- a/gui/factory_chart.h
+++ b/gui/factory_chart.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef factory_chart_h
-#define factory_chart_h
+#ifndef GUI_FACTORY_CHART_H
+#define GUI_FACTORY_CHART_H
+
 
 #define MAX_PROD_LABEL      (7-1)
 

--- a/gui/factory_edit.h
+++ b/gui/factory_edit.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_factory_edit_h
-#define gui_factory_edit_h
+#ifndef GUI_FACTORY_EDIT_H
+#define GUI_FACTORY_EDIT_H
+
 
 #include "extend_edit.h"
 #include "components/gui_label.h"

--- a/gui/factorylist_frame_t.h
+++ b/gui/factorylist_frame_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef factorylist_frame_t_h
-#define factorylist_frame_t_h
+#ifndef GUI_FACTORYLIST_FRAME_T_H
+#define GUI_FACTORYLIST_FRAME_T_H
+
 
 #include "gui_frame.h"
 #include "components/gui_scrollpane.h"

--- a/gui/factorylist_stats_t.h
+++ b/gui/factorylist_stats_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef factorylist_stats_t_h
-#define factorylist_stats_t_h
+#ifndef GUI_FACTORYLIST_STATS_T_H
+#define GUI_FACTORYLIST_STATS_T_H
+
 
 #include "../tpl/vector_tpl.h"
 #include "components/gui_component.h"

--- a/gui/goods_frame_t.h
+++ b/gui/goods_frame_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef goods_frame_t_h
-#define goods_frame_t_h
+#ifndef GUI_GOODS_FRAME_T_H
+#define GUI_GOODS_FRAME_T_H
+
 
 #include "gui_frame.h"
 #include "components/gui_button.h"

--- a/gui/goods_stats_t.h
+++ b/gui/goods_stats_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef good_stats_t_h
-#define good_stats_t_h
+#ifndef GUI_GOODS_STATS_T_H
+#define GUI_GOODS_STATS_T_H
+
 
 #include "../simtypes.h"
 #include "components/gui_component.h"

--- a/gui/ground_info.h
+++ b/gui/ground_info.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_ground_info_h
-#define gui_ground_info_h
+#ifndef GUI_GROUND_INFO_H
+#define GUI_GROUND_INFO_H
+
 
 #include "base_info.h"
 #include "components/gui_location_view_t.h"

--- a/gui/gui_frame.h
+++ b/gui/gui_frame.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_gui_frame_h
-#define gui_gui_frame_h
+#ifndef GUI_GUI_FRAME_H
+#define GUI_GUI_FRAME_H
+
 
 #include "../display/scr_coord.h"
 #include "../display/simgraph.h"

--- a/gui/gui_theme.h
+++ b/gui/gui_theme.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_theme_h
-#define gui_theme_h
+#ifndef GUI_GUI_THEME_H
+#define GUI_GUI_THEME_H
+
 
 #include "../dataobj/koord.h"
 #include "../simcolor.h"

--- a/gui/halt_detail.h
+++ b/gui/halt_detail.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_halt_detail_h
-#define gui_halt_detail_h
+#ifndef GUI_HALT_DETAIL_H
+#define GUI_HALT_DETAIL_H
+
 
 #include "components/gui_textarea.h"
 

--- a/gui/halt_info.h
+++ b/gui/halt_info.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_halt_info_h
-#define gui_halt_info_h
+#ifndef GUI_HALT_INFO_H
+#define GUI_HALT_INFO_H
+
 
 #include "gui_frame.h"
 #include "components/gui_label.h"

--- a/gui/halt_list_frame.h
+++ b/gui/halt_list_frame.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __halt_list_frame_h
-#define __halt_list_frame_h
+#ifndef GUI_HALT_LIST_FRAME_H
+#define GUI_HALT_LIST_FRAME_H
+
 
 #include "gui_frame.h"
 #include "components/gui_container.h"

--- a/gui/halt_list_stats.h
+++ b/gui/halt_list_stats.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef halt_list_stats_h
-#define halt_list_stats_h
+#ifndef GUI_HALT_LIST_STATS_H
+#define GUI_HALT_LIST_STATS_H
+
 
 #include "components/gui_component.h"
 #include "../halthandle_t.h"

--- a/gui/help_frame.h
+++ b/gui/help_frame.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_help_frame_h
-#define gui_help_frame_h
+#ifndef GUI_HELP_FRAME_H
+#define GUI_HELP_FRAME_H
+
 
 #include <string>
 

--- a/gui/jump_frame.h
+++ b/gui/jump_frame.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_jumpframe_h
-#define gui_jumpframe_h
+#ifndef GUI_JUMP_FRAME_H
+#define GUI_JUMP_FRAME_H
+
 
 #include "components/action_listener.h"
 #include "gui_frame.h"

--- a/gui/karte.h
+++ b/gui/karte.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_karte_h
-#define gui_karte_h
+#ifndef GUI_KARTE_H
+#define GUI_KARTE_H
+
 
 #include "components/gui_component.h"
 #include "../halthandle_t.h"

--- a/gui/kennfarbe.h
+++ b/gui/kennfarbe.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_kennfarbe_h
-#define gui_kennfarbe_h
+#ifndef GUI_KENNFARBE_H
+#define GUI_KENNFARBE_H
+
 
 #include "../utils/cbuffer_t.h"
 #include "gui_frame.h"

--- a/gui/label_info.h
+++ b/gui/label_info.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_label_info_h
-#define gui_label_info_h
+#ifndef GUI_LABEL_INFO_H
+#define GUI_LABEL_INFO_H
+
 
 #include "gui_frame.h"
 #include "components/gui_label.h"

--- a/gui/labellist_frame_t.h
+++ b/gui/labellist_frame_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef labellist_frame_t_h
-#define labellist_frame_t_h
+#ifndef GUI_LABELLIST_FRAME_T_H
+#define GUI_LABELLIST_FRAME_T_H
+
 
 #include "../gui/gui_frame.h"
 #include "../gui/labellist_stats_t.h"

--- a/gui/labellist_stats_t.h
+++ b/gui/labellist_stats_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef labellist_stats_t_h
-#define labellist_stats_t_h
+#ifndef GUI_LABELLIST_STATS_T_H
+#define GUI_LABELLIST_STATS_T_H
+
 
 #include "../tpl/vector_tpl.h"
 #include "components/gui_component.h"

--- a/gui/line_item.h
+++ b/gui/line_item.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef line_scrollitem_h
-#define line_scrollitem_h
+#ifndef GUI_LINE_ITEM_H
+#define GUI_LINE_ITEM_H
+
 
 #include "components/gui_scrolled_list.h"
 #include "../linehandle_t.h"

--- a/gui/load_relief_frame.h
+++ b/gui/load_relief_frame.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_load_relief_frame_h
-#define gui_load_relief_frame_h
+#ifndef GUI_LOAD_RELIEF_FRAME_H
+#define GUI_LOAD_RELIEF_FRAME_H
 
 
 #include "savegame_frame.h"

--- a/gui/loadsave_frame.h
+++ b/gui/loadsave_frame.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_loadsave_frame_h
-#define gui_loadsave_frame_h
+#ifndef GUI_LOADSAVE_FRAME_H
+#define GUI_LOADSAVE_FRAME_H
 
 
 #include "savegame_frame.h"

--- a/gui/map_frame.h
+++ b/gui/map_frame.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_map_frame_h
-#define gui_map_frame_h
+#ifndef GUI_MAP_FRAME_H
+#define GUI_MAP_FRAME_H
+
 
 #include "gui_frame.h"
 #include "../gui/simwin.h"

--- a/gui/message_frame_t.h
+++ b/gui/message_frame_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef message_frame_h
-#define message_frame_h
+#ifndef GUI_MESSAGE_FRAME_T_H
+#define GUI_MESSAGE_FRAME_T_H
+
 
 #include "../gui/simwin.h"
 

--- a/gui/message_option_t.h
+++ b/gui/message_option_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef message_option_h
-#define message_option_h
+#ifndef GUI_MESSAGE_OPTION_T_H
+#define GUI_MESSAGE_OPTION_T_H
+
 
 #include "../simmesg.h"
 #include "../gui/simwin.h"

--- a/gui/message_stats_t.h
+++ b/gui/message_stats_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef message_stats_t_h
-#define message_stats_t_h
+#ifndef GUI_MESSAGE_STATS_T_H
+#define GUI_MESSAGE_STATS_T_H
+
 
 #include "components/gui_component.h"
 #include "../display/simimg.h"

--- a/gui/messagebox.h
+++ b/gui/messagebox.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_messagebox_h
-#define gui_messagebox_h
+#ifndef GUI_MESSAGEBOX_H
+#define GUI_MESSAGEBOX_H
+
 
 #include "base_info.h"
 #include "components/gui_location_view_t.h"

--- a/gui/money_frame.h
+++ b/gui/money_frame.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef money_frame_h
-#define money_frame_h
+#ifndef GUI_MONEY_FRAME_H
+#define GUI_MONEY_FRAME_H
+
 
 #include "gui_frame.h"
 #include "components/action_listener.h"

--- a/gui/obj_info.h
+++ b/gui/obj_info.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_thing_info_h
-#define gui_thing_info_h
+#ifndef GUI_OBJ_INFO_H
+#define GUI_OBJ_INFO_H
+
 
 #include "../simdebug.h"
 #include "../simobj.h"

--- a/gui/onewaysign_info.h
+++ b/gui/onewaysign_info.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef onewaysign_info_t_h
-#define onewaysign_info_t_h
+#ifndef GUI_ONEWAYSIGN_INFO_H
+#define GUI_ONEWAYSIGN_INFO_H
+
 
 #include "../simconst.h"
 #include "obj_info.h"

--- a/gui/optionen.h
+++ b/gui/optionen.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_optionen_h
-#define gui_optionen_h
+#ifndef GUI_OPTIONEN_H
+#define GUI_OPTIONEN_H
+
 
 /**
  * Settings in the game

--- a/gui/overtaking_mode.h
+++ b/gui/overtaking_mode.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef overtaking_mode_h
-#define overtaking_mode_h
+#ifndef GUI_OVERTAKING_MODE_H
+#define GUI_OVERTAKING_MODE_H
+
 
 #include "gui_frame.h"
 #include "components/action_listener.h"

--- a/gui/pakselector.h
+++ b/gui/pakselector.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef pakselector_h
-#define pakselector_h
+#ifndef GUI_PAKSELECTOR_H
+#define GUI_PAKSELECTOR_H
 
 
 #include "savegame_frame.h"

--- a/gui/password_frame.h
+++ b/gui/password_frame.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_password_frame_h
-#define gui_password_frame_h
+#ifndef GUI_PASSWORD_FRAME_H
+#define GUI_PASSWORD_FRAME_H
 
 
 #include "components/action_listener.h"

--- a/gui/player_frame_t.h
+++ b/gui/player_frame_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_player_h
-#define gui_player_h
+#ifndef GUI_PLAYER_FRAME_T_H
+#define GUI_PLAYER_FRAME_T_H
+
 
 #include "../simconst.h"
 

--- a/gui/privatesign_info.h
+++ b/gui/privatesign_info.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef privatesign_info_t_h
-#define privatesign_info_t_h
+#ifndef GUI_PRIVATESIGN_INFO_H
+#define GUI_PRIVATESIGN_INFO_H
+
 
 #include "../simconst.h"
 #include "obj_info.h"

--- a/gui/replace_frame.h
+++ b/gui/replace_frame.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef replace_frame_t_h
-#define replace_frame_t_h
+#ifndef GUI_REPLACE_FRAME_H
+#define GUI_REPLACE_FRAME_H
+
 
 #include "gui_frame.h"
 

--- a/gui/savegame_frame.h
+++ b/gui/savegame_frame.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_savegame_frame_h
-#define gui_savegame_frame_h
+#ifndef GUI_SAVEGAME_FRAME_H
+#define GUI_SAVEGAME_FRAME_H
+
 
 #include <string.h>
 #include <cstring>

--- a/gui/scenario_frame.h
+++ b/gui/scenario_frame.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_scenario_frame_h
-#define gui_scenario_frame_h
+#ifndef GUI_SCENARIO_FRAME_H
+#define GUI_SCENARIO_FRAME_H
 
 
 #include "savegame_frame.h"

--- a/gui/scenario_info.h
+++ b/gui/scenario_info.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _SCEN_INFO_H_
-#define _SCEN_INFO_H_
+#ifndef GUI_SCENARIO_INFO_H
+#define GUI_SCENARIO_INFO_H
 
 
 #include "gui_frame.h"

--- a/gui/schedule_gui.h
+++ b/gui/schedule_gui.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_schedule_gui_h
-#define gui_schedule_gui_h
+#ifndef GUI_SCHEDULE_GUI_H
+#define GUI_SCHEDULE_GUI_H
+
 
 #include "gui_frame.h"
 

--- a/gui/schedule_list.h
+++ b/gui/schedule_list.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_schedule_list_h
-#define gui_schedule_list_h
+#ifndef GUI_SCHEDULE_LIST_H
+#define GUI_SCHEDULE_LIST_H
+
 
 #include "gui_frame.h"
 #include "components/gui_container.h"

--- a/gui/schiene_info.h
+++ b/gui/schiene_info.h
@@ -7,8 +7,9 @@
  * Track infowindow buttons //Ves
  */
 
-#ifndef schiene_info_t_h
-#define schiene_info_t_h
+#ifndef GUI_SCHIENE_INFO_H
+#define GUI_SCHIENE_INFO_H
+
 
 #include "obj_info.h"
 #include "../boden/wege/schiene.h"

--- a/gui/server_frame.h
+++ b/gui/server_frame.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_serverframe_h
-#define gui_serverframe_h
+#ifndef GUI_SERVER_FRAME_H
+#define GUI_SERVER_FRAME_H
+
 
 #include "gui_frame.h"
 #include "components/gui_button.h"

--- a/gui/settings_frame.h
+++ b/gui/settings_frame.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef settings_frame_h
-#define settings_frame_h
+#ifndef GUI_SETTINGS_FRAME_H
+#define GUI_SETTINGS_FRAME_H
 
 
 #include "gui_frame.h"

--- a/gui/settings_stats.h
+++ b/gui/settings_stats.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef settings_passenger_stats_h
-#define settings_passenger_stats_h
+#ifndef GUI_SETTINGS_STATS_H
+#define GUI_SETTINGS_STATS_H
+
 
 #include <math.h>
 

--- a/gui/signal_info.h
+++ b/gui/signal_info.h
@@ -7,8 +7,9 @@
  * signal infowindow buttons //Ves
  */
 
-#ifndef signal_info_t_h
-#define signal_info_t_h
+#ifndef GUI_SIGNAL_INFO_H
+#define GUI_SIGNAL_INFO_H
+
 
 #include "obj_info.h"
 #include "../obj/signal.h"

--- a/gui/signal_spacing.h
+++ b/gui/signal_spacing.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef signal_spacing_h
-#define signal_spacing_h
+#ifndef GUI_SIGNAL_SPACING_H
+#define GUI_SIGNAL_SPACING_H
+
 
 #include "gui_frame.h"
 #include "components/action_listener.h"

--- a/gui/simwin.h
+++ b/gui/simwin.h
@@ -7,8 +7,9 @@
  * The function implements a WindowManager 'Object'
  */
 
-#ifndef simwin_h
-#define simwin_h
+#ifndef GUI_SIMWIN_H
+#define GUI_SIMWIN_H
+
 
 #include <stddef.h> // for ptrdiff_t
 

--- a/gui/sprachen.h
+++ b/gui/sprachen.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_sprachen_h
-#define gui_sprachen_h
+#ifndef GUI_SPRACHEN_H
+#define GUI_SPRACHEN_H
+
 
 #include "gui_frame.h"
 #include "components/action_listener.h"

--- a/gui/station_building_select.h
+++ b/gui/station_building_select.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef station_building_select_h
-#define station_building_select_h
+#ifndef GUI_STATION_BUILDING_SELECT_H
+#define GUI_STATION_BUILDING_SELECT_H
+
 
 #include "components/action_listener.h"
 #include "gui_frame.h"

--- a/gui/themeselector.h
+++ b/gui/themeselector.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef themeselector_h
-#define themeselector_h
+#ifndef GUI_THEMESELECTOR_H
+#define GUI_THEMESELECTOR_H
+
 
 #include "simwin.h"
 #include "savegame_frame.h"

--- a/gui/times_history.h
+++ b/gui/times_history.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef gui_time_history_h
-#define gui_time_history_h
+#ifndef GUI_TIMES_HISTORY_H
+#define GUI_TIMES_HISTORY_H
+
 
 #include "components/gui_textarea.h"
 

--- a/gui/times_history_container.h
+++ b/gui/times_history_container.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef times_history_container_h
-#define times_history_container_h
+#ifndef GUI_TIMES_HISTORY_CONTAINER_H
+#define GUI_TIMES_HISTORY_CONTAINER_H
+
 
 #include "components/gui_component.h"
 #include "gui_frame.h"

--- a/gui/times_history_entry.h
+++ b/gui/times_history_entry.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef times_history_entry_h
-#define times_history_entry_h
+#ifndef GUI_TIMES_HISTORY_ENTRY_H
+#define GUI_TIMES_HISTORY_ENTRY_H
+
 
 #include "components/gui_component.h"
 #include "components/gui_label.h"

--- a/gui/tool_selector.h
+++ b/gui/tool_selector.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef TOOL_SELECTOR_H
-#define TOOL_SELECTOR_H
+#ifndef GUI_TOOL_SELECTOR_H
+#define GUI_TOOL_SELECTOR_H
+
 
 #include "gui_frame.h"
 #include "../tpl/vector_tpl.h"

--- a/gui/trafficlight_info.h
+++ b/gui/trafficlight_info.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef trafficlight_info_t_h
-#define trafficlight_info_t_h
+#ifndef GUI_TRAFFICLIGHT_INFO_H
+#define GUI_TRAFFICLIGHT_INFO_H
+
 
 #include "obj_info.h"
 #include "components/action_listener.h"

--- a/gui/welt.h
+++ b/gui/welt.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef welt_gui_h
-#define welt_gui_h
+#ifndef GUI_WELT_H
+#define GUI_WELT_H
+
 
 #include "gui_frame.h"
 #include "components/gui_button.h"

--- a/halthandle_t.h
+++ b/halthandle_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef halthandle_t_h
-#define halthandle_t_h
+#ifndef HALTHANDLE_T_H
+#define HALTHANDLE_T_H
+
 
 #include "tpl/quickstone_tpl.h"
 

--- a/ifc/simtestdriver.h
+++ b/ifc/simtestdriver.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef SIMTESTDRIVER_H
-#define SIMTESTDRIVER_H
+#ifndef IFC_SIMTESTDRIVER_H
+#define IFC_SIMTESTDRIVER_H
 
 
 class grund_t;

--- a/ifc/sync_steppable.h
+++ b/ifc/sync_steppable.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef sync_steppable_h
-#define sync_steppable_h
+#ifndef IFC_SYNC_STEPPABLE_H
+#define IFC_SYNC_STEPPABLE_H
+
 
 #include "../simtypes.h"
 

--- a/linehandle_t.h
+++ b/linehandle_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef linehandle_t_h
-#define linehandle_t_h
+#ifndef LINEHANDLE_T_H
+#define LINEHANDLE_T_H
+
 
 #include "tpl/quickstone_tpl.h"
 

--- a/macros.h
+++ b/macros.h
@@ -6,6 +6,7 @@
 #ifndef MACROS_H
 #define MACROS_H
 
+
 #include "simtypes.h"
 
 // XXX Workaround: Old GCCs choke on type check.

--- a/music/music.h
+++ b/music/music.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef MUSIC_H
-#define MUSIC_H
+#ifndef MUSIC_MUSIC_H
+#define MUSIC_MUSIC_H
+
 
 #include "../simtypes.h"
 

--- a/network/checksum.h
+++ b/network/checksum.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _CHECKSUM_H_
-#define _CHECKSUM_H_
+#ifndef NETWORK_CHECKSUM_H
+#define NETWORK_CHECKSUM_H
+
 
 #include "../utils/sha1.h"
 

--- a/network/memory_rw.h
+++ b/network/memory_rw.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _MEMORY_RW_H
-#define _MEMORY_RW_H
+#ifndef NETWORK_MEMORY_RW_H
+#define NETWORK_MEMORY_RW_H
+
 
 /* This is a class to write data to memory in intel byte order
  * on every architecture

--- a/network/network.h
+++ b/network/network.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef sim_network_h
-#define sim_network_h
+#ifndef NETWORK_NETWORK_H
+#define NETWORK_NETWORK_H
+
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #define USE_WINSOCK 1

--- a/network/network_address.h
+++ b/network/network_address.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _NETWORK_ADDRESS_H_
-#define _NETWORK_ADDRESS_H_
+#ifndef NETWORK_NETWORK_ADDRESS_H
+#define NETWORK_NETWORK_ADDRESS_H
+
 
 #include "../simtypes.h"
 #include "../tpl/vector_tpl.h"

--- a/network/network_cmd.h
+++ b/network/network_cmd.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _NETWORK_CMD_H_
-#define _NETWORK_CMD_H_
+#ifndef NETWORK_NETWORK_CMD_H
+#define NETWORK_NETWORK_CMD_H
+
 
 #include "../simtypes.h"
 #include "../tpl/slist_tpl.h"

--- a/network/network_cmd_ingame.h
+++ b/network/network_cmd_ingame.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _NETWORK_CMD_INGAME_H_
-#define _NETWORK_CMD_INGAME_H_
+#ifndef NETWORK_NETWORK_CMD_INGAME_H
+#define NETWORK_NETWORK_CMD_INGAME_H
+
 
 #include "network_cmd.h"
 #include "memory_rw.h"

--- a/network/network_cmd_scenario.h
+++ b/network/network_cmd_scenario.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _NETWORK_CMD_SCENARIO_H_
-#define _NETWORK_CMD_SCENARIO_H_
+#ifndef NETWORK_NETWORK_CMD_SCENARIO_H
+#define NETWORK_NETWORK_CMD_SCENARIO_H
+
 
 #include "network_cmd.h"
 #include "network_cmd_ingame.h"

--- a/network/network_cmp_pakset.h
+++ b/network/network_cmp_pakset.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _NETWORK_CMP_PAKSET_H_
-#define _NETWORK_CMP_PAKSET_H_
+#ifndef NETWORK_NETWORK_CMP_PAKSET_H
+#define NETWORK_NETWORK_CMP_PAKSET_H
+
 
 #include "network_cmd.h"
 #include "pakset_info.h"

--- a/network/network_file_transfer.h
+++ b/network/network_file_transfer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef NETWORK_FILE_TRANSFER_H
-#define NETWORK_FILE_TRANSFER_H
+#ifndef NETWORK_NETWORK_FILE_TRANSFER_H
+#define NETWORK_NETWORK_FILE_TRANSFER_H
+
 
 /**
  * Contains functions to send & receive files over network

--- a/network/network_packet.h
+++ b/network/network_packet.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _NETWORK_PACKET_H
-#define _NETWORK_PACKET_H
+#ifndef NETWORK_NETWORK_PACKET_H
+#define NETWORK_NETWORK_PACKET_H
+
 
 #include "../simtypes.h"
 #include "memory_rw.h"

--- a/network/network_socket_list.h
+++ b/network/network_socket_list.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _NETWORK_SOCKET_LIST_H_
-#define _NETWORK_SOCKET_LIST_H_
+#ifndef NETWORK_NETWORK_SOCKET_LIST_H
+#define NETWORK_NETWORK_SOCKET_LIST_H
+
 
 #include "network.h"
 #include "network_address.h"

--- a/network/pakset_info.h
+++ b/network/pakset_info.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _PAKSET_INFO_H
-#define _PAKSET_INFO_H
+#ifndef NETWORK_PAKSET_INFO_H
+#define NETWORK_PAKSET_INFO_H
+
 
 #include "../tpl/stringhashtable_tpl.h"
 #include "checksum.h"

--- a/network/pwd_hash.h
+++ b/network/pwd_hash.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef PWD_HASH_H
-#define PWD_HASH_H
+#ifndef NETWORK_PWD_HASH_H
+#define NETWORK_PWD_HASH_H
+
 
 #include <string.h>
 

--- a/obj/baum.h
+++ b/obj/baum.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef obj_baum_h
-#define obj_baum_h
+#ifndef OBJ_BAUM_H
+#define OBJ_BAUM_H
+
 
 #include <string>
 #include "../tpl/stringhashtable_tpl.h"

--- a/obj/bruecke.h
+++ b/obj/bruecke.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef obj_bruecke_h
-#define obj_bruecke_h
+#ifndef OBJ_BRUECKE_H
+#define OBJ_BRUECKE_H
+
 
 class karte_t;
 

--- a/obj/crossing.h
+++ b/obj/crossing.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef obj_crossing_h
-#define obj_crossing_h
+#ifndef OBJ_CROSSING_H
+#define OBJ_CROSSING_H
+
 
 #include "../simtypes.h"
 #include "../display/simimg.h"

--- a/obj/dummy.h
+++ b/obj/dummy.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef obj_dummy_h
-#define obj_dummy_h
+#ifndef OBJ_DUMMY_H
+#define OBJ_DUMMY_H
+
 
 #include "../simobj.h"
 #include "../display/simimg.h"

--- a/obj/field.h
+++ b/obj/field.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef obj_field_h
-#define obj_field_h
+#ifndef OBJ_FIELD_H
+#define OBJ_FIELD_H
+
 
 #include "../simobj.h"
 #include "../display/simimg.h"

--- a/obj/gebaeude.h
+++ b/obj/gebaeude.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef obj_gebaeude_h
-#define obj_gebaeude_h
+#ifndef OBJ_GEBAEUDE_H
+#define OBJ_GEBAEUDE_H
+
 
 #include "../ifc/sync_steppable.h"
 #include "../simobj.h"

--- a/obj/groundobj.h
+++ b/obj/groundobj.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef obj_groundobj_h
-#define obj_groundobj_h
+#ifndef OBJ_GROUNDOBJ_H
+#define OBJ_GROUNDOBJ_H
+
 
 #include "../tpl/stringhashtable_tpl.h"
 #include "../tpl/vector_tpl.h"

--- a/obj/label.h
+++ b/obj/label.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef label_h
-#define label_h
+#ifndef OBJ_LABEL_H
+#define OBJ_LABEL_H
+
 
 #include "../simobj.h"
 #include "../display/simimg.h"

--- a/obj/leitung2.h
+++ b/obj/leitung2.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef obj_leitung_t
-#define obj_leitung_t
+#ifndef OBJ_LEITUNG2_H
+#define OBJ_LEITUNG2_H
 
 
 #include "../ifc/sync_steppable.h"

--- a/obj/pillar.h
+++ b/obj/pillar.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef obj_pillar_h
-#define obj_pillar_h
+#ifndef OBJ_PILLAR_H
+#define OBJ_PILLAR_H
+
 
 #include "../simobj.h"
 

--- a/obj/roadsign.h
+++ b/obj/roadsign.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef obj_roadsign_h
-#define obj_roadsign_h
+#ifndef OBJ_ROADSIGN_H
+#define OBJ_ROADSIGN_H
+
 
 #include "../simobj.h"
 #include "../simtypes.h"

--- a/obj/signal.h
+++ b/obj/signal.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef obj_signal_h
-#define obj_signal_h
+#ifndef OBJ_SIGNAL_H
+#define OBJ_SIGNAL_H
+
 
 #include "roadsign.h"
 

--- a/obj/tunnel.h
+++ b/obj/tunnel.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef obj_tunnel_h
-#define obj_tunnel_h
+#ifndef OBJ_TUNNEL_H
+#define OBJ_TUNNEL_H
+
 
 #include "../simobj.h"
 #include "../display/simimg.h"

--- a/obj/wayobj.h
+++ b/obj/wayobj.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef wayobj_t_h
-#define wayobj_t_h
+#ifndef OBJ_WAYOBJ_H
+#define OBJ_WAYOBJ_H
+
 
 #include "../simtypes.h"
 #include "../display/simimg.h"

--- a/obj/wolke.h
+++ b/obj/wolke.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef obj_wolke_t
-#define obj_wolke_t
+#ifndef OBJ_WOLKE_H
+#define OBJ_WOLKE_H
+
 
 #include "../descriptor/skin_desc.h"
 #include "../ifc/sync_steppable.h"

--- a/obj/zeiger.h
+++ b/obj/zeiger.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef obj_zeiger_h
-#define obj_zeiger_h
+#ifndef OBJ_ZEIGER_H
+#define OBJ_ZEIGER_H
+
 
 #include "../simobj.h"
 #include "../simtypes.h"

--- a/old_blockmanager.h
+++ b/old_blockmanager.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef blockmanager_h
-#define blockmanager_h
+#ifndef OLD_BLOCKMANAGER_H
+#define OLD_BLOCKMANAGER_H
 
 
 class karte_t;

--- a/path_explorer.h
+++ b/path_explorer.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef path_explorer_h
-#define path_explorer_h
+#ifndef PATH_EXPLORER_H
+#define PATH_EXPLORER_H
+
 
 #include "network/memory_rw.h"
 #include "simline.h"

--- a/pathes.h
+++ b/pathes.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __PATHES_H
-#define __PATHES_H
+#ifndef PATHES_H
+#define PATHES_H
+
 
 /**
  * This header defines all paths used be simutrans relative to the game directory.

--- a/player/ai.h
+++ b/player/ai.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _AI_H
-#define _AI_H
+#ifndef PLAYER_AI_H
+#define PLAYER_AI_H
+
 
 #include "simplay.h"
 

--- a/player/ai_goods.h
+++ b/player/ai_goods.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef AI_GOODS_H
-#define AI_GOODS_H
+#ifndef PLAYER_AI_GOODS_H
+#define PLAYER_AI_GOODS_H
+
 
 #include "ai.h"
 

--- a/player/ai_passenger.h
+++ b/player/ai_passenger.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef AI_PASSENGER_H
-#define AI_PASSENGER_H
+#ifndef PLAYER_AI_PASSENGER_H
+#define PLAYER_AI_PASSENGER_H
 
 
 #include "ai.h"

--- a/player/finance.h
+++ b/player/finance.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef finance_h
-#define finance_h
+#ifndef PLAYER_FINANCE_H
+#define PLAYER_FINANCE_H
+
 
 #include <assert.h>
 

--- a/player/simplay.h
+++ b/player/simplay.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simplay_h
-#define simplay_h
+#ifndef PLAYER_SIMPLAY_H
+#define PLAYER_SIMPLAY_H
+
 
 #include "../network/pwd_hash.h"
 #include "../simtypes.h"

--- a/script/api/api.h
+++ b/script/api/api.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _API_H_
-#define _API_H_
+#ifndef SCRIPT_API_API_H
+#define SCRIPT_API_API_H
+
 
 /** @file api.h declarations of export functions. */
 

--- a/script/api/api_command.h
+++ b/script/api/api_command.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _API_COMMAND_H_
-#define _API_COMMAND_H_
+#ifndef SCRIPT_API_API_COMMAND_H
+#define SCRIPT_API_API_COMMAND_H
+
 
 #include "../api_param.h"
 #include "../../dataobj/koord3d.h"

--- a/script/api/api_obj_desc_base.h
+++ b/script/api/api_obj_desc_base.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _API_OBJ_DESC_BASE_H_
-#define _API_OBJ_DESC_BASE_H_
+#ifndef SCRIPT_API_API_OBJ_DESC_BASE_H
+#define SCRIPT_API_API_OBJ_DESC_BASE_H
+
 
 /** @file api_obj_desc.h templates for transfer of desc-pointers */
 

--- a/script/api/api_simple.h
+++ b/script/api/api_simple.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _API_SIMPLE_H__
-#define _API_SIMPLE_H__
+#ifndef SCRIPT_API_API_SIMPLE_H
+#define SCRIPT_API_API_SIMPLE_H
+
 
 #include "../../squirrel/squirrel.h"
 #include "../../dataobj/ribi.h"

--- a/script/api/export_desc.h
+++ b/script/api/export_desc.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _EXPORT_DESC_H__
-#define _EXPORT_DESC_H__
+#ifndef SCRIPT_API_EXPORT_DESC_H
+#define SCRIPT_API_EXPORT_DESC_H
+
 
 #include "../../squirrel/squirrel.h"
 

--- a/script/api/get_next.h
+++ b/script/api/get_next.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _GET_NEXT_H_
-#define _GET_NEXT_H_
+#ifndef SCRIPT_API_GET_NEXT_H
+#define SCRIPT_API_GET_NEXT_H
+
 
 #include "../../simtypes.h"
 #include "../../squirrel/squirrel.h"

--- a/script/api_class.h
+++ b/script/api_class.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _API_CLASS_H_
-#define _API_CLASS_H_
+#ifndef SCRIPT_API_CLASS_H
+#define SCRIPT_API_CLASS_H
+
 
 #include "api_param.h"
 

--- a/script/api_function.h
+++ b/script/api_function.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _API_FUNCTION_H_
-#define _API_FUNCTION_H_
+#ifndef SCRIPT_API_FUNCTION_H
+#define SCRIPT_API_FUNCTION_H
+
 
 #include "api_param.h"
 #include "../squirrel/squirrel.h"

--- a/script/api_param.h
+++ b/script/api_param.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _API_PARAM_H_
-#define _API_PARAM_H_
+#ifndef SCRIPT_API_PARAM_H
+#define SCRIPT_API_PARAM_H
+
 
 /** @file api_param.h templates for transfer of function call parameters */
 

--- a/script/dynamic_string.h
+++ b/script/dynamic_string.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _DYNAMIC_STRING_H_
-#define _DYNAMIC_STRING_H_
+#ifndef SCRIPT_DYNAMIC_STRING_H
+#define SCRIPT_DYNAMIC_STRING_H
+
 
 /** @file dynamic_string.h strings that can be asynchronously changed by scripts */
 

--- a/script/export_objs.h
+++ b/script/export_objs.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _EXP_GAME_OBJ_H_
-#define _EXP_GAME_OBJ_H_
+#ifndef SCRIPT_EXPORT_OBJS_H
+#define SCRIPT_EXPORT_OBJS_H
+
 
 #include "../squirrel/squirrel.h"
 

--- a/script/script.h
+++ b/script/script.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _SCRIPT_H_
-#define _SCRIPT_H_
+#ifndef SCRIPT_SCRIPT_H
+#define SCRIPT_SCRIPT_H
+
 
 /** @file script.h handles the virtual machine, interface to squirrel */
 

--- a/simcity.h
+++ b/simcity.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simcity_h
-#define simcity_h
+#ifndef SIMCITY_H
+#define SIMCITY_H
+
 
 #include "dataobj/ribi.h"
 

--- a/simcolor.h
+++ b/simcolor.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simcolor_h
-#define simcolor_h
+#ifndef SIMCOLOR_H
+#define SIMCOLOR_H
+
 
 #define LIGHT_COUNT (15)
 

--- a/simconst.h
+++ b/simconst.h
@@ -7,8 +7,9 @@
  * all defines that can change the compiling
  */
 
-#ifndef simconst_h
-#define simconst_h
+#ifndef SIMCONST_H
+#define SIMCONST_H
+
 
 // number of player
 #define MAX_PLAYER_COUNT (16)

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simconvoi_h
-#define simconvoi_h
+#ifndef SIMCONVOI_H
+#define SIMCONVOI_H
+
 
 #include "simtypes.h"
 #include "simunits.h"

--- a/simdebug.h
+++ b/simdebug.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simdebug_h
-#define simdebug_h
+#ifndef SIMDEBUG_H
+#define SIMDEBUG_H
 
 
  // do not check assertions

--- a/simdepot.h
+++ b/simdepot.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _simdepot_h
-#define _simdepot_h
+#ifndef SIMDEPOT_H
+#define SIMDEPOT_H
+
 
 #include "tpl/slist_tpl.h"
 #include "obj/gebaeude.h"

--- a/simevent.h
+++ b/simevent.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simevent_h
-#define simevent_h
+#ifndef SIMEVENT_H
+#define SIMEVENT_H
+
 
 /* Messageverarbeitung */
 

--- a/simfab.h
+++ b/simfab.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simfab_h
-#define simfab_h
+#ifndef SIMFAB_H
+#define SIMFAB_H
+
 
 #include <algorithm>
 

--- a/simhalt.h
+++ b/simhalt.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simhalt_h
-#define simhalt_h
+#ifndef SIMHALT_H
+#define SIMHALT_H
+
 
 #include "convoihandle_t.h"
 #include "linehandle_t.h"

--- a/siminteraction.h
+++ b/siminteraction.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef siminteraction_h
-#define siminteraction_h
+#ifndef SIMINTERACTION_H
+#define SIMINTERACTION_H
+
 
 class karte_ptr_t;
 class viewport_t;

--- a/simintr.h
+++ b/simintr.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simintr_h
-#define simintr_h
+#ifndef SIMINTR_H
+#define SIMINTR_H
+
 
 #include "macros.h"
 

--- a/simline.h
+++ b/simline.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simline_h
-#define simline_h
+#ifndef SIMLINE_H
+#define SIMLINE_H
+
 
 #include "convoihandle_t.h"
 #include "linehandle_t.h"

--- a/simlinemgmt.h
+++ b/simlinemgmt.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simlinemgmt_h
-#define simlinemgmt_h
+#ifndef SIMLINEMGMT_H
+#define SIMLINEMGMT_H
+
 
 #include "linehandle_t.h"
 #include "simtypes.h"

--- a/simloadingscreen.h
+++ b/simloadingscreen.h
@@ -6,6 +6,7 @@
 #ifndef SIMLOADINGSCREEN_H
 #define SIMLOADINGSCREEN_H
 
+
 #include "simtypes.h"
 #include "tpl/slist_tpl.h"
 

--- a/simmain.h
+++ b/simmain.h
@@ -6,6 +6,7 @@
 #ifndef SIMMAIN_H
 #define SIMMAIN_H
 
+
 #ifdef _WIN64
 #define _64BIT
 #endif

--- a/simmem.h
+++ b/simmem.h
@@ -6,6 +6,7 @@
 #ifndef SIMMEM_H
 #define SIMMEM_H
 
+
 #include <stddef.h>
 
 void guarded_free(void* ptr);

--- a/simmenu.h
+++ b/simmenu.h
@@ -5,8 +5,9 @@
 
 /// New configurable OOP tool system
 
-#ifndef simmenu_h
-#define simmenu_h
+#ifndef SIMMENU_H
+#define SIMMENU_H
+
 
 #include <string>
 #include "descriptor/sound_desc.h"

--- a/simmesg.h
+++ b/simmesg.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simmesg_h
-#define simmesg_h
+#ifndef SIMMESG_H
+#define SIMMESG_H
+
 
 #include "simtypes.h"
 #include "gui/gui_theme.h"

--- a/simobj.h
+++ b/simobj.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simobjs_h
-#define simobjs_h
+#ifndef SIMOBJ_H
+#define SIMOBJ_H
+
 
 #define INLINE_OBJ_TYPE
 

--- a/simplan.h
+++ b/simplan.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simplan_h
-#define simplan_h
+#ifndef SIMPLAN_H
+#define SIMPLAN_H
+
 
 #include "halthandle_t.h"
 #include "boden/grund.h"

--- a/simsignalbox.h
+++ b/simsignalbox.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _simsignalbox_h
-#define _simsignalbox_h
+#ifndef SIMSIGNALBOX_H
+#define SIMSIGNALBOX_H
+
 
 #include "obj/gebaeude.h"
 #include "tpl/slist_tpl.h"

--- a/simskin.h
+++ b/simskin.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __SIMSKIN_H
-#define __SIMSKIN_H
+#ifndef SIMSKIN_H
+#define SIMSKIN_H
+
 
 #include "simcolor.h"
 

--- a/simsound.h
+++ b/simsound.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simsound_h
-#define simsound_h
+#ifndef SIMSOUND_H
+#define SIMSOUND_H
+
 
 #include "simtypes.h"
 

--- a/simsys.h
+++ b/simsys.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simsys_h
-#define simsys_h
+#ifndef SIMSYS_H
+#define SIMSYS_H
+
 
 #include <stddef.h>
 #include "simtypes.h"

--- a/simsys_w32_png.h
+++ b/simsys_w32_png.h
@@ -6,6 +6,7 @@
 #ifndef SIMSYS_W32_PNG_H
 #define SIMSYS_W32_PNG_H
 
+
 #ifdef _WIN32
 // Try using GDIplus to save an screenshot.
 bool dr_screenshot_png(char const* filename, int w, int h, int maxwidth, unsigned short* data, int bitdepth);

--- a/simticker.h
+++ b/simticker.h
@@ -6,6 +6,7 @@
 #ifndef SIMTICKER_H
 #define SIMTICKER_H
 
+
 #include "simcolor.h"
 
 // ticker height

--- a/simtool-dialogs.h
+++ b/simtool-dialogs.h
@@ -6,6 +6,7 @@
 #ifndef SIMTOOL_DIALOGS_H
 #define SIMTOOL_DIALOGS_H
 
+
 #include "simmenu.h"
 #include "gui/simwin.h"
 

--- a/simtool.h
+++ b/simtool.h
@@ -6,6 +6,7 @@
 #ifndef SIMTOOL_H
 #define SIMTOOL_H
 
+
 /// New OO tool system
 
 #include "simtypes.h"

--- a/simtypes.h
+++ b/simtypes.h
@@ -6,6 +6,7 @@
 #ifndef SIMTYPES_H
 #define SIMTYPES_H
 
+
 #include <climits>
 #include <stdlib.h>
 

--- a/simunits.h
+++ b/simunits.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simunits_h
-#define simunits_h
+#ifndef SIMUNITS_H
+#define SIMUNITS_H
+
 
 /*
  * This file is designed to contain the unit conversion routines

--- a/simversion.h
+++ b/simversion.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simversion_h
-#define simversion_h
+#ifndef SIMVERSION_H
+#define SIMVERSION_H
+
 
 #ifdef MAKEOBJ
 #ifdef _MSC_VER

--- a/simware.h
+++ b/simware.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simware_h
-#define simware_h
+#ifndef SIMWARE_H
+#define SIMWARE_H
+
 
 #include "halthandle_t.h"
 #include "dataobj/koord.h"

--- a/simworld.h
+++ b/simworld.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simworld_h
-#define simworld_h
+#ifndef SIMWORLD_H
+#define SIMWORLD_H
+
 
 #include "simconst.h"
 #include "simtypes.h"

--- a/sound/sound.h
+++ b/sound/sound.h
@@ -3,8 +3,8 @@
  * (see LICENSE.txt)
  */
 
-#ifndef SOUND_H
-#define SOUND_H
+#ifndef SOUND_SOUND_H
+#define SOUND_SOUND_H
 
 
 /**

--- a/tpl/array2d_tpl.h
+++ b/tpl/array2d_tpl.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef tpl_array2d_tpl_h
-#define tpl_array2d_tpl_h
+#ifndef TPL_ARRAY2D_TPL_H
+#define TPL_ARRAY2D_TPL_H
+
 
 #include <string.h> //for memcpy
 #include "../dataobj/koord.h"

--- a/tpl/array_tpl.h
+++ b/tpl/array_tpl.h
@@ -6,6 +6,7 @@
 #ifndef TPL_ARRAY_TPL_H
 #define TPL_ARRAY_TPL_H
 
+
 #include <typeinfo>
 #include "../simdebug.h"
 #include "../simtypes.h"

--- a/tpl/binary_heap_tpl.h
+++ b/tpl/binary_heap_tpl.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef tpl_binary_heap_tpl_h
-#define tpl_binary_heap_tpl_h
+#ifndef TPL_BINARY_HEAP_TPL_H
+#define TPL_BINARY_HEAP_TPL_H
+
 
 #include "../simmem.h"
 

--- a/tpl/fixed_list_tpl.h
+++ b/tpl/fixed_list_tpl.h
@@ -12,8 +12,9 @@
  * (such as char).
  */
 
-#ifndef TPL_FIXED_LIST_H
-#define TPL_FIXED_LIST_H
+#ifndef TPL_FIXED_LIST_TPL_H
+#define TPL_FIXED_LIST_TPL_H
+
 
 #ifndef ITERATE
 #define ITERATE(collection,enumerator) for(uint32 enumerator = 0; enumerator < (collection).get_count(); enumerator++)

--- a/tpl/hashtable_tpl.h
+++ b/tpl/hashtable_tpl.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef tpl_hashtable_tpl_h
-#define tpl_hashtable_tpl_h
+#ifndef TPL_HASHTABLE_TPL_H
+#define TPL_HASHTABLE_TPL_H
+
 
 #include "slist_tpl.h"
 #include "../macros.h"

--- a/tpl/inthashtable_tpl.h
+++ b/tpl/inthashtable_tpl.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef inthashtable_tpl_h
-#define inthashtable_tpl_h
+#ifndef TPL_INTHASHTABLE_TPL_H
+#define TPL_INTHASHTABLE_TPL_H
+
 
 #include "hashtable_tpl.h"
 

--- a/tpl/koord_pair_hashtable_tpl.h
+++ b/tpl/koord_pair_hashtable_tpl.h
@@ -2,8 +2,9 @@
  * a template class which implements a hashtable with 2d koord keys
  */
 
-#ifndef koord_pair_hashtable_tpl_h
-#define koord_pair_hashtable_tpl_h
+#ifndef TPL_KOORD_PAIR_HASHTABLE_TPL_H
+#define TPL_KOORD_PAIR_HASHTABLE_TPL_H
+
 
 #include "hashtable_tpl.h"
 #include "../dataobj/koord.h"

--- a/tpl/koordhashtable_tpl.h
+++ b/tpl/koordhashtable_tpl.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef koordhashtable_tpl_h
-#define koordhashtable_tpl_h
+#ifndef TPL_KOORDHASHTABLE_TPL_H
+#define TPL_KOORDHASHTABLE_TPL_H
+
 
 #include "hashtable_tpl.h"
 #include "../dataobj/koord.h"

--- a/tpl/list_tpl.h
+++ b/tpl/list_tpl.h
@@ -5,8 +5,9 @@
 
 #pragma once
 
-#ifndef list_tpl_h
-#define list_tpl_h
+#ifndef TPL_LIST_TPL_H
+#define TPL_LIST_TPL_H
+
 
 /* <typeinfo> is needed for typeid... which is only used for debugging */
 #include <typeinfo>

--- a/tpl/minivec_tpl.h
+++ b/tpl/minivec_tpl.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef TPL_MINIVEC_H
-#define TPL_MINIVEC_H
+#ifndef TPL_MINIVEC_TPL_H
+#define TPL_MINIVEC_TPL_H
+
 
 #include "../simdebug.h"
 #include "../simtypes.h"

--- a/tpl/ordered_vector_tpl.h
+++ b/tpl/ordered_vector_tpl.h
@@ -6,6 +6,7 @@
 #ifndef TPL_ORDERED_VECTOR_TPL_H
 #define TPL_ORDERED_VECTOR_TPL_H
 
+
 #ifndef ITERATE
 #define ITERATE(collection,enumerator) for(uint32 enumerator = 0; enumerator < (collection).get_count(); enumerator++)
 #endif

--- a/tpl/piecewise_linear_tpl.h
+++ b/tpl/piecewise_linear_tpl.h
@@ -41,8 +41,10 @@
  * @author neroden (Nathanael Nerode)
  */
 
-#ifndef PIECEWISE_LINEAR_TPL_H
-#define PIECEWISE_LINEAR_TPL_H
+#ifndef TPL_PIECEWISE_LINEAR_TPL_H
+#define TPL_PIECEWISE_LINEAR_TPL_H
+
+
 // Integer types
 #include "../simtypes.h"
 // Data structure is from vector_tpl

--- a/tpl/plainstringhashtable_tpl.h
+++ b/tpl/plainstringhashtable_tpl.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef plainstringhashtable_tpl_h
-#define plainstringhashtable_tpl_h
+#ifndef TPL_PLAINSTRINGHASHTABLE_TPL_H
+#define TPL_PLAINSTRINGHASHTABLE_TPL_H
+
 
 #include "stringhashtable_tpl.h"
 #include "../utils/plainstring.h"

--- a/tpl/ptrhashtable_tpl.h
+++ b/tpl/ptrhashtable_tpl.h
@@ -7,8 +7,9 @@
  * a template class which implements a hashtable with pointer keys
  */
 
-#ifndef ptrhashtable_tpl_h
-#define ptrhashtable_tpl_h
+#ifndef TPL_PTRHASHTABLE_TPL_H
+#define TPL_PTRHASHTABLE_TPL_H
+
 
 #include "hashtable_tpl.h"
 #include <stdint.h> // intptr_t (standard)

--- a/tpl/quickstone_hashtable_tpl.h
+++ b/tpl/quickstone_hashtable_tpl.h
@@ -8,8 +8,9 @@
  * adapted from the pointer hashtable by jamespetts
  */
 
-#ifndef quickstone_hashtable_tpl_h
-#define quickstone_hashtable_tpl_h
+#ifndef TPL_QUICKSTONE_HASHTABLE_TPL_H
+#define TPL_QUICKSTONE_HASHTABLE_TPL_H
+
 
 #include "inthashtable_tpl.h"
 #include "hashtable_tpl.h"

--- a/tpl/quickstone_tpl.h
+++ b/tpl/quickstone_tpl.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef quickstone_tpl_h
-#define quickstone_tpl_h
+#ifndef TPL_QUICKSTONE_TPL_H
+#define TPL_QUICKSTONE_TPL_H
+
 
 #include "../simtypes.h"
 #include "../simdebug.h"

--- a/tpl/slist_tpl.h
+++ b/tpl/slist_tpl.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef tpl_slist_tpl_h
-#define tpl_slist_tpl_h
+#ifndef TPL_SLIST_TPL_H
+#define TPL_SLIST_TPL_H
+
 
 #include <iterator>
 #include <typeinfo>

--- a/tpl/sparse_tpl.h
+++ b/tpl/sparse_tpl.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef tpl_sparse_tpl_h
-#define tpl_sparse_tpl_h
+#ifndef TPL_SPARSE_TPL_H
+#define TPL_SPARSE_TPL_H
+
 
 #include "../dataobj/koord.h"
 #include "../simtypes.h"

--- a/tpl/stringhashtable_tpl.h
+++ b/tpl/stringhashtable_tpl.h
@@ -3,9 +3,9 @@
  * (see LICENSE.txt)
  */
 
+#ifndef TPL_STRINGHASHTABLE_TPL_H
+#define TPL_STRINGHASHTABLE_TPL_H
 
-#ifndef stringhashtable_tpl_h
-#define stringhashtable_tpl_h
 
 #include "hashtable_tpl.h"
 #include <string.h>

--- a/tpl/vector_tpl.h
+++ b/tpl/vector_tpl.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef TPL_VECTOR_H
-#define TPL_VECTOR_H
+#ifndef TPL_VECTOR_TPL_H
+#define TPL_VECTOR_TPL_H
+
 
 #ifndef ITERATE
 #define ITERATE(collection,enumerator) for(uint32 enumerator = 0; enumerator < (collection).get_count(); enumerator++)

--- a/tpl/weighted_vector_tpl.h
+++ b/tpl/weighted_vector_tpl.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef TPL_WEIGHTED_VECTOR_H
-#define TPL_WEIGHTED_VECTOR_H
+#ifndef TPL_WEIGHTED_VECTOR_TPL_H
+#define TPL_WEIGHTED_VECTOR_TPL_H
+
 
 #ifndef ITERATE
 #define ITERATE(collection,enumerator) for(uint32 enumerator = 0; enumerator < collection.get_count(); enumerator++)

--- a/unicode.h
+++ b/unicode.h
@@ -6,6 +6,7 @@
 #ifndef UNICODE_H
 #define UNICODE_H
 
+
 #include <stddef.h>
 #include "simtypes.h"
 

--- a/utils/cbuffer_t.h
+++ b/utils/cbuffer_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef cbuffer_t_h
-#define cbuffer_t_h
+#ifndef UTILS_CBUFFER_T_H
+#define UTILS_CBUFFER_T_H
+
 
 #include <stdarg.h>
 #include <stdlib.h>

--- a/utils/csv.h
+++ b/utils/csv.h
@@ -55,9 +55,9 @@ field1 data,"field2, data"
 
  */
 
+#ifndef UTILS_CSV_H
+#define UTILS_CSV_H
 
-#ifndef CSV_H
-#define CSV_H
 
 #include "cbuffer_t.h"
 

--- a/utils/dr_rdpng.h
+++ b/utils/dr_rdpng.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef DR_RDPNG_H
-#define DR_RDPNG_H
+#ifndef UTILS_DR_RDPNG_H
+#define UTILS_DR_RDPNG_H
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/utils/fetchopt.h
+++ b/utils/fetchopt.h
@@ -73,8 +73,9 @@ while ((ch = fetchopt.next()) != -1) {
 
 */
 
-#ifndef FETCHOPT_H
-#define FETCHOPT_H
+#ifndef UTILS_FETCHOPT_H
+#define UTILS_FETCHOPT_H
+
 
 class Fetchopt_t {
 	const char *optstr; // Options definition string

--- a/utils/float32e8_t.h
+++ b/utils/float32e8_t.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef FLOAT32E8_T_H_
-#define FLOAT32E8_T_H_
+#ifndef UTILS_FLOAT32E8_T_H
+#define UTILS_FLOAT32E8_T_H
+
 
 #include <iostream>
 using namespace std;

--- a/utils/for.h
+++ b/utils/for.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef FOR_H
-#define FOR_H
+#ifndef UTILS_FOR_H
+#define UTILS_FOR_H
+
 
 #include <iterator>
 

--- a/utils/log.h
+++ b/utils/log.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef tests_log_h
-#define tests_log_h
+#ifndef UTILS_LOG_H
+#define UTILS_LOG_H
+
 
 #include <stdarg.h>
 #include <stdio.h>

--- a/utils/plainstring.h
+++ b/utils/plainstring.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef PLAINSTRING_H
-#define PLAINSTRING_H
+#ifndef UTILS_PLAINSTRING_H
+#define UTILS_PLAINSTRING_H
+
 
 #include <cstring>
 

--- a/utils/searchfolder.h
+++ b/utils/searchfolder.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef __SEARCHFOLDER_H
-#define __SEARCHFOLDER_H
+#ifndef UTILS_SEARCHFOLDER_H
+#define UTILS_SEARCHFOLDER_H
+
 
 #include <string>
 #include "../tpl/vector_tpl.h"

--- a/utils/sha1.h
+++ b/utils/sha1.h
@@ -21,8 +21,9 @@
  *
  */
 
-#ifndef _SHA1_H_
-#define _SHA1_H_
+#ifndef UTILS_SHA1_H
+#define UTILS_SHA1_H
+
 
 #include "../simtypes.h"
 

--- a/utils/simrandom.h
+++ b/utils/simrandom.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef SIMRANDOM_H
-#define SIMRANDOM_H
+#ifndef UTILS_SIMRANDOM_H
+#define UTILS_SIMRANDOM_H
+
 
 #include <stddef.h>
 #include "../simtypes.h"

--- a/utils/simstring.h
+++ b/utils/simstring.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _simstring_h
-#define _simstring_h
+#ifndef UTILS_SIMSTRING_H
+#define UTILS_SIMSTRING_H
+
 
 #include <stddef.h>
 #include <string>

--- a/utils/simthread.h
+++ b/utils/simthread.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simthread_h
-#define simthread_h
+#ifndef UTILS_SIMTHREAD_H
+#define UTILS_SIMTHREAD_H
+
 
 #ifdef MULTI_THREAD
 

--- a/utils/snprintf.h
+++ b/utils/snprintf.h
@@ -62,8 +62,9 @@ Example:
                                |                                | efree(buffer);
 */
 
-#ifndef SNPRINTF_H
-#define SNPRINTF_H
+#ifndef UTILS_SNPRINTF_H
+#define UTILS_SNPRINTF_H
+
 
 BEGIN_EXTERN_C()
 PHPAPI int ap_php_snprintf(char *, size_t, const char *, ...) PHP_ATTRIBUTE_FORMAT(printf, 3, 4);

--- a/vehicle/movingobj.h
+++ b/vehicle/movingobj.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef vehicle_movingobj_h
-#define vehicle_movingobj_h
+#ifndef VEHICLE_MOVINGOBJ_H
+#define VEHICLE_MOVINGOBJ_H
+
 
 #include "../tpl/stringhashtable_tpl.h"
 #include "../tpl/vector_tpl.h"

--- a/vehicle/overtaker.h
+++ b/vehicle/overtaker.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _overtaker_h
-#define _overtaker_h
+#ifndef VEHICLE_OVERTAKER_H
+#define VEHICLE_OVERTAKER_H
+
 
 /**
  * All vehicles that can overtake must include this class

--- a/vehicle/simpeople.h
+++ b/vehicle/simpeople.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef simpeople_h
-#define simpeople_h
+#ifndef VEHICLE_SIMPEOPLE_H
+#define VEHICLE_SIMPEOPLE_H
+
 
 #include "simroadtraffic.h"
 

--- a/vehicle/simroadtraffic.h
+++ b/vehicle/simroadtraffic.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef SIMROADTRAFFIC_H
-#define SIMROADTRAFFIC_H
+#ifndef VEHICLE_SIMROADTRAFFIC_H
+#define VEHICLE_SIMROADTRAFFIC_H
+
 
 /**
  * Moving objects for Simutrans.

--- a/vehicle/simvehicle.h
+++ b/vehicle/simvehicle.h
@@ -3,8 +3,9 @@
  * (see LICENSE.txt)
  */
 
-#ifndef _simvehicle_h
-#define _simvehicle_h
+#ifndef VEHICLE_SIMVEHICLE_H
+#define VEHICLE_SIMVEHICLE_H
+
 
 #include <limits>
 #include <string>


### PR DESCRIPTION
Port of my patch from standard. To reproduce:
```bash
find . -type f -name "*.h" | grep -v "squirrel/" | grep -v "/openttd/" | grep -v "bzlib.h" | while read f; do guard="$(echo $f | cut -b 3- | tr '[[:lower:]]' '[[:upper:]]' | tr -C '[[:alnum:]]' '_' | rev | cut -c2- | rev)"; perl -i -p0e "s/(\n){2,}#ifndef ([^\n]*)\n#define \2(\n)+/\n\n#ifndef $guard\n#define $guard\n\n\n/" $f; done
```