### PR TITLE
Fix desyncs when using specific tools in network mode

### DIFF
--- a/gui/components/gui_convoy_assembler.cc
+++ b/gui/components/gui_convoy_assembler.cc
@@ -2283,7 +2283,7 @@ void gui_convoy_assembler_t::draw_vehicle_info_text(const scr_coord& pos)
 						}
 					}
 					// display upgrade counter
-					sprintf(txt_convoi_count_fluctuation, "(%hhu)", upgrade_count);
+					sprintf(txt_convoi_count_fluctuation, "(%hu)", (uint16)upgrade_count);
 					lb_convoi_count_fluctuation.set_visible(true);
 					lb_convoi_count_fluctuation.set_pos(scr_coord(lb_convoi_count.get_pos().x + proportional_string_width(txt_convoi_count) + D_H_SPACE, lb_convoi_count.get_pos().y));
 					lb_convoi_count_fluctuation.set_color(COL_UPGRADEABLE);

--- a/gui/convoi_detail_t.cc
+++ b/gui/convoi_detail_t.cc
@@ -513,7 +513,7 @@ void gui_vehicleinfo_t::draw(scr_coord offset)
 					buf.clear();
 
 					char tmpbuf[17];
-					sprintf(tmpbuf, "Permissive %i-%hhu", v->get_desc()->get_waytype(), i);
+					sprintf(tmpbuf, "Permissive %i-%hu", v->get_desc()->get_waytype(), (uint16)i);
 					buf.printf("%s %s", translator::translate("\nMUST USE: "), translator::translate(tmpbuf));
 					display_proportional_clip(pos.x + w + offset.x, pos.y + offset.y + total_height + extra_y, buf, ALIGN_LEFT, SYSCOL_TEXT, true);
 					extra_y += LINESPACE;
@@ -540,7 +540,7 @@ void gui_vehicleinfo_t::draw(scr_coord offset)
 				{
 					buf.clear();
 					char tmpbuf[18];
-					sprintf(tmpbuf, "Prohibitive %i-%hhu", v->get_desc()->get_waytype(), i);
+					sprintf(tmpbuf, "Prohibitive %i-%hu", v->get_desc()->get_waytype(), (uint16)i);
 					buf.printf("%s %s", translator::translate("\nMAY USE: "), translator::translate(tmpbuf));
 					display_proportional_clip(pos.x + w + offset.x, pos.y + offset.y + total_height + extra_y, buf, ALIGN_LEFT, SYSCOL_TEXT, true);
 					extra_y += LINESPACE;

--- a/gui/player_frame_t.cc
+++ b/gui/player_frame_t.cc
@@ -345,7 +345,7 @@ bool ki_kontroll_t::action_triggered( gui_action_creator_t *comp,value_t p )
 			}
 
 			static char param[16];
-			sprintf(param,"g%hhu,%i,%i", welt->get_active_player_nr(), i, access_out[i].pressed);
+			sprintf(param,"g%hu,%i,%i", (uint16)welt->get_active_player_nr(), i, (int)access_out[i].pressed);
 			tool_t *tool = create_tool( TOOL_ACCESS_TOOL | SIMPLE_TOOL );
 			tool->set_default_param(param);
 			welt->set_tool( tool, welt->get_active_player() );
@@ -388,7 +388,7 @@ bool ki_kontroll_t::action_triggered( gui_action_creator_t *comp,value_t p )
 		if (comp == take_over_player + i)
 		{
 			static char param[16];
-			sprintf(param, "u, %hhu, %hhu", welt->get_active_player_nr(), i);
+			sprintf(param, "u, %hu, %hu", (uint16)welt->get_active_player_nr(), (uint16)i);
 			tool_t* tool = create_tool(TOOL_CHANGE_PLAYER | SIMPLE_TOOL);
 			tool->set_default_param(param);
 			welt->set_tool(tool, welt->get_active_player());

--- a/simtool.cc
+++ b/simtool.cc
@@ -8667,10 +8667,10 @@ bool tool_change_convoi_t::init( player_t *player )
 	}
 	case 'c': // reassign class
 
-		uint8 compartment, new_class;
+		uint16 compartment, new_class;
 		sint32 good_type; // 0 = Passenger, 1 = Mail,
 		sint32 reset; // 0 = reset only single class, 1 = reset all classes
-		sscanf(p, "%hhu,%hhu,%i,%i", &compartment, &new_class, &good_type, &reset);
+		sscanf(p, "%hu,%hu,%i,%i", &compartment, &new_class, &good_type, &reset);
 		//uint16 new_class = atoi(p);
 		if (reset == 1)
 		{


### PR DESCRIPTION
Old MSVC compilers and MinGW do not support %hhu for printf/scanf properly, leading to desyncs when reassigning a convoi class, changing players, and using the access tool.