### PR TITLE
Add missing override keywords

### DIFF
--- a/gui/ai_option_t.h
+++ b/gui/ai_option_t.h
@@ -39,7 +39,7 @@ public:
 	 * @return the filename for the helptext, or NULL
 	 * @author Hj. Malthaner
 	 */
-	const char * get_help_filename() const {return "players.txt";}
+	const char * get_help_filename() const OVERRIDE {return "players.txt";}
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 };

--- a/gui/banner.h
+++ b/gui/banner.h
@@ -35,9 +35,9 @@ private:
 public:
 	banner_t();
 
-	bool has_sticky() const { return false; }
+	bool has_sticky() const OVERRIDE { return false; }
 
-	virtual bool has_title() const { return false; }
+	virtual bool has_title() const OVERRIDE { return false; }
 
 	/**
 	* Window Title
@@ -50,7 +50,7 @@ public:
 	* -borders and -body background
 	* @author Hj. Malthaner
 	*/
-	PLAYER_COLOR_VAL get_titlecolor() const {return WIN_TITLE; }
+	PLAYER_COLOR_VAL get_titlecolor() const OVERRIDE {return WIN_TITLE; }
 
 	bool is_hit(int, int) OVERRIDE { return true; }
 
@@ -62,7 +62,7 @@ public:
 	* component is displayed.
 	* @author Hj. Malthaner
 	*/
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 };

--- a/gui/city_info.h
+++ b/gui/city_info.h
@@ -63,17 +63,17 @@ public:
 
 	virtual ~city_info_t();
 
-	const char *get_help_filename() const {return "citywindow.txt";}
+	const char *get_help_filename() const OVERRIDE {return "citywindow.txt";}
 
-	virtual koord3d get_weltpos(bool);
+	virtual koord3d get_weltpos(bool) OVERRIDE;
 
-	virtual bool is_weltpos();
+	virtual bool is_weltpos() OVERRIDE;
 
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 
-	void map_rotate90( sint16 );
+	void map_rotate90( sint16 ) OVERRIDE;
 
 	// since we need to update the city pointer when topped
 	bool infowin_event(event_t const*) OVERRIDE;
@@ -85,19 +85,19 @@ public:
 	 * @return true if such a button is needed
 	 * @author Hj. Malthaner
 	 */
-	virtual bool has_min_sizer() const {return true;}
+	virtual bool has_min_sizer() const OVERRIDE {return true;}
 
 	/**
 	 * resize window in response to a resize event
 	 */
-	void resize(const scr_coord delta);
+	void resize(const scr_coord delta) OVERRIDE;
 
 	// this constructor is only used during loading
 	city_info_t();
 
-	void rdwr(loadsave_t *);
+	void rdwr(loadsave_t *) OVERRIDE;
 
-	uint32 get_rdwr_id() { return magic_city_info_t; }
+	uint32 get_rdwr_id() OVERRIDE { return magic_city_info_t; }
 };
 
 #endif

--- a/gui/citybuilding_edit.h
+++ b/gui/citybuilding_edit.h
@@ -38,9 +38,9 @@ private:
 	button_t bt_left_rotate, bt_right_rotate;
 	gui_label_t lb_rotation, lb_rotation_info;
 
-	void fill_list( bool translate );
+	void fill_list( bool translate ) OVERRIDE;
 
-	virtual void change_item_info( sint32 i );
+	virtual void change_item_info( sint32 i ) OVERRIDE;
 
 public:
 	citybuilding_edit_frame_t(player_t* player);
@@ -57,7 +57,7 @@ public:
 	* @return the filename for the helptext, or NULL
 	* @author Hj. Malthaner
 	*/
-	const char* get_help_filename() const { return "citybuilding_build.txt"; }
+	const char* get_help_filename() const OVERRIDE { return "citybuilding_build.txt"; }
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 };

--- a/gui/citylist_frame_t.h
+++ b/gui/citylist_frame_t.h
@@ -67,20 +67,20 @@ class citylist_frame_t : public gui_frame_t, private action_listener_t
      * component is displayed.
      * @author Hj. Malthaner
      */
-    void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
     /**
      * resize window in response to a resize event
      * @author Hj. Malthaner
      */
-    void resize(const scr_coord delta);
+	void resize(const scr_coord delta) OVERRIDE;
 
     /**
      * Set the window associated helptext
      * @return the filename for the helptext, or NULL
      * @author V. Meyer
      */
-    const char * get_help_filename() const {return "citylist_filter.txt"; }
+	const char * get_help_filename() const OVERRIDE {return "citylist_filter.txt"; }
 
     static citylist::sort_mode_t get_sortierung() { return sortby; }
     static void set_sortierung(const citylist::sort_mode_t& sm) { sortby = sm; }

--- a/gui/citylist_stats_t.h
+++ b/gui/citylist_stats_t.h
@@ -45,7 +45,7 @@ public:
 	void recalc_size();
 
 	// Draw the component
-	void draw(scr_coord offset);
+	void draw(scr_coord offset) OVERRIDE;
 };
 
 #endif

--- a/gui/climates.h
+++ b/gui/climates.h
@@ -74,10 +74,10 @@ public:
 	 * @return the filename for the helptext, or NULL
 	 * @author Hj. Malthaner
 	 */
-	const char * get_help_filename() const {return "climates.txt";}
+	const char * get_help_filename() const OVERRIDE {return "climates.txt";}
 
 	// does not work during new world dialog
-	virtual bool has_sticky() const { return false; }
+	virtual bool has_sticky() const OVERRIDE { return false; }
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 

--- a/gui/components/gui_button.h
+++ b/gui/components/gui_button.h
@@ -143,7 +143,7 @@ public:
 	 * Draw the component
 	 * @author Hj. Malthaner
 	 */
-	void draw(scr_coord offset);
+	void draw(scr_coord offset) OVERRIDE;
 
 	void enable(bool true_false_par = true) { b_enabled = true_false_par; }
 
@@ -152,7 +152,7 @@ public:
 	bool enabled() { return b_enabled; }
 
 	// Knightly : a button can only be focusable when it is enabled
-	virtual bool is_focusable() { return b_enabled && gui_component_t::is_focusable(); }
+	virtual bool is_focusable() OVERRIDE { return b_enabled && gui_component_t::is_focusable(); }
 
 	void update_focusability();
 

--- a/gui/components/gui_chart.h
+++ b/gui/components/gui_chart.h
@@ -34,7 +34,7 @@ public:
 	 * paint chart
 	 * @author hsiegeln
 	 */
-	void draw(scr_coord offset);
+	void draw(scr_coord offset) OVERRIDE;
 
 	bool infowin_event(event_t const*) OVERRIDE;
 

--- a/gui/components/gui_combobox.h
+++ b/gui/components/gui_combobox.h
@@ -76,7 +76,7 @@ public:
 	 * Draw the component
 	 * @author Hj. Malthaner
 	 */
-	void draw(scr_coord offset);
+	void draw(scr_coord offset) OVERRIDE;
 
 	/**
 	 * add element to droplist
@@ -136,7 +136,7 @@ public:
 	* Set this component's position.
 	* @author Hj. Malthaner
 	*/
-	virtual void set_pos(scr_coord pos_par);
+	virtual void set_pos(scr_coord pos_par) OVERRIDE;
 
 	void set_size(scr_size size) OVERRIDE;
 

--- a/gui/components/gui_container.h
+++ b/gui/components/gui_container.h
@@ -63,7 +63,7 @@ public:
 	* Draw the component
 	* @author Hj. Malthaner
 	*/
-	virtual void draw(scr_coord offset);
+	virtual void draw(scr_coord offset) OVERRIDE;
 
 	/**
 	* Removes all Components in the Container.
@@ -75,7 +75,7 @@ public:
 	 * Returns true if any child component is focusable
 	 * @author Knightly
 	 */
-	virtual bool is_focusable();
+	virtual bool is_focusable() OVERRIDE;
 
 	/**
 	 * Activates this element.
@@ -90,14 +90,14 @@ public:
 	 * returns element that has the focus
 	 * that is: go down the hierarchy as much as possible
 	 */
-	virtual gui_component_t *get_focus();
+	virtual gui_component_t *get_focus() OVERRIDE;
 
 	/**
 	 * Get the relative position of the focused component.
 	 * Used for auto-scrolling inside a scroll pane.
 	 * @author Knightly
 	 */
-	virtual scr_coord get_focus_pos() { return comp_focus ? pos+comp_focus->get_focus_pos() : scr_coord::invalid; }
+	virtual scr_coord get_focus_pos() OVERRIDE { return comp_focus ? pos+comp_focus->get_focus_pos() : scr_coord::invalid; }
 };
 
 #endif

--- a/gui/components/gui_convoiinfo.h
+++ b/gui/components/gui_convoiinfo.h
@@ -43,7 +43,7 @@ public:
 	* Draw the component
 	* @author Hj. Malthaner
 	*/
-	void draw(scr_coord offset);
+	void draw(scr_coord offset) OVERRIDE;
 };
 
 #endif

--- a/gui/components/gui_fixedwidth_textarea.h
+++ b/gui/components/gui_fixedwidth_textarea.h
@@ -40,14 +40,14 @@ public:
 	void recalc_size();
 
 	// after using any of these setter functions, remember to call recalc_size() to recalculate textarea height
-	void set_width(const sint16 width);
+	void set_width(const sint16 width) OVERRIDE;
 
 	void set_reserved_area(const scr_size area);
 
 	// it will deliberately ignore the y-component (height) of the size
 	void set_size(scr_size size) OVERRIDE;
 
-	virtual void draw(scr_coord offset);
+	virtual void draw(scr_coord offset) OVERRIDE;
 };
 
 #endif

--- a/gui/components/gui_flowtext.h
+++ b/gui/components/gui_flowtext.h
@@ -41,7 +41,7 @@ public:
 	 * Paints the component
 	 * @author Hj. Malthaner
 	 */
-	void draw(scr_coord offset);
+	void draw(scr_coord offset) OVERRIDE;
 
 	bool infowin_event(event_t const*) OVERRIDE;
 

--- a/gui/components/gui_image.h
+++ b/gui/components/gui_image.h
@@ -34,7 +34,7 @@ class gui_image_t : public gui_component_t
 		 * Draw the component
 		 * @author Hj. Malthaner
 		 */
-		void draw( scr_coord offset );
+		void draw( scr_coord offset ) OVERRIDE;
 };
 
 #endif

--- a/gui/components/gui_image_list.h
+++ b/gui/components/gui_image_list.h
@@ -113,7 +113,7 @@ public:
 	 * Draw/record the picture
 	 * @author Hj. Malthaner
 	 */
-	virtual void draw(scr_coord offset);
+	virtual void draw(scr_coord offset) OVERRIDE;
 
 	/**
 	 * Looks for the image at given position.

--- a/gui/components/gui_numberinput.h
+++ b/gui/components/gui_numberinput.h
@@ -101,14 +101,14 @@ public:
 	 * Draw the component
 	 * @author Dwachs
 	 */
-	void draw(scr_coord offset);
+	void draw(scr_coord offset) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 
 	void enable() { b_enabled = true; set_focusable(true); bt_left.enable(); bt_right.enable(); }
 	void disable() { b_enabled = false; set_focusable(false); bt_left.disable(); bt_right.disable(); }
 	bool enabled() const { return b_enabled; }
-	virtual bool is_focusable() { return b_enabled && gui_component_t::is_focusable(); }
+	virtual bool is_focusable() OVERRIDE { return b_enabled && gui_component_t::is_focusable(); }
 };
 
 #endif

--- a/gui/components/gui_obj_view_t.h
+++ b/gui/components/gui_obj_view_t.h
@@ -20,7 +20,7 @@ private:
 	obj_t const *obj; /**< The object to display */
 
 protected:
-	koord3d get_location();
+	koord3d get_location() OVERRIDE;
 
 public:
 	obj_view_t(scr_size const size) :
@@ -32,7 +32,7 @@ public:
 
 	void set_obj( obj_t const *d ) { obj = d; }
 
-	void draw(scr_coord offset) { internal_draw(offset, obj); }
+	void draw(scr_coord offset) OVERRIDE { internal_draw(offset, obj); }
 
 	/**
 	 * resize window in response to a resize event

--- a/gui/components/gui_scrollbar.h
+++ b/gui/components/gui_scrollbar.h
@@ -94,7 +94,7 @@ public:
 
 	bool infowin_event(event_t const*) OVERRIDE;
 
-	void draw(scr_coord pos);
+	void draw(scr_coord pos) OVERRIDE;
 };
 
 #endif

--- a/gui/components/gui_scrolled_list.h
+++ b/gui/components/gui_scrolled_list.h
@@ -61,13 +61,13 @@ public:
 	public:
 		const_text_scrollitem_t(char const* const t, uint8 const col) : consttext(t), color(col) {}
 
-		virtual scr_coord_val draw( scr_coord pos, scr_coord_val width, bool is_selected, bool has_focus );
-		virtual scr_coord_val get_height() const { return LINESPACE; }
+		virtual scr_coord_val draw( scr_coord pos, scr_coord_val width, bool is_selected, bool has_focus ) OVERRIDE;
+		virtual scr_coord_val get_height() const OVERRIDE { return LINESPACE; }
 
 		virtual uint8 get_color() { return color; }
 		virtual void set_color(uint8 col) { color = col; }
 
-		virtual char const* get_text() const { return consttext; }
+		virtual char const* get_text() const OVERRIDE { return consttext; }
 		virtual void set_text(char const *) {}
 
 		virtual bool sort( vector_tpl<scrollitem_t *>&v, int, void * ) const OVERRIDE;
@@ -81,7 +81,7 @@ public:
 	public:
 		var_text_scrollitem_t(char const* const t, uint8 const col) : const_text_scrollitem_t(t,col), text(t) {}
 		virtual void set_text(char const *t) OVERRIDE { text = t; }
-		virtual bool is_editable() { return true; }
+		virtual bool is_editable() OVERRIDE { return true; }
 	};
 
 private:
@@ -154,7 +154,7 @@ public:
 
 	bool infowin_event(event_t const*) OVERRIDE;
 
-	void draw(scr_coord pos);
+	void draw(scr_coord pos) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 };

--- a/gui/components/gui_scrollpane.h
+++ b/gui/components/gui_scrollpane.h
@@ -54,7 +54,7 @@ public:
 	 */
 	void set_scroll_position(int x, int y);
 
-	scr_rect get_client( void );
+	scr_rect get_client( void ) OVERRIDE;
 
 	int get_scroll_x() const;
 	int get_scroll_y() const;
@@ -71,7 +71,7 @@ public:
 	 * Draw the component
 	 * @author Hj. Malthaner
 	 */
-	void draw(scr_coord offset);
+	void draw(scr_coord offset) OVERRIDE;
 
 	void set_show_scroll_x(bool yesno) { b_show_scroll_x = yesno; }
 
@@ -85,19 +85,19 @@ public:
 	 * Returns true if the hosted component is focusable
 	 * @author Knightly
 	 */
-	virtual bool is_focusable() { return comp->is_focusable(); }
+	virtual bool is_focusable() OVERRIDE { return comp->is_focusable(); }
 
 	/**
 	 * returns element that has the focus
 	 */
-	gui_component_t *get_focus() { return comp->get_focus(); }
+	gui_component_t *get_focus() OVERRIDE { return comp->get_focus(); }
 
 	/**
 	 * Get the relative position of the focused component.
 	 * Used for auto-scrolling inside a scroll pane.
 	 * @author Knightly
 	 */
-	virtual scr_coord get_focus_pos() { return pos + ( comp->get_focus_pos() - scr_coord( scroll_x.get_knob_offset(), scroll_y.get_knob_offset() ) ); }
+	virtual scr_coord get_focus_pos() OVERRIDE { return pos + ( comp->get_focus_pos() - scr_coord( scroll_x.get_knob_offset(), scroll_y.get_knob_offset() ) ); }
 };
 
 #endif

--- a/gui/components/gui_tab_panel.h
+++ b/gui/components/gui_tab_panel.h
@@ -75,7 +75,7 @@ public:
 	 * Draw tabs
 	 * @author Hj. Malthaner
 	 */
-	void draw(scr_coord offset);
+	void draw(scr_coord offset) OVERRIDE;
 
 	/**
 	 * Resizing must be propagated!
@@ -104,16 +104,16 @@ public:
 	 * Returns true if the hosted component of the active tab is focusable
 	 * @author Knightly
 	 */
-	virtual bool is_focusable() { return get_aktives_tab()->is_focusable(); }
+	virtual bool is_focusable() OVERRIDE { return get_aktives_tab()->is_focusable(); }
 
-	gui_component_t *get_focus() { return get_aktives_tab()->get_focus(); }
+	gui_component_t *get_focus() OVERRIDE { return get_aktives_tab()->get_focus(); }
 
 	/**
 	 * Get the relative position of the focused component.
 	 * Used for auto-scrolling inside a scroll pane.
 	 * @author Knightly
 	 */
-	virtual scr_coord get_focus_pos() { return pos + get_aktives_tab()->get_focus_pos(); }
+	virtual scr_coord get_focus_pos() OVERRIDE { return pos + get_aktives_tab()->get_focus_pos(); }
 };
 
 #endif

--- a/gui/components/gui_textinput.h
+++ b/gui/components/gui_textinput.h
@@ -127,7 +127,7 @@ public:
 	 * Draw the component
 	 * @author Hj. Malthaner
 	 */
-	virtual void draw(scr_coord offset);
+	virtual void draw(scr_coord offset) OVERRIDE;
 
 	// x position of the current cursor (for IME purposes)
 	scr_coord_val get_current_cursor_x() { return calc_cursor_pos(head_cursor_pos); };
@@ -156,7 +156,7 @@ class gui_hidden_textinput_t : public gui_textinput_t
 	bool infowin_event(event_t const*) OVERRIDE;
 
 	// function that performs the actual display; just draw with stars ...
-	virtual void display_with_cursor(scr_coord offset, bool cursor_active, bool cursor_visible);
+	virtual void display_with_cursor(scr_coord offset, bool cursor_active, bool cursor_visible) OVERRIDE;
 };
 
 

--- a/gui/convoi_detail_t.h
+++ b/gui/convoi_detail_t.h
@@ -148,20 +148,20 @@ public:
 	 * component is displayed.
 	 * @author Hj. Malthaner
 	 */
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	/**
 	 * Set the window associated helptext
 	 * @return the filename for the helptext, or NULL
 	 * @author V. Meyer
 	 */
-	const char * get_help_filename() const {return "convoidetail.txt"; }
+	const char * get_help_filename() const OVERRIDE {return "convoidetail.txt"; }
 
 	/**
 	 * Set window size and adjust component sizes and/or positions accordingly
 	 * @author Hj. Malthaner
 	 */
-	virtual void set_windowsize(scr_size size);
+	virtual void set_windowsize(scr_size size) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 
@@ -173,9 +173,9 @@ public:
 	// this constructor is only used during loading
 	convoi_detail_t();
 
-	void rdwr( loadsave_t *file );
+	void rdwr( loadsave_t *file ) OVERRIDE;
 
-	uint32 get_rdwr_id() { return magic_convoi_detail; }
+	uint32 get_rdwr_id() OVERRIDE { return magic_convoi_detail; }
 };
 
 #endif

--- a/gui/convoi_filter_frame.h
+++ b/gui/convoi_filter_frame.h
@@ -129,19 +129,19 @@ public:
 	 * Does this window need a min size button in the title bar?
 	 * @return true if such a button is needed
 	 */
-	bool has_min_sizer() const {return true;}
+	bool has_min_sizer() const OVERRIDE {return true;}
 
 	/**
 	 * resize window in response to a resize event
 	 */
-	void resize(const scr_coord delta);
+	void resize(const scr_coord delta) OVERRIDE;
 
 	/**
 	 * Set the window associated helptext
 	 * @return the filename for the helptext, or NULL
 	 * @author V. Meyer
 	 */
-	const char *get_help_filename() const {return "convoi_filter.txt"; }
+	const char *get_help_filename() const OVERRIDE {return "convoi_filter.txt"; }
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 };

--- a/gui/convoi_frame.h
+++ b/gui/convoi_frame.h
@@ -98,13 +98,13 @@ public:
 	 * gemeldet
 	 * @author V. Meyer
 	 */
-	bool infowin_event(const event_t *ev);
+	bool infowin_event(const event_t *ev) OVERRIDE;
 
 	/**
 	 * This method is called if the size of the window should be changed
 	 * @author Markus Weber
 	 */
-	void resize(const scr_coord size_change);                       // 28-Dec-01        Markus Weber Added
+	void resize(const scr_coord size_change) OVERRIDE;                       // 28-Dec-01        Markus Weber Added
 
 	/**
 	 * Draw new component. The values to be passed refer to the window
@@ -112,14 +112,14 @@ public:
 	 * component is displayed.
 	 * @author Hj. Malthaner
 	 */
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	/**
 	 * Set the window associated helptext
 	 * @return the filename for the helptext, or NULL
 	 * @author V. Meyer
 	 */
-	const char * get_help_filename() const {return "convoi.txt"; }
+	const char * get_help_filename() const OVERRIDE {return "convoi.txt"; }
 
 	static sort_mode_t get_sortierung() { return sortby; }
 	static void set_sortierung(sort_mode_t sm) { sortby = sm; }

--- a/gui/convoi_info_t.h
+++ b/gui/convoi_info_t.h
@@ -134,7 +134,7 @@ public:
 	 * @return the filename for the helptext, or NULL
 	 * @author V. Meyer
 	 */
-	const char * get_help_filename() const { return "convoiinfo.txt"; }
+	const char * get_help_filename() const OVERRIDE { return "convoiinfo.txt"; }
 
 	/**
 	 * Draw new component. The values to be passed refer to the window
@@ -142,17 +142,17 @@ public:
 	 * component is displayed.
 	 * @author Hj. Malthaner
 	 */
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	/**
 	 * Set window size and adjust component sizes and/or positions accordingly
 	 * @author Hj. Malthaner
 	 */
-	virtual void set_windowsize(scr_size size);
+	virtual void set_windowsize(scr_size size) OVERRIDE;
 
-	virtual bool is_weltpos();
+	virtual bool is_weltpos() OVERRIDE;
 
-	virtual koord3d get_weltpos( bool set );
+	virtual koord3d get_weltpos( bool set ) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 
@@ -164,9 +164,9 @@ public:
 	// this constructor is only used during loading
 	convoi_info_t();
 
-	void rdwr( loadsave_t *file );
+	void rdwr( loadsave_t *file ) OVERRIDE;
 
-	uint32 get_rdwr_id() { return magic_convoi_info; }
+	uint32 get_rdwr_id() OVERRIDE { return magic_convoi_info; }
 };
 
 #endif

--- a/gui/convoy_item.h
+++ b/gui/convoy_item.h
@@ -24,7 +24,7 @@ public:
 	void set_color(COLOR_VAL) OVERRIDE { assert(false); }
 	char const* get_text() const OVERRIDE;
 	void set_text(char const*) OVERRIDE;
-	bool is_editable() { return true; }
+	bool is_editable() OVERRIDE { return true; }
 	bool is_valid() OVERRIDE { return cnv.is_bound(); }	//  can be used to indicate invalid entries
 };
 

