### PR TITLE
FIX: Wrong halts being compared for overlaid stations in frequency calculation

### DIFF
--- a/player/simplay.cc
+++ b/player/simplay.cc
@@ -1045,21 +1045,21 @@ void player_t::report_vehicle_problem(convoihandle_t cnv,const koord3d position)
 
 		case convoi_t::OUT_OF_RANGE:
 			{
-				koord destination = position.get_2d();
+				koord3d destination = position;
 				schedule_t* const sch = cnv->get_schedule();
 				const uint8 entries = sch->get_count();
 				uint8 count = 0;
-				while(count <= entries && !haltestelle_t::get_halt(destination, this).is_bound() && (welt->lookup_kartenboden(destination) == NULL || !welt->lookup_kartenboden(destination)->get_depot()))
+				while(count <= entries && !haltestelle_t::get_halt(destination, this).is_bound() && (welt->lookup_kartenboden(destination.get_2d()) == NULL || !welt->lookup_kartenboden(destination.get_2d())->get_depot()))
 				{
 					// Make sure that we are not incorrectly calculating the distance to a waypoint.
 					bool rev = cnv->is_reversed();
 					uint8 index = sch->get_current_stop();
 					sch->increment_index(&index, &rev);
-					destination = sch->entries.get_element(index).pos.get_2d();
+					destination = sch->entries.get_element(index).pos;
 					count++;
 				}
 				const uint32 distance_from_last_stop_to_here_tiles = shortest_distance(cnv->get_pos().get_2d(), cnv->front()->get_last_stop_pos().get_2d());
-				const uint32 distance_tiles = distance_from_last_stop_to_here_tiles + (shortest_distance(cnv->get_pos().get_2d(), destination));
+				const uint32 distance_tiles = distance_from_last_stop_to_here_tiles + (shortest_distance(cnv->get_pos().get_2d(), destination.get_2d()));
 				const double distance = (double)(distance_tiles * (double)welt->get_settings().get_meters_per_tile()) / 1000.0;
 				const double excess = distance - (double)cnv->get_min_range();
 				DBG_MESSAGE("player_t::report_vehicle_problem","Vehicle %s cannot travel %.2fkm to (%i,%i) because it would exceed its range of %i by %.2fkm", cnv->get_name(), distance, position.x, position.y, cnv->get_min_range(), excess);

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -98,7 +98,48 @@ void haltestelle_t::step_all()
 }
 
 
-halthandle_t haltestelle_t::get_halt(const koord pos, const player_t *player )
+static vector_tpl<convoihandle_t>stale_convois;
+static vector_tpl<linehandle_t>stale_lines;
+
+
+void haltestelle_t::start_load_game()
+{
+	all_koords = new inthashtable_tpl<sint32,halthandle_t>;
+}
+
+
+void haltestelle_t::end_load_game()
+{
+	delete all_koords;
+	all_koords = NULL;
+}
+
+/**
+ * return an index to a halt; it is only used for old games
+ * by default create a new halt if none found
+ */
+halthandle_t haltestelle_t::get_halt_koord_index(koord k)
+{
+	if(!welt->is_within_limits(k)) {
+		return halthandle_t();
+	}
+	// check in hashtable
+	halthandle_t h;
+	const sint32 n = get_halt_key(koord3d(k,-128), welt->get_size().y);
+	assert(all_koords);
+	h = all_koords->get( n );
+
+	if(  !h.is_bound()  ) {
+		// No halts found => create one
+		h = haltestelle_t::create(k, NULL );
+		all_koords->set( n,  h );
+	}
+	return h;
+}
+
+
+
+halthandle_t haltestelle_t::get_halt_2D(const koord pos, const player_t *player )
 {
 	const planquadrat_t *plan = welt->access(pos);
 	if(plan)
@@ -146,46 +187,6 @@ halthandle_t haltestelle_t::get_halt(const koord pos, const player_t *player )
 	}
 	return halthandle_t();
 }
