### PR TITLE
fix: crash when opening settings

### DIFF
--- a/gui/settings_stats.cc
+++ b/gui/settings_stats.cc
@@ -415,6 +415,7 @@ void settings_extended_revenue_stats_t::init( settings_t *sets )
 	INIT_NUM("max_comfort_preference_percentage", sets->get_max_comfort_preference_percentage(), 100, 65535, gui_numberinput_t::AUTOLINEAR, false);
 	end_table();
 
+	add_table(1,0);
 	SEPERATOR;
 	INIT_BOOL("simplified_maintenance", sets->simplified_maintenance);
 	INIT_END;


### PR DESCRIPTION
This option should probably be removed anyway. It would be troublesome to maintain two different systems at once.