--- a/gui/curiosity_edit.h
+++ b/gui/curiosity_edit.h
@@ -38,9 +38,9 @@ private:
 	button_t bt_left_rotate, bt_right_rotate;
 	gui_label_t lb_rotation, lb_rotation_info;
 
-	void fill_list( bool translate );
+	void fill_list( bool translate ) OVERRIDE;
 
-	virtual void change_item_info( sint32 i );
+	virtual void change_item_info( sint32 i ) OVERRIDE;
 
 public:
 	curiosity_edit_frame_t(player_t* player);
@@ -57,7 +57,7 @@ public:
 	* @return the filename for the helptext, or NULL
 	* @author Hj. Malthaner
 	*/
-	const char* get_help_filename() const { return "curiosity_build.txt"; }
+	const char* get_help_filename() const OVERRIDE { return "curiosity_build.txt"; }
 
 	/**
 	* Draw new component. The values to be passed refer to the window
@@ -65,7 +65,7 @@ public:
 	* component is displayed.
 	* @author Hj. Malthaner
 	*/
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 };

--- a/gui/curiositylist_frame_t.h
+++ b/gui/curiositylist_frame_t.h
@@ -46,14 +46,14 @@ class curiositylist_frame_t : public gui_frame_t, private action_listener_t
 	 * resize window in response to a resize event
 	 * @author Hj. Malthaner
 	 */
-	void resize(const scr_coord delta);
+	void resize(const scr_coord delta) OVERRIDE;
 
 	/**
 	 * Set the window associated helptext
 	 * @return the filename for the helptext, or NULL
 	 * @author V. Meyer
 	 */
-	const char * get_help_filename() const {return "curiositylist_filter.txt"; }
+	const char * get_help_filename() const OVERRIDE {return "curiositylist_filter.txt"; }
 
 	 /**
 	 * This function refreshes the station-list

--- a/gui/curiositylist_stats_t.h
+++ b/gui/curiositylist_stats_t.h
@@ -48,7 +48,7 @@ public:
 	* Draw the component
 	* @author Hj. Malthaner
 	*/
-	void draw(scr_coord offset);
+	void draw(scr_coord offset) OVERRIDE;
 };
 
 #endif

--- a/gui/depot_frame.h
+++ b/gui/depot_frame.h
@@ -118,7 +118,7 @@ private:
 	 * @return true if such a button is needed
 	 * @author Hj. Malthaner
 	 */
-	bool has_min_sizer() const {return true;}
+	bool has_min_sizer() const OVERRIDE {return true;}
 
 	// true if already stored here
 	bool is_contained(const vehicle_desc_t *info);
@@ -159,7 +159,7 @@ public:
 	 * @author (Mathew Hounsell)
 	 * @date   11-Mar-2003
 	 */
-	void set_windowsize(scr_size size);
+	void set_windowsize(scr_size size) OVERRIDE;
 
 	/**
 	 * Create and fill loks_vec and waggons_vec.
@@ -180,17 +180,17 @@ public:
 	 * @return the filename for the helptext, or NULL
 	 * @author Hj. Malthaner
 	 */
-	const char * get_help_filename() const {return "depot.txt";}
+	const char * get_help_filename() const OVERRIDE {return "depot.txt";}
 
 	/**
 	 * Does this window need a next button in the title bar?
 	 * @return true if such a button is needed
 	 * @author Volker Meyer
 	 */
-	bool has_next() const {return true;}
+	bool has_next() const OVERRIDE {return true;}
 
-	virtual koord3d get_weltpos(bool);
-	virtual bool is_weltpos();
+	virtual koord3d get_weltpos(bool) OVERRIDE;
+	virtual bool is_weltpos() OVERRIDE;
 
 	/**
 	 * Open dialog for schedule entry.
@@ -204,7 +204,7 @@ public:
 	 * Draw the Frame
 	 * @author Hansjörg Malthaner
 	 */
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	// @author hsiegeln
 	void apply_line();

--- a/gui/display_settings.h
+++ b/gui/display_settings.h
@@ -73,13 +73,13 @@ public:
 	 * @return The help file name or NULL
 	 * @author Hj. Malthaner
 	 */
-	const char * get_help_filename() const { return "display.txt"; }
+	const char * get_help_filename() const OVERRIDE { return "display.txt"; }
 
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 
-	virtual void set_windowsize(scr_size size);
+	virtual void set_windowsize(scr_size size) OVERRIDE;
 };
 
 #endif

--- a/gui/enlarge_map_frame_t.h
+++ b/gui/enlarge_map_frame_t.h
@@ -85,7 +85,7 @@ public:
 	 * @return the filename for the helptext, or NULL
 	 * @author Hj. Malthaner
 	 */
-	const char * get_help_filename() const { return "enlarge_map.txt";}
+	const char * get_help_filename() const OVERRIDE { return "enlarge_map.txt";}
 
 	/**
 	 * Draw new component. The values to be passed refer to the window
@@ -93,7 +93,7 @@ public:
 	 * component is displayed.
 	 * @author Hj. Malthaner
 	 */
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 };
 
 #endif

--- a/gui/extend_edit.h
+++ b/gui/extend_edit.h
@@ -39,8 +39,6 @@ class player_t;
  * @author Niels Roest
  * @author hsiegeln: major redesign
  */
-
-
 class extend_edit_gui_t :
 	public gui_frame_t,
 	public action_listener_t
@@ -71,7 +69,7 @@ protected:
 
 	bool is_show_trans_name;
 
-	void resize(const scr_coord delta);
+	void resize(const scr_coord delta) OVERRIDE;
 
 	virtual void fill_list( bool /* translate */ ) {}
 
@@ -85,7 +83,7 @@ public:
 	* @return true if such a button is needed
 	* @author Hj. Malthaner
 	*/
-	bool has_min_sizer() const {return true;}
+	bool has_min_sizer() const OVERRIDE {return true;}
 
 	bool infowin_event(event_t const*) OVERRIDE;
 

--- a/gui/fabrik_info.h
+++ b/gui/fabrik_info.h
@@ -90,15 +90,15 @@ public:
 	 * @return the filename for the helptext, or NULL
 	 * @author Hj. Malthaner
 	 */
-	const char *get_help_filename() const {return "industry_info.txt";}
+	const char *get_help_filename() const OVERRIDE {return "industry_info.txt";}
 
-	virtual bool has_min_sizer() const {return true;}
+	virtual bool has_min_sizer() const OVERRIDE {return true;}
 
-	virtual koord3d get_weltpos(bool) { return fab->get_pos(); }
+	virtual koord3d get_weltpos(bool) OVERRIDE { return fab->get_pos(); }
 
-	virtual bool is_weltpos();
+	virtual bool is_weltpos() OVERRIDE;
 
-	virtual void set_windowsize(scr_size size);
+	virtual void set_windowsize(scr_size size) OVERRIDE;
 
 	/**
 	* Draw new component. The values to be passed refer to the window
@@ -106,19 +106,19 @@ public:
 	* component is displayed.
 	* @author Hj. Malthaner
 	*/
-	virtual void draw(scr_coord pos, scr_size size);
+	virtual void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 
 	// rotated map need new info ...
-	void map_rotate90( sint16 ) { update_info(); }
+	void map_rotate90( sint16 ) OVERRIDE { update_info(); }
 
 	// this constructor is only used during loading
 	fabrik_info_t();
 
-	void rdwr( loadsave_t *file );
+	void rdwr( loadsave_t *file ) OVERRIDE;
 
-	uint32 get_rdwr_id() { return magic_factory_info; }
+	uint32 get_rdwr_id() OVERRIDE { return magic_factory_info; }
 };
 
 #endif

--- a/gui/factory_chart.h
+++ b/gui/factory_chart.h
@@ -53,7 +53,7 @@ public:
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 
-	virtual void draw(scr_coord pos);
+	virtual void draw(scr_coord pos) OVERRIDE;
 
 	void rdwr( loadsave_t *file );
 };

--- a/gui/factory_edit.h
+++ b/gui/factory_edit.h
@@ -46,9 +46,9 @@ private:
 	gui_numberinput_t inp_production;
 	gui_label_t lb_production_info;
 
-	void fill_list( bool translate );
+	void fill_list( bool translate ) OVERRIDE;
 
-	virtual void change_item_info( sint32 i );
+	virtual void change_item_info( sint32 i ) OVERRIDE;
 
 public:
 	factory_edit_frame_t(player_t* player);
@@ -65,7 +65,7 @@ public:
 	* @return the filename for the helptext, or NULL
 	* @author Hj. Malthaner
 	*/
-	const char* get_help_filename() const { return "factory_build.txt"; }
+	const char* get_help_filename() const OVERRIDE { return "factory_build.txt"; }
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 };

--- a/gui/factorylist_frame_t.h
+++ b/gui/factorylist_frame_t.h
@@ -45,14 +45,14 @@ public:
 	 * resize window in response to a resize event
 	 * @author Hj. Malthaner
 	 */
-	void resize(const scr_coord delta);
+	void resize(const scr_coord delta) OVERRIDE;
 
 	/**
 	 * Set the window associated helptext
 	 * @return the filename for the helptext, or NULL
 	 * @author V. Meyer
 	 */
-	const char * get_help_filename() const {return "factorylist_filter.txt"; }
+	const char * get_help_filename() const OVERRIDE {return "factorylist_filter.txt"; }
 
 	static factorylist::sort_mode_t get_sortierung() { return sortby; }
 	static void set_sortierung(const factorylist::sort_mode_t& sm) { sortby = sm; }

--- a/gui/factorylist_stats_t.h
+++ b/gui/factorylist_stats_t.h
@@ -48,7 +48,7 @@ public:
 	* Draw the component
 	* @author Hj. Malthaner
 	*/
-	void draw(scr_coord offset);
+	void draw(scr_coord offset) OVERRIDE;
 };
 
 #endif

--- a/gui/goods_frame_t.h
+++ b/gui/goods_frame_t.h
@@ -94,16 +94,16 @@ public:
 	* @author Hj. Malthaner
 	* @date   16-Oct-2003
 	*/
-	void resize(const scr_coord delta);
+	void resize(const scr_coord delta) OVERRIDE;
 
-	bool has_min_sizer() const {return true;}
+	bool has_min_sizer() const OVERRIDE {return true;}
 
 	/**
 	 * Set the window associated helptext
 	 * @return the filename for the helptext, or NULL
 	 * @author V. Meyer
 	 */
-	const char * get_help_filename() const {return "goods_filter.txt"; }
+	const char * get_help_filename() const OVERRIDE {return "goods_filter.txt"; }
 
 	/**
 	 * Draw new component. The values to be passed refer to the window
@@ -111,7 +111,7 @@ public:
 	 * component is displayed.
 	 * @author Hj. Malthaner
 	 */
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 };

--- a/gui/halt_detail.h
+++ b/gui/halt_detail.h
@@ -59,22 +59,22 @@ public:
 	 * @return the filename for the helptext, or NULL
 	 * @author Hj. Malthaner
 	 */
-	const char * get_help_filename() const { return "station_details.txt"; }
+	const char * get_help_filename() const OVERRIDE { return "station_details.txt"; }
 
 	// Set window size and adjust component sizes and/or positions accordingly
-	virtual void set_windowsize(scr_size size);
+	virtual void set_windowsize(scr_size size) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 
 	// only defined to update schedule, if changed
-	void draw( scr_coord pos, scr_size size );
+	void draw( scr_coord pos, scr_size size ) OVERRIDE;
 
 	// this constructor is only used during loading
 	halt_detail_t();
 