-
-static vector_tpl<convoihandle_t>stale_convois;
-static vector_tpl<linehandle_t>stale_lines;
-
-
-void haltestelle_t::start_load_game()
-{
-	all_koords = new inthashtable_tpl<sint32,halthandle_t>;
-}
-
-
-void haltestelle_t::end_load_game()
-{
-	delete all_koords;
-	all_koords = NULL;
-}
-
-/**
- * return an index to a halt; it is only used for old games
- * by default create a new halt if none found
- */
-halthandle_t haltestelle_t::get_halt_koord_index(koord k)
-{
-	if(!welt->is_within_limits(k)) {
-		return halthandle_t();
-	}
-	// check in hashtable
-	halthandle_t h;
-	const sint32 n = get_halt_key(koord3d(k,-128), welt->get_size().y);
-	assert(all_koords);
-	h = all_koords->get( n );
-
-	if(  !h.is_bound()  ) {
-		// No halts found => create one
-		h = haltestelle_t::create(k, NULL );
-		all_koords->set( n,  h );
-	}
-	return h;
-}
-
 
 /* we allow only for a single stop per grund
  * this will only return something if this stop is accessible by the player passed in the second parameter
@@ -1864,22 +1865,22 @@ uint32 haltestelle_t::calc_service_frequency(halthandle_t destination, uint8 cat
 		uint32 timing = 0;
 		bool line_serves_destination = false;
 		uint32 number_of_calls_at_this_stop = 0;
-		koord3d current_halt;
-		koord3d next_halt;
+		koord3d current_halt_pos;
+		koord3d next_halt_pos;
 		for (uint8 n = 0; n < schedule_count; n++)
 		{
-			current_halt = registered_lines[i]->get_schedule()->entries[n].pos;
+			current_halt_pos = registered_lines[i]->get_schedule()->entries[n].pos;
 			if (n < schedule_count - 2)
 			{
-				next_halt = registered_lines[i]->get_schedule()->entries[n + 1].pos;
+				next_halt_pos = registered_lines[i]->get_schedule()->entries[n + 1].pos;
 			}
 			else
 			{
-				next_halt = registered_lines[i]->get_schedule()->entries[0].pos;
+				next_halt_pos = registered_lines[i]->get_schedule()->entries[0].pos;
 			}
 			if (n < schedule_count - 1)
 			{
-				const uint32 average_time = registered_lines[i]->get_average_journey_times().get(id_pair(haltestelle_t::get_halt(current_halt, owner).get_id(), haltestelle_t::get_halt(next_halt, owner).get_id())).get_average();
+				const uint32 average_time = registered_lines[i]->get_average_journey_times().get(id_pair(haltestelle_t::get_halt(current_halt_pos, owner).get_id(), haltestelle_t::get_halt(next_halt_pos, owner).get_id())).get_average();
 				if (average_time != 0 && average_time != UINT32_MAX_VALUE)
 				{
 					timing += average_time;
@@ -1887,7 +1888,7 @@ uint32 haltestelle_t::calc_service_frequency(halthandle_t destination, uint8 cat
 				else
 				{
 					// Fallback to convoy's general average speed if a point-to-point average is not available.
-					const uint32 distance = shortest_distance(current_halt.get_2d(), next_halt.get_2d());
+					const uint32 distance = shortest_distance(current_halt_pos.get_2d(), next_halt_pos.get_2d());
 					const uint32 recorded_average_speed = registered_lines[i]->get_finance_history(1, LINE_AVERAGE_SPEED);
 					const uint32 average_speed = recorded_average_speed > 0 ? recorded_average_speed : speed_to_kmh(registered_lines[i]->get_convoy(0)->get_min_top_speed()) >> 1;
 					const uint32 journey_time = welt->travel_time_tenths_from_distance(distance, average_speed);
@@ -1896,7 +1897,7 @@ uint32 haltestelle_t::calc_service_frequency(halthandle_t destination, uint8 cat
 				}
 			}
 
-			halthandle_t current_halthandle = haltestelle_t::get_halt(current_halt, owner);
+			halthandle_t current_halthandle = haltestelle_t::get_halt(current_halt_pos, owner);
 
 			if (current_halthandle == destination)
 			{

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -1864,18 +1864,18 @@ uint32 haltestelle_t::calc_service_frequency(halthandle_t destination, uint8 cat
 		uint32 timing = 0;
 		bool line_serves_destination = false;
 		uint32 number_of_calls_at_this_stop = 0;
-		koord current_halt;
-		koord next_halt;
+		koord3d current_halt;
+		koord3d next_halt;
 		for (uint8 n = 0; n < schedule_count; n++)
 		{
-			current_halt = registered_lines[i]->get_schedule()->entries[n].pos.get_2d();
+			current_halt = registered_lines[i]->get_schedule()->entries[n].pos;
 			if (n < schedule_count - 2)
 			{
-				next_halt = registered_lines[i]->get_schedule()->entries[n + 1].pos.get_2d();
+				next_halt = registered_lines[i]->get_schedule()->entries[n + 1].pos;
 			}
 			else
 			{
-				next_halt = registered_lines[i]->get_schedule()->entries[0].pos.get_2d();
+				next_halt = registered_lines[i]->get_schedule()->entries[0].pos;
 			}
 			if (n < schedule_count - 1)
 			{
@@ -1887,7 +1887,7 @@ uint32 haltestelle_t::calc_service_frequency(halthandle_t destination, uint8 cat
 				else
 				{
 					// Fallback to convoy's general average speed if a point-to-point average is not available.
-					const uint32 distance = shortest_distance(current_halt, next_halt);
+					const uint32 distance = shortest_distance(current_halt.get_2d(), next_halt.get_2d());
 					const uint32 recorded_average_speed = registered_lines[i]->get_finance_history(1, LINE_AVERAGE_SPEED);
 					const uint32 average_speed = recorded_average_speed > 0 ? recorded_average_speed : speed_to_kmh(registered_lines[i]->get_convoy(0)->get_min_top_speed()) >> 1;
 					const uint32 journey_time = welt->travel_time_tenths_from_distance(distance, average_speed);

--- a/simhalt.h
+++ b/simhalt.h
@@ -233,7 +233,7 @@ public:
 	 * this will only return something if this stop belongs to same player or is public, or is a dock (when on water)
 	 */
 	static halthandle_t get_halt(const koord3d pos, const player_t *player );
-	static halthandle_t get_halt(const koord pos, const player_t *player );
+	static halthandle_t get_halt_2D(const koord pos, const player_t *player );
 
 //	static slist_tpl<halthandle_t>& get_alle_haltestellen() { return alle_haltestellen; }
 	static const vector_tpl<halthandle_t>& get_alle_haltestellen() { return alle_haltestellen; }


### PR DESCRIPTION
For example, if stop A is connected to an underground stop B, while stop C is unconnected to either but located above stop B, frequency would be calculated from stop A->C and B->A, leaving A->B "unknown".