-	void rdwr( loadsave_t *file );
+	void rdwr( loadsave_t *file ) OVERRIDE;
 
-	uint32 get_rdwr_id() { return magic_halt_detail; }
+	uint32 get_rdwr_id() OVERRIDE { return magic_halt_detail; }
 };
 
 #endif

--- a/gui/halt_info.h
+++ b/gui/halt_info.h
@@ -93,7 +93,7 @@ public:
 	 * @return the filename for the helptext, or NULL
 	 * @author Hj. Malthaner
 	 */
-	const char * get_help_filename() const {return "station.txt";}
+	const char * get_help_filename() const OVERRIDE {return "station.txt";}
 
 	/**
 	 * Draw new component. The values to be passed refer to the window
@@ -101,28 +101,28 @@ public:
 	 * component is displayed.
 	 * @author Hj. Malthaner
 	 */
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	/**
 	 * Set window size and adjust component sizes and/or positions accordingly
 	 * @author Hj. Malthaner
 	 */
-	virtual void set_windowsize(scr_size size);
+	virtual void set_windowsize(scr_size size) OVERRIDE;
 
-	virtual koord3d get_weltpos(bool);
+	virtual koord3d get_weltpos(bool) OVERRIDE;
 
-	virtual bool is_weltpos();
+	virtual bool is_weltpos() OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 
-	void map_rotate90( sint16 );
+	void map_rotate90( sint16 ) OVERRIDE;
 
 	// this constructor is only used during loading
 	halt_info_t();
 
-	void rdwr( loadsave_t *file );
+	void rdwr( loadsave_t *file ) OVERRIDE;
 
-	uint32 get_rdwr_id() { return magic_halt_info; }
+	uint32 get_rdwr_id() OVERRIDE { return magic_halt_info; }
 };
 
 #endif

--- a/gui/halt_list_filter_frame.h
+++ b/gui/halt_list_filter_frame.h
@@ -48,7 +48,7 @@ private:
 			}
 			return button_t::infowin_event(ev);
 		}
-		virtual void draw(scr_coord offset) {
+		virtual void draw(scr_coord offset) OVERRIDE {
 			if(ware_ab) {
 				pressed = parent->get_ware_filter_ab(ware_ab);
 			}
@@ -118,7 +118,7 @@ public:
 	 * Does this window need a min size button in the title bar?
 	 * @return true if such a button is needed
 	 */
-	bool has_min_sizer() const {return true;}
+	bool has_min_sizer() const OVERRIDE {return true;}
 
 	/**
 	 * Draw new component. The values to be passed refer to the window
@@ -126,19 +126,19 @@ public:
 	 * component is displayed.
 	 * @author V. Meyer
 	 */
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
     /**
      * resize window in response to a resize event
      */
-	void resize(const scr_coord delta);
+	void resize(const scr_coord delta) OVERRIDE;
 
 	/**
 	 * Set the window associated helptext
 	 * @return the filename for the helptext, or NULL
 	 * @author V. Meyer
 	 */
-	const char * get_help_filename() const {return "haltlist_filter.txt"; }
+	const char * get_help_filename() const OVERRIDE {return "haltlist_filter.txt"; }
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 };

--- a/gui/halt_list_frame.h
+++ b/gui/halt_list_frame.h
@@ -106,7 +106,7 @@ public:
 	 * This method is called if the size of the window should be changed
 	 * @author Markus Weber
 	 */
-	void resize(const scr_coord size_change);
+	void resize(const scr_coord size_change) OVERRIDE;
 
 	/**
 	 * Draw new component. The values to be passed refer to the window
@@ -114,7 +114,7 @@ public:
 	 * component is displayed.
 	 * @author Hj. Malthaner
 	 */
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	/**
 	 * This function refreshes the station-list
@@ -127,7 +127,7 @@ public:
 	 * @return the filename for the helptext, or NULL
 	 * @author V. Meyer
 	 */
-	const char *get_help_filename() const {return "haltlist.txt"; }
+	const char *get_help_filename() const OVERRIDE {return "haltlist.txt"; }
 
 	static sort_mode_t get_sortierung() { return sortby; }
 	static void set_sortierung(sort_mode_t sm) { sortby = sm; }

--- a/gui/halt_list_stats.h
+++ b/gui/halt_list_stats.h
@@ -26,7 +26,7 @@ public:
 
 	bool infowin_event(event_t const*) OVERRIDE;
 
-	void draw(scr_coord offset);
+	void draw(scr_coord offset) OVERRIDE;
 };
 
 #endif

--- a/gui/help_frame.h
+++ b/gui/help_frame.h
@@ -52,7 +52,7 @@ public:
 	 * resize window in response to a resize event
 	 * @author Hj. Malthaner
 	 */
-	void resize(const scr_coord delta);
+	void resize(const scr_coord delta) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 };

--- a/gui/jump_frame.h
+++ b/gui/jump_frame.h
@@ -30,7 +30,7 @@ public:
 	* @return the filename for the helptext, or NULL
 	* @author Hj. Malthaner
 	*/
-	const char * get_help_filename() const { return "jump_frame.txt"; }
+	const char * get_help_filename() const OVERRIDE { return "jump_frame.txt"; }
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 };

--- a/gui/karte.h
+++ b/gui/karte.h
@@ -252,7 +252,7 @@ public:
 
 	bool infowin_event(event_t const*) OVERRIDE;
 
-	void draw(scr_coord pos);
+	void draw(scr_coord pos) OVERRIDE;
 
 	void set_current_cnv( convoihandle_t c );
 

--- a/gui/kennfarbe.h
+++ b/gui/kennfarbe.h
@@ -40,7 +40,7 @@ class farbengui_t : public gui_frame_t, action_listener_t
 		 * @return the filename for the helptext, or NULL
 		 * @author Hj. Malthaner
 		 */
-		const char * get_help_filename() const { return "color.txt"; }
+		const char * get_help_filename() const OVERRIDE { return "color.txt"; }
 
 		bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 };

--- a/gui/label_info.h
+++ b/gui/label_info.h
@@ -38,7 +38,7 @@ public:
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 
 	// rotated map need new info ...
-	void map_rotate90( sint16 );
+	void map_rotate90( sint16 ) OVERRIDE;
 };
 
 #endif

--- a/gui/labellist_frame_t.h
+++ b/gui/labellist_frame_t.h
@@ -45,14 +45,14 @@ class labellist_frame_t : public gui_frame_t, private action_listener_t
      * resize window in response to a resize event
      * @author Hj. Malthaner
      */
-    void resize(const scr_coord delta);
+	void resize(const scr_coord delta) OVERRIDE;
 
     /**
      * Set the window associated helptext
      * @return the filename for the helptext, or NULL
      * @author V. Meyer
      */
-    const char * get_help_filename() const {return "labellist_filter.txt"; }
+	const char * get_help_filename() const OVERRIDE {return "labellist_filter.txt"; }
 
      /**
      * This function refreshes the station-list
@@ -69,7 +69,7 @@ class labellist_frame_t : public gui_frame_t, private action_listener_t
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 
 	// rotated map need new info ...
-	void map_rotate90( sint16 ) { display_list(); }
+	void map_rotate90( sint16 ) OVERRIDE { display_list(); }
 };
 
 #endif

--- a/gui/labellist_stats_t.h
+++ b/gui/labellist_stats_t.h
@@ -46,7 +46,7 @@ public:
 	* Draw the component
 	* @author Hj. Malthaner
 	*/
-	void draw(scr_coord offset);
+	void draw(scr_coord offset) OVERRIDE;
 };
 
 #endif

--- a/gui/line_class_manager.h
+++ b/gui/line_class_manager.h
@@ -105,20 +105,20 @@ public:
 	 * component is displayed.
 	 * @author Hj. Malthaner
 	 */
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	/**
 	 * Set the window associated helptext
 	 * @return the filename for the helptext, or NULL
 	 * @author V. Meyer
 	 */
-	const char * get_help_filename() const {return "line_class_manager.txt"; }
+	const char * get_help_filename() const OVERRIDE {return "line_class_manager.txt"; }
 
 	/**
 	 * Set window size and adjust component sizes and/or positions accordingly
 	 * @author Hj. Malthaner
 	 */
-	virtual void set_windowsize(scr_size size);
+	virtual void set_windowsize(scr_size size) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 
@@ -130,9 +130,9 @@ public:
 	// this constructor is only used during loading
 	line_class_manager_t();
 
-	void rdwr( loadsave_t *file );
+	void rdwr( loadsave_t *file ) OVERRIDE;
 
-	uint32 get_rdwr_id() { return magic_line_class_manager; }
+	uint32 get_rdwr_id() OVERRIDE { return magic_line_class_manager; }
 
 	~line_class_manager_t();
 };

--- a/gui/line_item.h
+++ b/gui/line_item.h
@@ -31,7 +31,7 @@ public:
 	char const* get_text() const OVERRIDE;
 	void set_text(char const*) OVERRIDE;
 	bool is_valid() OVERRIDE { return line.is_bound(); }	//  can be used to indicate invalid entries
-	bool is_editable() { return true; }
+	bool is_editable() OVERRIDE { return true; }
 };
 
 #endif

--- a/gui/line_management_gui.h
+++ b/gui/line_management_gui.h
@@ -25,8 +25,8 @@ public:
 
 	// stuff for UI saving
 	line_management_gui_t();
-	virtual void rdwr( loadsave_t *file );
-	virtual uint32 get_rdwr_id() { return magic_line_schedule_rdwr_dummy; }
+	virtual void rdwr( loadsave_t *file ) OVERRIDE;
+	virtual uint32 get_rdwr_id() OVERRIDE { return magic_line_schedule_rdwr_dummy; }
 
 
 private:

--- a/gui/map_frame.h
+++ b/gui/map_frame.h
@@ -116,14 +116,14 @@ public:
 	 * @return the filename for the helptext, or NULL
 	 * @author Hj. Malthaner
 	 */
-	const char * get_help_filename() const {return "map.txt";}
+	const char * get_help_filename() const OVERRIDE {return "map.txt";}
 
 	/**
 	 * Does this window need a min size button in the title bar?
 	 * @return true if such a button is needed
 	 * @author Hj. Malthaner
 	 */
-	bool has_min_sizer() const {return true;}
+	bool has_min_sizer() const OVERRIDE {return true;}
 
 	/**
 	 * Constructor. Adds all necessary Subcomponents.
@@ -131,9 +131,9 @@ public:
 	 */
 	map_frame_t();
 
-	void rdwr( loadsave_t *file );
+	void rdwr( loadsave_t *file ) OVERRIDE;
 
-	virtual uint32 get_rdwr_id() { return magic_reliefmap; }
+	virtual uint32 get_rdwr_id() OVERRIDE { return magic_reliefmap; }
 
 	bool infowin_event(event_t const*) OVERRIDE;
 
@@ -142,14 +142,14 @@ public:
 	 * @author (Mathew Hounsell)
 	 * @date   11-Mar-2003
 	 */
-	void set_windowsize(scr_size size);
+	void set_windowsize(scr_size size) OVERRIDE;
 
 	/**
 	 * resize window in response to a resize event
 	 * @author Hj. Malthaner
 	 * @date   01-Jun-2002
 	 */
-	void resize(const scr_coord delta=scr_coord(0,0));
+	void resize(const scr_coord delta=scr_coord(0,0)) OVERRIDE;
 
 	/**
 	 * Draw new component. The values to be passed refer to the window
@@ -157,7 +157,7 @@ public:
 	 * component is displayed.
 	 * @author Hj. Malthaner
 	 */
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 };

--- a/gui/message_frame_t.h
+++ b/gui/message_frame_t.h
@@ -43,19 +43,19 @@ public:
 	 * @return the filename for the helptext, or NULL
 	 * @author Hj. Malthaner
 	 */
-	const char * get_help_filename() const {return "mailbox.txt";}
+	const char * get_help_filename() const OVERRIDE {return "mailbox.txt";}
 
 	/**
 	* resize window in response to a resize event
 	* @author Hj. Malthaner
 	*/
-	void resize(const scr_coord delta);
+	void resize(const scr_coord delta) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 
-	void rdwr(loadsave_t *);
+	void rdwr(loadsave_t *) OVERRIDE;
 
-	uint32 get_rdwr_id() { return magic_messageframe; }
+	uint32 get_rdwr_id() OVERRIDE { return magic_messageframe; }
 };
 
 #endif

--- a/gui/message_option_t.h
+++ b/gui/message_option_t.h
@@ -36,11 +36,11 @@ public:
 	 * @return the filename for the helptext, or NULL
 	 * @author Hj. Malthaner
 	 */
-	const char * get_help_filename() const {return "mailbox.txt";}
+	const char * get_help_filename() const OVERRIDE {return "mailbox.txt";}
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 
-	uint32 get_rdwr_id() { return magic_message_options; }
+	uint32 get_rdwr_id() OVERRIDE { return magic_message_options; }
 };
 
 #endif

--- a/gui/message_stats_t.h
+++ b/gui/message_stats_t.h
@@ -49,7 +49,7 @@ public:
 	 * Draw the component
 	 * @author Hj. Malthaner
 	 */
-	void draw(scr_coord offset);
+	void draw(scr_coord offset) OVERRIDE;
 };
 
 #endif

--- a/gui/money_frame.h
+++ b/gui/money_frame.h
@@ -128,7 +128,7 @@ public:
 	 * @return the filename for the helptext, or NULL
 	 * @author Hj. Malthaner
 	 */
-	const char * get_help_filename() const {return "finances.txt";}
+	const char * get_help_filename() const OVERRIDE {return "finances.txt";}
 
 	/**
 	 * Constructor. Adds all necessary Subcomponents.
@@ -142,14 +142,14 @@ public:
 	 * component is displayed.
 	 * @author Hj. Malthaner
 	 */
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 
 	// saving/restore stuff
-	uint32 get_rdwr_id();
+	uint32 get_rdwr_id() OVERRIDE;
 
-	void rdwr( loadsave_t *file );
+	void rdwr( loadsave_t *file ) OVERRIDE;
 };
 
 #endif

--- a/gui/onewaysign_info.h
+++ b/gui/onewaysign_info.h
@@ -33,7 +33,7 @@ class onewaysign_info_t : public obj_infowin_t, public action_listener_t
 		 * @return the filename for the helptext, or NULL
 		 * @author Hj. Malthaner
 		 */
-		const char *get_help_filename() const {return "onewaysign_info.txt";}
+		const char *get_help_filename() const OVERRIDE {return "onewaysign_info.txt";}
 
 		bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 

--- a/gui/optionen.h
+++ b/gui/optionen.h
@@ -31,12 +31,12 @@ class optionen_gui_t : public gui_frame_t, action_listener_t
 	public:
 		optionen_gui_t();
 
-		 /**
+		/**
 		 * Set the window associated helptext
 		 * @return the filename for the helptext, or NULL
 		 * @author Hj. Malthaner
 		 */
-		const char * get_help_filename() const {return "options.txt";}
+		const char * get_help_filename() const OVERRIDE {return "options.txt";}
 
 		bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 };

--- a/gui/overtaking_mode.h
+++ b/gui/overtaking_mode.h
@@ -39,7 +39,7 @@ public:
 	overtaking_mode_frame_t( player_t *, tool_build_bridge_t * );
 	overtaking_mode_frame_t( player_t *, tool_build_tunnel_t * );
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
-	const char * get_help_filename() const { return "overtaking_mode_frame.txt"; }
+	const char * get_help_filename() const OVERRIDE { return "overtaking_mode_frame.txt"; }
 };
 
 #endif

--- a/gui/pakselector.h
+++ b/gui/pakselector.h
@@ -19,28 +19,28 @@ private:
 	gui_file_table_delete_column_t addon_column;
 
 protected:
-	virtual bool item_action(const char *fullpath);
-	virtual bool del_action(const char *fullpath);
-	virtual const char *get_info(const char *fname);
+	virtual bool item_action(const char *fullpath) OVERRIDE;
+	virtual bool del_action(const char *fullpath) OVERRIDE;
+	virtual const char *get_info(const char *fname) OVERRIDE;
 
 	// true, if valid
-	virtual bool check_file( const char *filename, const char *suffix );
+	virtual bool check_file( const char *filename, const char *suffix ) OVERRIDE;
 
-	virtual void init(const char *suffix, const char *path);
-	virtual void add_file(const char *fullpath, const char *filename, const bool not_cutting_suffix);
+	virtual void init(const char *suffix, const char *path) OVERRIDE;
+	virtual void add_file(const char *fullpath, const char *filename, const bool not_cutting_suffix) OVERRIDE;
 
 public:
-	void fill_list();	// do the search ...
-	virtual bool has_title() const { return false; }
+	void fill_list() OVERRIDE;	// do the search ...
+	virtual bool has_title() const OVERRIDE { return false; }
 	bool has_pak() const { return use_table ? file_table.get_size().h > 0 : !entries.empty(); }
 
 	// If there is only one option, this will set the pak name and return true.
 	// Otherwise it will return false.  (Note, it's const but it modifies global data.)
 	bool check_only_one_option() const;
-	const char * get_help_filename() const { return ""; }
+	const char * get_help_filename() const OVERRIDE { return ""; }
 	// since we only want to see the frames ...
-	void draw(scr_coord pos, scr_size gr);
-	void set_windowsize(scr_size size);
+	void draw(scr_coord pos, scr_size gr) OVERRIDE;
+	void set_windowsize(scr_size size) OVERRIDE;
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 	pakselector_t();
 };

--- a/gui/password_frame.h
+++ b/gui/password_frame.h
@@ -29,7 +29,7 @@ protected:
 public:
 	password_frame_t( player_t *player );
 
-	const char * get_help_filename() const {return "password.txt";}
+	const char * get_help_filename() const OVERRIDE {return "password.txt";}
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 };

--- a/gui/player_frame_t.h
+++ b/gui/player_frame_t.h
@@ -54,7 +54,7 @@ public:
 	 * @return the filename for the helptext, or NULL
 	 * @author Hj. Malthaner
 	 */
-	const char * get_help_filename() const {return "players.txt";}
+	const char * get_help_filename() const OVERRIDE {return "players.txt";}
 
 	/**
 	 * Draw new component. The values to be passed refer to the window
@@ -62,7 +62,7 @@ public:
 	 * component is displayed.
 	 * @author Hj. Malthaner
 	 */
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 
@@ -75,7 +75,7 @@ public:
 	void update_data();
 
 	// since no information are needed to be saved to restore this, returning magic is enough
-	virtual uint32 get_rdwr_id() { return magic_ki_kontroll_t; }
+	virtual uint32 get_rdwr_id() OVERRIDE { return magic_ki_kontroll_t; }
 };
 
 #endif

--- a/gui/privatesign_info.h
+++ b/gui/privatesign_info.h
@@ -33,7 +33,7 @@ class privatesign_info_t : public obj_infowin_t, public action_listener_t
 	 * @return the filename for the helptext, or NULL
 	 * @author Hj. Malthaner
 	 */
-	const char *get_help_filename() const {return "privatesign_info.txt";}
+	const char *get_help_filename() const OVERRIDE {return "privatesign_info.txt";}
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 

--- a/gui/schedule_gui.h
+++ b/gui/schedule_gui.h
@@ -143,19 +143,19 @@ public:
 
 	bool infowin_event(event_t const*) OVERRIDE;
 
-	const char *get_help_filename() const {return "schedule.txt";}
+	const char *get_help_filename() const OVERRIDE {return "schedule.txt";}
 
 	/**
 	 * Draw the Frame
 	 * @author Hansjörg Malthaner
 	 */
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	/**
 	 * Set window size and adjust component sizes and/or positions accordingly
 	 * @author Hj. Malthaner
 	 */
-	virtual void set_windowsize(scr_size size);
+	virtual void set_windowsize(scr_size size) OVERRIDE;
 
 	/**
 	 * show or hide the line selector combobox and its associated label
@@ -171,14 +171,14 @@ public:
 	/**
 	 * Map rotated, rotate schedules too
 	 */
-	void map_rotate90( sint16 );
+	void map_rotate90( sint16 ) OVERRIDE;
 
 	// this constructor is only used during loading
 	schedule_gui_t();
 
-	virtual void rdwr( loadsave_t *file );
+	virtual void rdwr( loadsave_t *file ) OVERRIDE;
 
-	uint32 get_rdwr_id() { return magic_schedule_rdwr_dummy; }
+	uint32 get_rdwr_id() OVERRIDE { return magic_schedule_rdwr_dummy; }
 };
 
 #endif

--- a/gui/schedule_list.h
+++ b/gui/schedule_list.h
@@ -98,14 +98,14 @@ public:
 	* @return the filename for the helptext, or NULL
 	* @author Hj. Malthaner
 	*/
-	const char* get_help_filename() const { return "linemanagement.txt"; }
+	const char* get_help_filename() const OVERRIDE { return "linemanagement.txt"; }
 
 	/**
 	* Does this window need a min size button in the title bar?
 	* @return true if such a button is needed
 	* @author Hj. Malthaner
 	*/
-	bool has_min_sizer() const {return true;}
+	bool has_min_sizer() const OVERRIDE {return true;}
 
 	/**
 	* Draw new component. The values to be passed refer to the window
@@ -113,13 +113,13 @@ public:
 	* component is displayed.
 	* @author Hj. Malthaner
 	*/
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	/**
 	* Set window size and adjust component sizes and/or positions accordingly
 	* @author Hj. Malthaner
 	*/
-	virtual void set_windowsize(scr_size size);
+	virtual void set_windowsize(scr_size size) OVERRIDE;
 
 	bool infowin_event(event_t const*) OVERRIDE;
 
@@ -137,8 +137,8 @@ public:
 	void update_data(linehandle_t changed_line);
 
 	// following: rdwr stuff
-	void rdwr( loadsave_t *file );
-	uint32 get_rdwr_id();
+	void rdwr( loadsave_t *file ) OVERRIDE;
+	uint32 get_rdwr_id() OVERRIDE;
 };
 
 #endif

--- a/gui/schiene_info.h
+++ b/gui/schiene_info.h
@@ -40,11 +40,11 @@ protected:
 	 * @return the filename for the helptext, or NULL
 	 * @author Hj. Malthaner
 	 */
-	const char *get_help_filename() const { return "track_info.txt"; }
+	const char *get_help_filename() const OVERRIDE { return "track_info.txt"; }
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 
-	virtual void draw(scr_coord pos, scr_size size);
+	virtual void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	// called, after external change
 	//void update_data();

--- a/gui/server_frame.h
+++ b/gui/server_frame.h
@@ -83,14 +83,14 @@ private:
 public:
 	server_frame_t();
 
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	/**
 	 * Return name of file which contains associated help text for this window
 	 * @return Help file name, nor NULL if no help file exists
 	 * @author Hj. Malthaner
 	 */
-	const char *get_help_filename() const {return "server.txt";}
+	const char *get_help_filename() const OVERRIDE {return "server.txt";}
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 

--- a/gui/settings_frame.h
+++ b/gui/settings_frame.h
@@ -57,18 +57,18 @@ public:
 	 * @return the filename for the helptext, or NULL
 	 * @author Hj. Malthaner
 	 */
-	const char *get_help_filename() const {return "settings.txt";}
+	const char *get_help_filename() const OVERRIDE {return "settings.txt";}
 
 	/**
 	* resize window in response to a resize event
 	* @author Hj. Malthaner
 	*/
-	void resize(const scr_coord delta);
+	void resize(const scr_coord delta) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 
 	// does not work during new world dialogue
-	virtual bool has_sticky() const { return false; }
+	virtual bool has_sticky() const OVERRIDE { return false; }
 
 	bool infowin_event(event_t const*) OVERRIDE;
 };

--- a/gui/signal_info.h
+++ b/gui/signal_info.h
@@ -34,7 +34,7 @@ class signal_info_t : public obj_infowin_t, public action_listener_t
 	 * @return the filename for the helptext, or NULL
 	 * @author Hj. Malthaner
 	 */
-	const char *get_help_filename() const { return "signals_overview.txt"; }
+	const char *get_help_filename() const OVERRIDE { return "signals_overview.txt"; }
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 

--- a/gui/signal_spacing.h
+++ b/gui/signal_spacing.h
@@ -37,7 +37,7 @@ private:
 public:
 	signal_spacing_frame_t( player_t *, tool_build_roadsign_t * );
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
-	const char * get_help_filename() const { return "signal_spacing.txt"; }
+	const char * get_help_filename() const OVERRIDE { return "signal_spacing.txt"; }
 };
 
 #endif

--- a/gui/sound_frame.h
+++ b/gui/sound_frame.h
@@ -46,7 +46,7 @@ public:
 	 * @return the filename for the helptext, or NULL
      * @author Hj. Malthaner
      */
-    const char * get_help_filename() const {return "sound.txt";}
+	const char * get_help_filename() const OVERRIDE {return "sound.txt";}
 
 
     /**
@@ -61,7 +61,7 @@ public:
 	 * component is displayed.
      * @author Hj. Malthaner
      */
-    void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 };

--- a/gui/sprachen.h
+++ b/gui/sprachen.h
@@ -54,7 +54,7 @@ public:
 	 * @return the filename for the helptext, or NULL
 	 * @author Hj. Malthaner
 	 */
-	const char *get_help_filename() const {return "language.txt";}
+	const char *get_help_filename() const OVERRIDE {return "language.txt";}
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 };

--- a/gui/themeselector.h
+++ b/gui/themeselector.h
@@ -20,20 +20,20 @@ class themeselector_t : public savegame_frame_t
 protected:
 	static std::string undo; // undo buffer
 
-	virtual bool        item_action   ( const char *fullpath );
-	virtual bool        ok_action     ( const char *fullpath );
-	virtual bool        cancel_action ( const char *fullpath );
-	virtual const char* get_info      ( const char *fname    );
-	virtual bool        check_file    ( const char *filename, const char *suffix );
+	virtual bool        item_action   ( const char *fullpath ) OVERRIDE;
+	virtual bool        ok_action     ( const char *fullpath ) OVERRIDE;
+	virtual bool        cancel_action ( const char *fullpath ) OVERRIDE;
+	virtual const char* get_info      ( const char *fname    ) OVERRIDE;
+	virtual bool        check_file    ( const char *filename, const char *suffix ) OVERRIDE;
 
 public:
 	themeselector_t ( void );
 
 	void        fill_list       ( void ) OVERRIDE;
-	const char* get_help_filename ( void ) const { return NULL; }
+	const char* get_help_filename ( void ) const OVERRIDE { return NULL; }
 
-	uint32      get_rdwr_id     ( void ) { return magic_themes; }
-	void        rdwr            ( loadsave_t *file );
+	uint32      get_rdwr_id     ( void ) OVERRIDE { return magic_themes; }
+	void        rdwr            ( loadsave_t *file ) OVERRIDE;
 };
 
 #endif

--- a/gui/times_history.h
+++ b/gui/times_history.h
@@ -51,12 +51,12 @@ public:
 	// const char * get_help_filename() const { return ".txt"; }
 
 	// Set window size and adjust component sizes and/or positions accordingly
-	virtual void set_windowsize(scr_size size);
+	virtual void set_windowsize(scr_size size) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 
 	// only defined to update, if changed
-	void draw( scr_coord pos, scr_size size );
+	void draw( scr_coord pos, scr_size size ) OVERRIDE;
 
 	// this constructor is only used during loading
 	times_history_t();

--- a/gui/times_history_container.h
+++ b/gui/times_history_container.h
@@ -56,7 +56,7 @@ public:
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 
-	void draw(scr_coord offset);
+	void draw(scr_coord offset) OVERRIDE;
 
 	inline void set_schedule(schedule_t *s) { schedule = s; }
 };

--- a/gui/tool_selector.h
+++ b/gui/tool_selector.h
@@ -80,9 +80,9 @@ public:
 	 * @return the filename for the helptext, or NULL
 	 * @author Hj. Malthaner
 	 */
-	const char *get_help_filename() const {return help_file;}
+	const char *get_help_filename() const OVERRIDE {return help_file;}
 
-	PLAYER_COLOR_VAL get_titlecolor() const { return WIN_TITLE; }
+	PLAYER_COLOR_VAL get_titlecolor() const OVERRIDE { return WIN_TITLE; }
 
 	bool is_hit(int x, int y) OVERRIDE;
 
@@ -91,7 +91,7 @@ public:
 	 * @return true if such a button is needed
 	 * @author Volker Meyer
 	 */
-	bool has_next() const {return has_prev_next;}
+	bool has_next() const OVERRIDE {return has_prev_next;}
 
 	bool infowin_event(event_t const*) OVERRIDE;
 
@@ -101,10 +101,10 @@ public:
 	 * component is displayed.
 	 * @author Hj. Malthaner
 	 */
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	// since no information are needed to be saved to restore this, returning magic is enough
-	virtual uint32 get_rdwr_id() { return magic_toolbar+toolbar_id; }
+	virtual uint32 get_rdwr_id() OVERRIDE { return magic_toolbar+toolbar_id; }
 
 	bool empty(player_t *player) const;
 };

--- a/gui/trafficlight_info.h
+++ b/gui/trafficlight_info.h
@@ -35,7 +35,7 @@ class trafficlight_info_t : public obj_infowin_t, public action_listener_t
 	 * @return the filename for the helptext, or NULL
 	 * @author Hj. Malthaner
 	 */
-	const char *get_help_filename() const {return "trafficlight_info.txt";}
+	const char *get_help_filename() const OVERRIDE {return "trafficlight_info.txt";}
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 

--- a/gui/vehicle_class_manager.h
+++ b/gui/vehicle_class_manager.h
@@ -150,20 +150,20 @@ public:
 	 * component is displayed.
 	 * @author Hj. Malthaner
 	 */
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	/**
 	 * Set the window associated helptext
 	 * @return the filename for the helptext, or NULL
 	 * @author V. Meyer
 	 */
-	const char * get_help_filename() const {return "vehicle_class_manager.txt"; }
+	const char * get_help_filename() const OVERRIDE {return "vehicle_class_manager.txt"; }
 
 	/**
 	 * Set window size and adjust component sizes and/or positions accordingly
 	 * @author Hj. Malthaner
 	 */
-	virtual void set_windowsize(scr_size size);
+	virtual void set_windowsize(scr_size size) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 
@@ -175,9 +175,9 @@ public:
 	// this constructor is only used during loading
 	vehicle_class_manager_t();
 
-	void rdwr( loadsave_t *file );
+	void rdwr( loadsave_t *file ) OVERRIDE;
 
-	uint32 get_rdwr_id() { return magic_class_manager; }
+	uint32 get_rdwr_id() OVERRIDE { return magic_class_manager; }
 
 	~vehicle_class_manager_t();
 };

--- a/gui/welt.h
+++ b/gui/welt.h
@@ -139,12 +139,12 @@ public:
 		* @return the filename for the helptext, or NULL
 		* @author Hj. Malthaner
 		*/
-	const char * get_help_filename() const {return "new_world.txt";}
+	const char * get_help_filename() const OVERRIDE {return "new_world.txt";}
 
 	settings_t* get_sets() const { return sets; }
 
 	// does not work during new world dialog
-	bool has_sticky() const { return false; }
+	bool has_sticky() const OVERRIDE { return false; }
 
 	bool infowin_event(event_t const*) OVERRIDE;
 
@@ -154,7 +154,7 @@ public:
 		* component is displayed.
 		* @author Hj. Malthaner
 		*/
-	void draw(scr_coord pos, scr_size size);
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 };

--- a/obj/wayobj.h
+++ b/obj/wayobj.h
@@ -50,13 +50,13 @@ public:
 
 	const way_obj_desc_t *get_desc() const {return desc;}
 
-	void rotate90();
+	void rotate90() OVERRIDE;
 
 	/**
 	* the front image, drawn before vehicles
 	* @author V. Meyer
 	*/
-	image_id get_image() const {
+	image_id get_image() const OVERRIDE {
 		return hang ? desc->get_back_slope_image_id(hang) :
 			(diagonal ? desc->get_back_diagonal_image_id(dir) : desc->get_back_image_id(dir));
 	}
@@ -65,7 +65,7 @@ public:
 	* the front image, drawn after everything else
 	* @author V. Meyer
 	*/
-	image_id get_front_image() const {
+	image_id get_front_image() const OVERRIDE {
 		return hang ? desc->get_front_slope_image_id(hang) :
 			diagonal ? desc->get_front_diagonal_image_id(dir) : desc->get_front_image_id(dir);
 	}
@@ -84,9 +84,9 @@ public:
 	/**
 	 * waytype associated with this object
 	 */
-	waytype_t get_waytype() const { return desc ? desc->get_wtyp() : invalid_wt; }
+	waytype_t get_waytype() const OVERRIDE { return desc ? desc->get_wtyp() : invalid_wt; }
 
-	void calc_image();
+	void calc_image() OVERRIDE;
 
 	/**
 	* Speichert den Zustand des Objekts.
@@ -95,10 +95,10 @@ public:
 	* soll.
 	* @author Hj. Malthaner
 	*/
-	void rdwr(loadsave_t *file);
+	void rdwr(loadsave_t *file) OVERRIDE;
 
 	// subtracts cost
-	void cleanup(player_t *player);
+	void cleanup(player_t *player) OVERRIDE;
 
 	const char*  is_deletable(const player_t *player) OVERRIDE;
 	bool clashes_with_halt() {
@@ -109,7 +109,7 @@ public:
 	* calculate image after loading
 	* @author prissi
 	*/
-	void finish_rd();
+	void finish_rd() OVERRIDE;
 
 	// specific for wayobj
 	void set_dir(ribi_t::ribi d) { dir = d; calc_image(); }

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -226,15 +226,15 @@ private:
 	static const sint32 timings_reduction_point = 6;
 	bool re_ordered; // Whether this convoy's vehicles are currently arranged in reverse order.
 protected:
-	virtual void update_vehicle_summary(vehicle_summary_t &vehicle);
-	virtual void update_adverse_summary(adverse_summary_t &adverse);
-	virtual void update_freight_summary(freight_summary_t &freight);
+	virtual void update_vehicle_summary(vehicle_summary_t &vehicle) OVERRIDE;
+	virtual void update_adverse_summary(adverse_summary_t &adverse) OVERRIDE;
+	virtual void update_freight_summary(freight_summary_t &freight) OVERRIDE;
 	virtual void update_weight_summary(weight_summary_t &weight);
-	virtual float32e8_t get_brake_summary(/*const float32e8_t &speed*/ /* in m/s */);
-	virtual float32e8_t get_force_summary(const float32e8_t &speed /* in m/s */);
-	virtual float32e8_t get_power_summary(const float32e8_t &speed /* in m/s */);
+	virtual float32e8_t get_brake_summary(/*const float32e8_t &speed*/ /* in m/s */) OVERRIDE;
+	virtual float32e8_t get_force_summary(const float32e8_t &speed /* in m/s */) OVERRIDE;
+	virtual float32e8_t get_power_summary(const float32e8_t &speed /* in m/s */) OVERRIDE;
 public:
-	virtual sint16 get_current_friction();
+	virtual sint16 get_current_friction() OVERRIDE;
 
 	// weight_summary becomes invalid, when vehicle_summary or envirion_summary
 	// becomes invalid.
@@ -1091,7 +1091,7 @@ public:
 	 * all other stuff => convoi_t::step()
 	 * @author Hj. Malthaner
 	 */
-	sync_result sync_step(uint32 delta_t);
+	sync_result sync_step(uint32 delta_t) OVERRIDE;
 
 	/**
 	 * All things like route search or loading, that may take a little
@@ -1483,7 +1483,7 @@ public:
 	uint32 get_average_kmh();
 
 	// Overtaking for convois
-	virtual bool can_overtake(overtaker_t *other_overtaker, sint32 other_speed, sint16 steps_other);
+	virtual bool can_overtake(overtaker_t *other_overtaker, sint32 other_speed, sint16 steps_other) OVERRIDE;
 
 	/*
 	 * Functions related to requested_change_lane

--- a/simtool-dialogs.h
+++ b/simtool-dialogs.h
@@ -406,7 +406,7 @@ class dialog_edit_tree_t : public tool_t {
 public:
 	dialog_edit_tree_t() : tool_t(DIALOG_EDIT_TREE | DIALOG_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE{ return translator::translate("baum builder"); }
-	image_id get_icon(player_t *) const { return baum_t::get_count() > 0 ? icon : IMG_EMPTY; }
+	image_id get_icon(player_t *) const OVERRIDE { return baum_t::get_count() > 0 ? icon : IMG_EMPTY; }
 	bool is_selected() const OVERRIDE{ return win_get_magic(magic_edit_tree); }
 		bool init(player_t* player) OVERRIDE{
 		if (baum_t::get_count() > 0 && !is_selected()) {
@@ -424,7 +424,7 @@ class dialog_enlarge_map_t : public tool_t{
 public:
 	dialog_enlarge_map_t() : tool_t(DIALOG_ENLARGE_MAP | DIALOG_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE{ return env_t::networkmode ? translator::translate("deactivated in online mode") : translator::translate("enlarge map"); }
-	image_id get_icon(player_t *) const { return env_t::networkmode ? IMG_EMPTY : icon; }
+	image_id get_icon(player_t *) const OVERRIDE { return env_t::networkmode ? IMG_EMPTY : icon; }
 	bool is_selected() const OVERRIDE{ return win_get_magic(magic_bigger_map); }
 		bool init(player_t*) OVERRIDE{
 		if (!env_t::networkmode) {
@@ -456,7 +456,7 @@ class dialog_climates_t : public tool_t {
 public:
 	dialog_climates_t() : tool_t(DIALOG_CLIMATES | DIALOG_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE{ return (!env_t::networkmode || env_t::server) ? translator::translate("Climate Control") : translator::translate("deactivated in online mode"); }
-	image_id get_icon(player_t *) const { return (!env_t::networkmode || env_t::server) ? icon : IMG_EMPTY; }
+	image_id get_icon(player_t *) const OVERRIDE { return (!env_t::networkmode || env_t::server) ? icon : IMG_EMPTY; }
 	bool is_selected() const OVERRIDE{ return win_get_magic(magic_climate); }
 		bool init(player_t*) OVERRIDE{
 		if (!env_t::networkmode || env_t::server) {
@@ -472,7 +472,7 @@ class dialog_settings_t : public tool_t {
 public:
 	dialog_settings_t() : tool_t(DIALOG_SETTINGS | DIALOG_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE{ return (!env_t::networkmode || env_t::server) ? translator::translate("Setting") : translator::translate("deactivated in online mode"); }
-	image_id get_icon(player_t *) const { return (!env_t::networkmode || env_t::server) ? icon : IMG_EMPTY; }
+	image_id get_icon(player_t *) const OVERRIDE { return (!env_t::networkmode || env_t::server) ? icon : IMG_EMPTY; }
 	bool is_selected() const OVERRIDE{ return win_get_magic(magic_settings_frame_t); }
 		bool init(player_t*) OVERRIDE{
 		if (!env_t::networkmode || env_t::server) {

--- a/simtool.h
+++ b/simtool.h
@@ -96,7 +96,7 @@ public:
 	/**
 	 * @return true if this tool operates over the grid, not the map tiles.
 	 */
-	bool is_grid_tool() const {return true;}
+	bool is_grid_tool() const OVERRIDE {return true;}
 
 	bool update_pos_after_use() const OVERRIDE { return true; }
 };
@@ -232,9 +232,9 @@ private:
 class tool_plant_tree_t : public kartenboden_tool_t {
 public:
 	tool_plant_tree_t() : kartenboden_tool_t(TOOL_PLANT_TREE | GENERAL_TOOL) {}
-	image_id get_icon(player_t *) const { return baum_t::get_count() > 0 ? icon : IMG_EMPTY; }
+	image_id get_icon(player_t *) const OVERRIDE { return baum_t::get_count() > 0 ? icon : IMG_EMPTY; }
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate( "Plant tree" ); }
-	bool init(player_t*) { return baum_t::get_count() > 0; }
+	bool init(player_t*) OVERRIDE { return baum_t::get_count() > 0; }
 	char const* move(player_t* const player, uint16 const b, koord3d const k) OVERRIDE;
 	bool move_has_effects() const OVERRIDE { return true; }
 	char const* work(player_t*, koord3d) OVERRIDE;
@@ -455,7 +455,7 @@ public:
 		koord3d signalbox;
 	} signal[MAX_PLAYER_COUNT];
 
-	void rotate90(sint16 y_diff);
+	void rotate90(sint16 y_diff) OVERRIDE;
 
 private:
 	static char toolstring[256];
@@ -508,7 +508,7 @@ private:
 	const char* tool_signalbox_aux(player_t* player, koord3d pos, const building_desc_t* desc, sint64 cost);
 public:
 	tool_signalbox_t() : tool_t(TOOL_BUILD_SIGNALBOX | GENERAL_TOOL) {}
-	const char *check_pos(player_t *, koord3d pos);
+	const char *check_pos(player_t *, koord3d pos) OVERRIDE;
 	image_id get_icon(player_t*) const OVERRIDE;
 	char const* get_tooltip(player_t const*) const OVERRIDE;
 	bool init(player_t*) OVERRIDE;
@@ -599,8 +599,8 @@ public:
 	char const* get_tooltip(player_t const*) const OVERRIDE { return env_t::networkmode ? translator::translate("deactivated in online mode") : translator::translate("Lock game"); }
 	image_id get_icon(player_t*) const OVERRIDE { return env_t::networkmode ? IMG_EMPTY : icon; }
 	// deactivate in network mode
-	bool init(player_t *) { return !env_t::networkmode; }
-	const char *work( player_t *, koord3d );
+	bool init(player_t *) OVERRIDE { return !env_t::networkmode; }
+	const char *work( player_t *, koord3d ) OVERRIDE;
 	bool is_init_network_save() const OVERRIDE { return true; }
 };
 
@@ -617,9 +617,9 @@ public:
 class tool_forest_t : public two_click_tool_t {
 public:
 	tool_forest_t() : two_click_tool_t(TOOL_FOREST | GENERAL_TOOL) {}
-	image_id get_icon(player_t *) const { return baum_t::get_count() > 0 ? icon : IMG_EMPTY; }
+	image_id get_icon(player_t *) const OVERRIDE { return baum_t::get_count() > 0 ? icon : IMG_EMPTY; }
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Add forest"); }
-	bool init( player_t *player) { return  baum_t::get_count() > 0  &&  two_click_tool_t::init(player); }
+	bool init( player_t *player) OVERRIDE { return  baum_t::get_count() > 0  &&  two_click_tool_t::init(player); }
 private:
 	char const* do_work(player_t*, koord3d const&, koord3d const&) OVERRIDE;
 	void mark_tiles(player_t*, koord3d const&, koord3d const&) OVERRIDE;
@@ -670,8 +670,8 @@ private:
 class tool_make_stop_public_t : public tool_t {
 public:
 	tool_make_stop_public_t() : tool_t(TOOL_MAKE_STOP_PUBLIC | GENERAL_TOOL) {}
-	bool init(player_t * );
-	bool exit(player_t *s ) { return init(s); }
+	bool init(player_t * ) OVERRIDE;
+	bool exit(player_t *s ) OVERRIDE { return init(s); }
 	char const* get_tooltip(player_t const*) const OVERRIDE;
 	char const* move(player_t*, uint16 /* buttonstate */, koord3d) OVERRIDE;
 	bool move_has_effects() const OVERRIDE { return true; }
@@ -698,14 +698,14 @@ public:
 	char const* get_tooltip(player_t const*) const OVERRIDE { return env_t::networkmode ? translator::translate("deactivated in online mode") : translator::translate("Pause"); }
 	image_id get_icon(player_t*) const OVERRIDE { return env_t::networkmode ? IMG_EMPTY : icon; }
 	bool is_selected() const OVERRIDE { return welt->is_paused(); }
-	bool init( player_t * ) {
+	bool init( player_t * ) OVERRIDE {
 		if(  !env_t::networkmode  ) {
 			welt->set_fast_forward(0);
 			welt->set_pause( welt->is_paused()^1 );
 		}
 		return false;
 	}
-	bool exit(player_t *s ) { return init(s); }
+	bool exit(player_t *s ) OVERRIDE { return init(s); }
 	bool is_init_network_save() const OVERRIDE { return !env_t::networkmode; }
 	bool is_work_network_save() const OVERRIDE { return !env_t::networkmode; }
 };
@@ -716,7 +716,7 @@ public:
 	char const* get_tooltip(player_t const*) const OVERRIDE { return env_t::networkmode ? translator::translate("deactivated in online mode") : translator::translate("Fast forward"); }
 	image_id get_icon(player_t*) const OVERRIDE { return env_t::networkmode ? IMG_EMPTY : icon; }
 	bool is_selected() const OVERRIDE { return welt->is_fast_forward(); }
-	bool init( player_t * ) {
+	bool init( player_t * ) OVERRIDE {
 		if(  !env_t::networkmode  ) {
 			if(  welt->is_fast_forward()  &&  env_t::simple_drawing_fast_forward  ) {
 				welt->set_dirty();
@@ -726,7 +726,7 @@ public:
 		}
 		return false;
 	}
-	bool exit(player_t *s ) { return init(s); }
+	bool exit(player_t *s ) OVERRIDE { return init(s); }
 	bool is_init_network_save() const OVERRIDE { return !env_t::networkmode; }
 	bool is_work_network_save() const OVERRIDE { return !env_t::networkmode; }
 };
@@ -745,7 +745,7 @@ class tool_increase_industry_t : public tool_t {
 public:
 	tool_increase_industry_t() : tool_t(TOOL_INCREASE_INDUSTRY | SIMPLE_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Increase Industry density"); }
-	bool init( player_t * );
+	bool init( player_t * ) OVERRIDE;
 };
 
 /* prissi: undo building */
@@ -763,7 +763,7 @@ class tool_switch_player_t : public tool_t {
 public:
 	tool_switch_player_t() : tool_t(TOOL_SWITCH_PLAYER | SIMPLE_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Change player"); }
-	bool init( player_t * ) {
+	bool init( player_t * ) OVERRIDE {
 		welt->switch_active_player( welt->get_active_player_nr()+1, true );
 		return false;
 	}
@@ -777,7 +777,7 @@ class tool_step_year_t : public tool_t {
 public:
 	tool_step_year_t() : tool_t(TOOL_STEP_YEAR | SIMPLE_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Step timeline one year"); }
-	bool init( player_t * ) {
+	bool init( player_t * ) OVERRIDE {
 		welt->step_year();
 		return false;
 	}
@@ -790,7 +790,7 @@ public:
 		int factor = atoi(default_param);
 		return factor>0 ? translator::translate("Accelerate time") : translator::translate("Deccelerate time");
 	}
-	bool init( player_t *player ) {
+	bool init( player_t *player ) OVERRIDE {
 		if(  !env_t::networkmode  ||  player->get_player_nr()==1  ) {
 			// in networkmode only for public player
 			welt->change_time_multiplier( atoi(default_param) );
@@ -823,12 +823,12 @@ public:
 	tool_show_coverage_t() : tool_t(TOOL_SHOW_COVERAGE | SIMPLE_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("show station coverage"); }
 	bool is_selected() const OVERRIDE { return env_t::station_coverage_show; }
-	bool init( player_t * ) {
+	bool init( player_t * ) OVERRIDE {
 		env_t::station_coverage_show = !env_t::station_coverage_show;
 		welt->set_dirty();
 		return false;
 	}
-	bool exit(player_t *s ) { return init(s); }
+	bool exit(player_t *s ) OVERRIDE { return init(s); }
 	bool is_init_network_save() const OVERRIDE { return true; }
 	bool is_work_network_save() const OVERRIDE { return true; }
 };
@@ -838,12 +838,12 @@ public:
 	tool_show_signalbox_coverage_t() : tool_t(TOOL_SHOW_SIGNALBOX_COVERAGE | SIMPLE_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("show signalbox coverage"); }
 	bool is_selected() const OVERRIDE { return env_t::signalbox_coverage_show; }
-	bool init(player_t *) {
+	bool init(player_t *) OVERRIDE {
 		env_t::signalbox_coverage_show = !env_t::signalbox_coverage_show;
 		welt->set_dirty();
 		return false;
 	}
-	bool exit(player_t *s) { return init(s); }
+	bool exit(player_t *s) OVERRIDE { return init(s); }
 	bool is_init_network_save() const OVERRIDE { return true; }
 	bool is_work_network_save() const OVERRIDE { return true; }
 };
@@ -851,7 +851,7 @@ public:
 class tool_convoy_nameplate_t : public tool_t {
 public:
 	tool_convoy_nameplate_t() : tool_t(TOOL_CONVOY_NAMEPLATES | SIMPLE_TOOL) {}
-	bool init(player_t *) {
+	bool init(player_t *) OVERRIDE {
 		env_t::show_cnv_nameplates = (env_t::show_cnv_nameplates + 1) % 3;
 		welt->set_dirty();
 		return false;
@@ -868,7 +868,7 @@ public:
 			(env_t::show_names>>2)==2 ? "hide station names" :
 			(env_t::show_names&1) ? "show waiting bars" : "show station names");
 	}
-	bool init( player_t * ) {
+	bool init( player_t * ) OVERRIDE {
 		if(  env_t::show_names>=11  ) {
 			if(  (env_t::show_names&3)==3  ) {
 				env_t::show_names = 0;
@@ -898,12 +898,12 @@ public:
 	tool_show_grid_t() : tool_t(TOOL_SHOW_GRID | SIMPLE_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("show grid"); }
 	bool is_selected() const OVERRIDE { return grund_t::show_grid; }
-	bool init( player_t * ) {
+	bool init( player_t * ) OVERRIDE {
 		grund_t::toggle_grid();
 		welt->set_dirty();
 		return false;
 	}
-	bool exit(player_t *s ) { return init(s); }
+	bool exit(player_t *s ) OVERRIDE { return init(s); }
 	bool is_init_network_save() const OVERRIDE { return true; }
 	bool is_work_network_save() const OVERRIDE { return true; }
 };
@@ -913,8 +913,8 @@ public:
 	tool_show_trees_t() : tool_t(TOOL_SHOW_TREES | SIMPLE_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("hide trees"); }
 	bool is_selected() const OVERRIDE {return env_t::hide_trees; }
-	bool init( player_t * );
-	bool exit(player_t *s ) { return init(s); }
+	bool init( player_t * ) OVERRIDE;
+	bool exit(player_t *s ) OVERRIDE { return init(s); }
 	bool is_init_network_save() const OVERRIDE { return true; }
 	bool is_work_network_save() const OVERRIDE { return true; }
 };
@@ -927,7 +927,7 @@ public:
 			env_t::hide_buildings==0 ? "hide city building" :
 			(env_t::hide_buildings==1) ? "hide all building" : "show all building");
 	}
-	bool init( player_t * ) {
+	bool init( player_t * ) OVERRIDE {
 		env_t::hide_buildings ++;
 		if(env_t::hide_buildings>env_t::ALL_HIDDEN_BUILDING) {
 			env_t::hide_buildings = env_t::NOT_HIDE;
@@ -946,9 +946,9 @@ public:
 	char const* get_tooltip(player_t const*) const OVERRIDE;
 	bool is_selected() const OVERRIDE;
 	void draw_after(scr_coord, bool dirty) const OVERRIDE;
-	bool init( player_t * );
+	bool init( player_t * ) OVERRIDE;
 	char const* work(player_t*, koord3d) OVERRIDE;
-	bool exit(player_t * ) { return false; }
+	bool exit(player_t * ) OVERRIDE { return false; }
 	bool is_init_network_save() const OVERRIDE { return true; }
 	bool is_work_network_save() const OVERRIDE { return true; }
 };
@@ -977,8 +977,8 @@ class tool_fill_trees_t : public tool_t {
 public:
 	tool_fill_trees_t() : tool_t(TOOL_FILL_TREES | SIMPLE_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Fill trees"); }
-	image_id get_icon(player_t *) const { return baum_t::get_count() > 0 ? icon : IMG_EMPTY; }
-	bool init(player_t * ) {
+	image_id get_icon(player_t *) const OVERRIDE { return baum_t::get_count() > 0 ? icon : IMG_EMPTY; }
+	bool init(player_t * ) OVERRIDE {
 		if(  baum_t::get_count() > 0  &&  default_param  ) {
 			baum_t::fill_trees( atoi(default_param) );
 		}
@@ -991,7 +991,7 @@ class tool_daynight_level_t : public tool_t {
 public:
 	tool_daynight_level_t() : tool_t(TOOL_DAYNIGHT_LEVEL | SIMPLE_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE;
-	bool init(player_t * );
+	bool init(player_t * ) OVERRIDE;
 	bool is_init_network_save() const OVERRIDE { return true; }
 	bool is_work_network_save() const OVERRIDE { return true; }
 };
@@ -1000,7 +1000,7 @@ class tool_vehicle_tooltips_t : public tool_t {
 public:
 	tool_vehicle_tooltips_t() : tool_t(TOOL_VEHICLE_TOOLTIPS | SIMPLE_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Toggle vehicle tooltips"); }
-	bool init( player_t * ) {
+	bool init( player_t * ) OVERRIDE {
 		env_t::show_vehicle_states = (env_t::show_vehicle_states+1)%3;
 		welt->set_dirty();
 		return false;
@@ -1014,14 +1014,14 @@ public:
 	tool_toggle_pax_station_t() : tool_t(TOOL_TOOGLE_PAX | SIMPLE_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("5LIGHT_CHOOSE"); }
 	bool is_selected() const OVERRIDE { return welt->get_settings().get_show_pax(); }
-	bool init( player_t * ) {
+	bool init( player_t * ) OVERRIDE {
 		if( !env_t::networkmode) {
 			settings_t& s = welt->get_settings();
 			s.set_show_pax(!s.get_show_pax());
 		}
 		return false;
 	}
-	bool exit(player_t *s ) { return init(s); }
+	bool exit(player_t *s ) OVERRIDE { return init(s); }
 	bool is_init_network_save() const OVERRIDE { return false; }
 };
 
@@ -1030,14 +1030,14 @@ public:
 	tool_toggle_pedestrians_t() : tool_t(TOOL_TOOGLE_PEDESTRIANS | SIMPLE_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("6LIGHT_CHOOSE"); }
 	bool is_selected() const OVERRIDE { return welt->get_settings().get_random_pedestrians(); }
-	bool init( player_t * ) {
+	bool init( player_t * ) OVERRIDE {
 		if( !env_t::networkmode) {
 			settings_t& s = welt->get_settings();
 			s.set_random_pedestrians(!s.get_random_pedestrians());
 		}
 		return false;
 	}
-	bool exit(player_t *s ) { return init(s); }
+	bool exit(player_t *s ) OVERRIDE { return init(s); }
 	bool is_init_network_save() const OVERRIDE { return false; }
 };
 
@@ -1046,7 +1046,7 @@ public:
 	tool_toggle_reservation_t() : tool_t(TOOL_TOGGLE_RESERVATION | SIMPLE_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("show/hide block reservations"); }
 	bool is_selected() const OVERRIDE { return schiene_t::show_reservations; }
-	bool init( player_t * ) {
+	bool init( player_t * ) OVERRIDE {
 		schiene_t::show_reservations ^= 1;
 		welt->set_dirty();
 		return false;
@@ -1060,7 +1060,7 @@ public:
 	tool_show_ribi_t() : tool_t(TOOL_SHOW_RIBI| SIMPLE_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("view masked ribi"); }
 	bool is_selected() const OVERRIDE { return strasse_t::show_masked_ribi; }
-	bool init( player_t * ) {
+	bool init( player_t * ) OVERRIDE {
 		if(  skinverwaltung_t::ribi_arrow  ) {
 			strasse_t::show_masked_ribi ^= 1;
 			welt->set_dirty();
@@ -1079,7 +1079,7 @@ public:
 	tool_view_owner_t() : tool_t(TOOL_VIEW_OWNER | SIMPLE_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("show/hide object owner"); }
 	bool is_selected() const OVERRIDE { return obj_t::show_owner; }
-	bool init( player_t * ) {
+	bool init( player_t * ) OVERRIDE {
 		obj_t::show_owner ^= 1;
 		welt->set_dirty();
 		return false;
@@ -1093,12 +1093,12 @@ public:
 	tool_hide_under_cursor_t() : tool_t(TOOL_HIDE_UNDER_CURSOR | SIMPLE_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("hide objects under cursor"); }
 	bool is_selected() const OVERRIDE { return env_t::hide_under_cursor; }
-	bool init( player_t * ) {
+	bool init( player_t * ) OVERRIDE {
 		env_t::hide_under_cursor = !env_t::hide_under_cursor  &&  env_t::cursor_hide_range>0;
 		welt->set_dirty();
 		return false;
 	}
-	bool exit(player_t *s ) { return init(s); }
+	bool exit(player_t *s ) OVERRIDE { return init(s); }
 	bool is_init_network_save() const OVERRIDE { return true; }
 	bool is_work_network_save() const OVERRIDE { return true; }
 };
@@ -1110,7 +1110,7 @@ public:
 	tool_traffic_level_t() : tool_t(TOOL_TRAFFIC_LEVEL | SIMPLE_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("6WORLD_CHOOSE"); }
 	bool is_selected() const OVERRIDE { return false; }
-	bool init( player_t * ) {
+	bool init( player_t * ) OVERRIDE {
 		assert(  default_param  );
 		sint16 level = min( max( atoi(default_param), 0), 16);
 		welt->get_settings().set_traffic_level(level);


### PR DESCRIPTION
Port of r8679 from Standard. Fixes lots of -Winconsistent-missing-override warnings when building with clang/gcc.