### PR TITLE
Refactor save/load to use read/write streams

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,6 +316,11 @@ add_executable(simutrans-extended
 	gui/vehiclelist_frame.cc
 	gui/vehicle_class_manager.cc
 	gui/welt.cc
+	io/rdwr/bzip2_file_rdwr_stream.cc
+	io/rdwr/raw_file_rdwr_stream.cc
+	io/rdwr/rdwr_stream.cc
+	io/rdwr/zlib_file_rdwr_stream.cc
+	io/classify_file.cc
 	network/checksum.cc
 	network/memory_rw.cc
 	network/network_address.cc
@@ -522,6 +527,7 @@ if (SIMUTRANS_USE_UPNP)
 endif (SIMUTRANS_USE_UPNP)
 
 if (SIMUTRANS_USE_ZSTD)
+	target_sources(simutrans-extended PRIVATE io/rdwr/zstd_file_rdwr_stream.cc)
 	target_compile_definitions(simutrans-extended PRIVATE USE_ZSTD=1)
 	target_link_libraries(simutrans-extended PRIVATE ZSTD::ZSTD)
 endif (SIMUTRANS_USE_ZSTD)

--- a/Makefile
+++ b/Makefile
@@ -194,8 +194,9 @@ endif
 
 ifdef USE_ZSTD
   ifeq ($(shell expr $(USE_ZSTD) \>= 1), 1)
-    FLAGS      += -DUSE_ZSTD
-    LDFLAGS     += -lzstd
+    FLAGS   += -DUSE_ZSTD
+    LDFLAGS += -lzstd
+    SOURCES += io/rdwr/zstd_file_rdwr_stream.cc
   endif
 endif
 
@@ -449,6 +450,11 @@ SOURCES += gui/vehiclelist_frame.cc
 SOURCES += gui/obj_info.cc
 SOURCES += gui/vehicle_class_manager.cc
 SOURCES += gui/welt.cc
+SOURCES += io/classify_file.cc
+SOURCES += io/rdwr/bzip2_file_rdwr_stream.cc
+SOURCES += io/rdwr/raw_file_rdwr_stream.cc
+SOURCES += io/rdwr/rdwr_stream.cc
+SOURCES += io/rdwr/zlib_file_rdwr_stream.cc
 SOURCES += network/checksum.cc
 SOURCES += network/memory_rw.cc
 SOURCES += network/network.cc

--- a/dataobj/environment.cc
+++ b/dataobj/environment.cc
@@ -61,7 +61,7 @@ sint32 env_t::server_frames_ahead = 4;
 sint32 env_t::additional_client_frames_behind = 4;
 sint32 env_t::network_frames_per_step = 4;
 uint32 env_t::server_sync_steps_between_checks = 24;
-bool env_t::pause_server_no_clients = false; 
+bool env_t::pause_server_no_clients = false;
 bool env_t::server_runs_background_tasks_when_paused = false;
 
 std::string env_t::nickname = "";

--- a/dataobj/loadsave.cc
+++ b/dataobj/loadsave.cc
@@ -16,17 +16,17 @@
 #include "../simversion.h"
 #include "../simmem.h"
 #include "../simdebug.h"
-#include "../utils/plainstring.h"
-#include "loadsave.h"
 
+#include "../utils/plainstring.h"
 #include "../utils/simstring.h"
 
+#include "../io/rdwr/bzip2_file_rdwr_stream.h"
+#include "../io/rdwr/raw_file_rdwr_stream.h"
+#include "../io/rdwr/zlib_file_rdwr_stream.h"
 #if USE_ZSTD
-#include <zstd.h>
+#include "../io/rdwr/zstd_file_rdwr_stream.h"
 #endif
 
-#include <zlib.h>
-#include <bzlib.h>
 
 
 #define INVALID_RDWR_ID (-1)
@@ -190,45 +190,29 @@ void saving_finalize()
 #endif
 
 
-struct file_descriptors_t {
-	FILE *fp;
-	gzFile gzfp;
-	BZFILE *bzfp;
-	int bse;
-#if USE_ZSTD
-	ZSTD_inBuffer zin;
-	ZSTD_outBuffer zout;
-	void *zbuff;
-	ZSTD_CCtx *cctx;
-	ZSTD_DCtx *dctx;
-	file_descriptors_t() : fp( NULL ), gzfp( NULL ), bzfp( NULL ), bse( BZ_OK + 1 ), zbuff(NULL), cctx( NULL ), dctx( NULL ) {}
-#else
-	file_descriptors_t() : fp(NULL), gzfp(NULL), bzfp(NULL), bse(BZ_OK+1) {}
-#endif
-};
-
-
 loadsave_t::mode_t loadsave_t::save_mode = bzip2;	// default to use for saving
 loadsave_t::mode_t loadsave_t::autosave_mode = zipped;	// default to use for autosaving
 int loadsave_t::save_level = 6;
 int loadsave_t::autosave_level = 1;
 
-loadsave_t::loadsave_t() : filename()
+
+loadsave_t::loadsave_t() :
+	mode(binary),
+	buffered(false),
+	stream(NULL)
 {
-	last_error = FILE_ERROR_OK;
-	mode = 0;
-	saving = false;
-	buffered = false;
-	fd = new file_descriptors_t();
+	curr_buff = 0;
 }
 
 loadsave_t::~loadsave_t()
 {
 	set_buffered(false);
-	close();
-	delete fd;
-	if(  last_error != FILE_ERROR_OK  ) {
-		dbg->error( "loadsave_t()", "failed %s with error %i", (saving ? "saving" : "reading"), (int)last_error );
+
+	const bool saving = is_saving();
+	const char *errmsg = close();
+
+	if(  errmsg  ) {
+		dbg->error( "loadsave_t::~loadsave_t", "Could not %s save file: %s", (saving ? "save" : "load"), errmsg );
 	}
 }
 
@@ -239,33 +223,12 @@ void loadsave_t::set_buffered(bool enable)
 		if(  !buffered  ) {
 			buffered = true;
 			curr_buff = 0;
-			buf_pos[0] = buf_pos[1] = 0;
-			buf_len[0] = buf_len[1] = 0;
-			ls_buf[0] = new char[LS_BUF_SIZE];
-#if USE_ZSTD
-			if( is_zstd() ) {
-				if( saving ) {
-					fd->zin.src = NULL;
-					fd->zin.size = 0;
-					fd->zin.pos = 0;
+			buff[0].pos = buff[1].pos = 0;
+			buff[0].len = buff[1].len = 0;
+			buff[0].buf = new char[LS_BUF_SIZE];
 
-					fd->zout.dst = fd->zbuff;
-					fd->zout.size = LS_BUF_SIZE;
-					fd->zout.pos = 0;
-				}
-				else {
-					fd->zin.src = fd->zbuff;
-					fd->zin.size = LS_BUF_SIZE;
-					fd->zin.pos = 0;
-
-					fd->zout.dst = NULL;
-					fd->zout.size = 0;
-					fd->zout.pos = 0;
-				}
-			}
-#endif
 #ifdef MULTI_THREAD
-			ls_buf[1] = new char[LS_BUF_SIZE]; // second buffer only when multithreaded
+			buff[1].buf = new char[LS_BUF_SIZE]; // second buffer only when multithreaded
 
 			simthread_barrier_init(&loadsave_barrier, NULL, 2);
 			pthread_mutex_init(&loadsave_mutex, NULL);
@@ -278,7 +241,7 @@ void loadsave_t::set_buffered(bool enable)
 
 			ls.loadsave_routine = this;
 
-			pthread_create(&ls_thread, &attr, saving ? save_thread : load_thread, (void *)&ls);
+			pthread_create(&ls_thread, &attr, is_saving() ? save_thread : load_thread, (void *)&ls);
 
 			pthread_attr_destroy(&attr);
 #endif
@@ -286,7 +249,7 @@ void loadsave_t::set_buffered(bool enable)
 	}
 	else {
 		if(  buffered  ) {
-			if(  saving  &&  buf_pos[curr_buff]>0  ) {
+			if(  is_saving()  &&  buff[curr_buff].pos>0  ) {
 #ifdef MULTI_THREAD
 				saving_finalize();
 #else
@@ -294,7 +257,7 @@ void loadsave_t::set_buffered(bool enable)
 #endif
 			}
 #ifdef MULTI_THREAD
-			if(  !saving  ) {
+			if(  !is_saving()  ) {
 				loading_finalize();
 			}
 			pthread_join(ls_thread,NULL);
@@ -303,211 +266,125 @@ void loadsave_t::set_buffered(bool enable)
 			pthread_mutex_destroy(&readdata_mutex);
 			simthread_barrier_destroy(&loadsave_barrier);
 
-			delete [] ls_buf[1]; // second buffer only when multithreaded
+			delete[] buff[1].buf; // second buffer only when multithreaded
 #endif
-			delete [] ls_buf[0];
+			delete[] buff[0].buf;
 			buffered = false;
 		}
 	}
 }
 
 
-bool loadsave_t::rd_open(const char *filename_utf8 )
+loadsave_t::file_status_t loadsave_t::rd_open(const char *filename_utf8)
 {
 	close();
-	last_error = FILE_ERROR_OK; // no error
 
-	version = 0;
-	extended_version = 0;
-	extended_revision = 0;
-	mode = binary;
-	saving = false;
+	const file_classify_status_t cl_status = classify_file(filename_utf8, &finfo);
 
-	fd->fp = dr_fopen(filename_utf8, "rb");
-	if(  fd->fp==NULL  ) {
-		// most likely not existing
-		last_error = FILE_ERROR_NOT_EXISTING;
-		return false;
+	if (cl_status != FILE_CLASSIFY_OK) {
+		// file likely does not exist
+		dbg->warning("loadsave_t::rd_open", "File '%s' does not exist or is not accessible", filename_utf8);
+		return FILE_STATUS_ERR_NOT_EXISTING;
 	}
-	// now check for BZ2 format
-	//char buf[80];
-	char buf[512];
-	//if(  fread( buf, 1, 512, fd->fp )==512  ) {
-	if(  fread( buf, 1, 2, fd->fp )==2  ) {
-		if(  buf[0]=='B'  &&  buf[1]=='Z'  ) {
-			mode = bzip2;
-		}
-		if(  buf[0]=='Z'  &&  buf[1]=='D'  ) {
-			mode = zstd;
-		}
+	else if(  finfo.ext_version.version == INVALID_FILE_VERSION  ) {
+		return FILE_STATUS_ERR_NO_VERSION;
 	}
-
-	if(  mode==bzip2  ) {
-		fseek(fd->fp,0,SEEK_SET);
-		fd->bse = BZ_OK+1;
-		fd->bzfp = NULL;
-		fd->bzfp = BZ2_bzReadOpen( &fd->bse, fd->fp, 0, 0, NULL, 0 );
-		if(  fd->bse!=BZ_OK  ) {
-			MEMZERO(buf);
-			last_error = FILE_ERROR_BZ_CORRUPT;
-			close();
-			return false;
-		}
-	}
-
-	if(  mode==zstd  ) {
-#if USE_ZSTD
-		fd->zbuff = xmalloc(LS_BUF_SIZE);
-
-		fd->dctx = ZSTD_createDCtx();
-		if(  fd->dctx==NULL  ) {
-			// zstd could not init
-			last_error = FILE_ERROR_BZ_CORRUPT;
-			close();
-			return false;
-		}
-		set_buffered( true );
-		fd->zin.size = 0;
-#else
-		last_error = FILE_ERROR_UNSUPPORTED_COMPRESSION;
-		fclose( fd->fp );
-		fd->fp = NULL;
-		dbg->error( "loadsave_t::rd_open", "Compiled without zstd support!" );
-		return false;
-#endif
-	}
-
-	if(  !is_bzip2()  &&  !is_zstd()  ) {
-		fclose(fd->fp);
-		mode = zipped;
-		// and now with zlib ...
-		fd->gzfp = dr_gzopen(filename_utf8, "rb");
-		if(fd->gzfp==NULL) {
-			last_error = FILE_ERROR_GZ_CORRUPT;
-			return false;
-		}
-	}
-
-	if(  read( buf, sizeof( SAVEGAME_PREFIX ) ) == sizeof( SAVEGAME_PREFIX )  ) {
-		// get the rest of the string
-		for( int i = sizeof( SAVEGAME_PREFIX ); i < 79; ) {
-			int ch = lsgetc();
-			if( ch < 32 ) {
-				break;
-			}
-			buf[ i++ ] = (char)ch;
-			buf[ i ] = 0;
-		}
-	}
-	else {
-		// could not even read start of file
-		last_error = FILE_ERROR_BZ_CORRUPT;
-		close();
-		return false;
-	}
-
-	if (strstart(buf, SAVEGAME_PREFIX)) {
-		combined_version versions = int_version(buf + sizeof(SAVEGAME_PREFIX) - 1, pak_extension);
-		version = versions.version;
-		extended_version = versions.extended_version;
-		if(  version == 0  ) {
-			close();
-			last_error = FILE_ERROR_NO_VERSION;
-			return false;
-		}
-	}
-	else if (strstart(buf, XML_SAVEGAME_PREFIX)) {
-		mode |= xml;
-		while (lsgetc() != '<') { /* nothing */ }
-		read(buf, sizeof(SAVEGAME_PREFIX) - 1);
-		if (!strstart(buf, SAVEGAME_PREFIX)) {
-			last_error = FILE_ERROR_NO_VERSION;
-			close();
-			// not a simutrans XML file ...
-			return false;
-		}
-
-		read(buf, sizeof("version=\"") - 1);
-		char str[256];
-		char *s = str;
-		for (int i = 0; i < 255; i++) {
-			char c = lsgetc();
-			if (c=='\"') {
-				break;
-			}
-			*s++ = c;
-		}
-		*s = 0;
-		combined_version versions = int_version(str, pak_extension);
-		version = versions.version;
-		extended_version = versions.extended_version;
-		if(  version == 0  ) {
-			close();
-			last_error = FILE_ERROR_NO_VERSION;
-			return false;
-		}
-
-		read(buf, sizeof(" pak=\"") - 1);
-		if (version > 0) {
-			s = pak_extension;
-			for (int i = 0; i < 63; i++) {
-				char c = lsgetc();
-				if (c=='\"') {
-					break;
-				}
-				*s++ = c;
-			}
-			*s = 0;
-			while (lsgetc() != '>');
-		}
-
+	else if(  finfo.ext_version.version > (SIM_VERSION_MAJOR*1000 + SIM_SERVER_MINOR)  ) {
 		/*
-		 * reading future versions will almost certainly lead to exceptions
-		 * so we close here
+		 * Reading future versions will almost certainly lead to exceptions; so we close here.
 		 * It would be nice to give a detailed message what failed (like the fatal error does)
 		 * But this error may happening also in regular installations after running a nighly
-		 * so we just record the failure and return false
+		 * so we just record the failure.
 		 */
-		if(  version > (SIM_VERSION_MAJOR*1000 + SIM_SERVER_MINOR)  ) {
-			close();
-			last_error = FILE_ERROR_FUTURE_VERSION;
-			return false;
+		return FILE_STATUS_ERR_FUTURE_VERSION;
+	}
+
+	// now open the file
+	assert(stream == NULL);
+	mode = 0;
+
+	switch (finfo.file_type) {
+		case file_info_t::TYPE_XML_ZSTD:
+			mode = xml;
+			// fallthrough
+		case file_info_t::TYPE_ZSTD:
+			mode |= zstd;
+#if USE_ZSTD
+			stream = new zstd_file_rdwr_stream_t(filename_utf8, false, 0); break;
+#else
+			dbg->error("loadsave_t::rd_open", "Unsupported save file compression 'zstd'"); break;
+			return FILE_STATUS_ERR_UNSUPPORTED_COMPRESSION;
+#endif
+
+		case file_info_t::TYPE_XML_BZIP2:
+			mode = xml;
+			// fallthrough
+		case file_info_t::TYPE_BZIP2:
+			mode |= bzip2;
+			stream = new bzip2_file_rdwr_stream_t(filename_utf8, false); break;
+
+		case file_info_t::TYPE_XML_ZIPPED:
+			mode = xml;
+			// fallthrough
+		case file_info_t::TYPE_ZIPPED:
+			mode |= zipped;
+			stream = new zlib_file_rdwr_stream_t(filename_utf8, false, 0); break;
+
+		case file_info_t::TYPE_XML:
+			mode = xml;
+			// fallthrough
+		default:
+			stream = new raw_file_rdwr_stream_t(filename_utf8, false); break;
+	}
+
+	if (!stream || stream->get_status() != rdwr_stream_t::STATUS_OK) {
+		const char *errmsg = close();
+
+		// file likely does not exist any longer
+		if (errmsg) {
+			dbg->warning("loadsave_t::rd_open", "Cannot read from '%s': %s", filename_utf8, errmsg);
 		}
-	}
-	else {
-		close();
-		last_error = FILE_ERROR_NO_VERSION;
-		return false;
+		else {
+			dbg->warning("loadsave_t::rd_open", "Cannot read from '%s'", filename_utf8);
+		}
+
+		return FILE_STATUS_ERR_NOT_EXISTING;
 	}
 
-	if(mode==text) {
-		close();
-		last_error = FILE_ERROR_NO_VERSION;
-		dbg->error("loadsave_t::rd_open()","text mode no longer supported." );
-		return false;
+	// skip header
+	size_t header_size = finfo.header_size;
+
+	while (header_size != 0) {
+		char buf[128];
+		const size_t sz = min(header_size, 128);
+		stream->read(buf, sz);
+		header_size -= sz;
 	}
 
-	if(*pak_extension==0) {
-		strcpy( pak_extension, "(unknown)" );
+	if(*finfo.pak_extension==0) {
+		strcpy( finfo.pak_extension, "(unknown)" );
 	}
-	this->filename = filename_utf8;
+
 #ifndef SPECIAL_RESCUE_12_6
-	if (extended_version >= 12)
+	if (finfo.ext_version.extended_version >= 12)
 	{
-		rdwr_long(extended_revision);
+		rdwr_long(finfo.ext_version.extended_revision);
 	}
 	else
 	{
-		extended_revision = 0;
+		finfo.ext_version.extended_revision = 0;
 	}
 #else
-	extended_revision = 0;
+	finfo.ext_version.extended_revision = 0;
 #endif
-	return true;
+
+	return FILE_STATUS_OK;
 }
 
-void loadsave_t::rdwr_string(std::string &s) {
-	if (saving) {
+
+void loadsave_t::rdwr_string(std::string &s)
+{
+	if (is_saving()) {
 		const char* name = s.c_str();
 		rdwr_str(name);
 	}
@@ -520,73 +397,41 @@ void loadsave_t::rdwr_string(std::string &s) {
 }
 
 
-bool loadsave_t::wr_open( const char *filename_utf8, mode_t m, int level, const char *pak_extension, const char *savegame_version, const char *savegame_version_ex, const char *)
+
+loadsave_t::file_status_t loadsave_t::wr_open( const char *filename_utf8, mode_t m, int level, const char *pak_extension,
+	const char *savegame_version, const char *savegame_version_ex, const char * )
 {
 	mode = m;
-	last_error = FILE_ERROR_OK; // no error
 	close();
 
 #if !USE_ZSTD
 	if( mode & zstd ) {
 		mode &= ~zstd;
 		mode |= bzip2;
-		dbg->warning( "loadsave_t::rd_open", "Compiled without zstd support, using bzip2!" );
+		dbg->warning( "loadsave_t::wr_open", "Compiled without zstd support, using bzip2!" );
 	}
 #endif
 
-	saving = true;
-	if(  is_zipped()  ) {
-		// using zlib on servers, since 3x times faster saving than bz2
-		char compr[ 4 ] = { 'w', 'b', (char)('0' + clamp( level, 1, 9 )), 0 };
-		fd->gzfp = dr_gzopen(filename_utf8, compr );
-	}
-	else if(  mode==binary  ) {
-		// no compression
-		fd->fp = dr_fopen(filename_utf8, "wb");
-	}
+	assert(stream == NULL);
+
+	switch (mode & ~xml) {
 #if USE_ZSTD
-	else if(  is_zstd()  ) {
-		fd->cctx = ZSTD_createCCtx();
-		if(  fd->cctx==NULL  ) {
-			// zstd could not init
-			last_error = FILE_ERROR_BZ_CORRUPT;
-			close();
-			return false;
-		}
-		// in principe both below could fail ...
-		ZSTD_CCtx_setParameter( fd->cctx, ZSTD_c_compressionLevel, level );
-//		ZSTD_CCtx_setParameter( fd->cctx, ZSTD_c_checksumFlag, 1 );
-		// XML or bzip ...
-		fd->fp = dr_fopen(filename_utf8, "wb");
-		fd->zbuff = xmalloc(LS_BUF_SIZE);
-		// the additional magic for zstd
-		fwrite( "ZD", 1, 2, fd->fp );
-		set_buffered( true );
-	}
+		case zstd: stream = new zstd_file_rdwr_stream_t(filename_utf8, true, level); break;
 #endif
-	else if(  is_bzip2()  ) {
-		// XML or bzip ...
-		fd->fp = dr_fopen(filename_utf8, "wb");
-		// the additional magic for bzip2
-		fd->bse = BZ_OK+1;
-		fd->bzfp = NULL;
-		if(  fd->fp  ) {
-			fd->bzfp = BZ2_bzWriteOpen( &fd->bse, fd->fp, 9, 0, 30 /* default is 30 */ );
-			if(  fd->bse!=BZ_OK  ) {
-				return false;
-			}
-		}
-	}
-	else {
-		// uncompressed xml should be here ...
-		assert(  mode==xml  );
-		fd->fp = dr_fopen(filename_utf8, "wb");
+		case bzip2:  stream = new bzip2_file_rdwr_stream_t(filename_utf8, true);       break;
+		case zipped: stream = new zlib_file_rdwr_stream_t(filename_utf8, true, level); break;
+		case binary: stream = new raw_file_rdwr_stream_t(filename_utf8, true);         break;
+		default:
+			dbg->error("loadsave_t::wr_open", "Unsupported save file compression");
+			return FILE_STATUS_ERR_UNSUPPORTED_COMPRESSION;
 	}
 
-	// check whether we could open the file
-	if(  is_zipped()  ?  fd->gzfp == NULL  :  fd->fp == NULL  ) {
-		return false;
+	if (stream->get_status() != rdwr_stream_t::STATUS_OK) {
+		dbg->error("loadsave_t::wr_open", "Cannot open '%s' for writing!", filename_utf8);
+		return (stream->get_status() == rdwr_stream_t::STATUS_ERR_NOT_EXISTING) ? FILE_STATUS_ERR_NOT_EXISTING : FILE_STATUS_ERR_CORRUPT;
 	}
+
+	set_buffered( true );
 
 	// get the right extension
 	const char *start = pak_extension;
@@ -608,19 +453,19 @@ bool loadsave_t::wr_open( const char *filename_utf8, mode_t m, int level, const 
 		c++;
 	}
 	assert(start<end);
-	tstrncpy(this->pak_extension, start, lengthof(this->pak_extension));
+	tstrncpy(finfo.pak_extension, start, lengthof(finfo.pak_extension));
 	// delete trailing path separator
-	this->pak_extension[strlen(this->pak_extension)-1] = 0;
+	finfo.pak_extension[strlen(finfo.pak_extension)-1] = 0;
 
-	loadsave_t::combined_version combined_version = int_version(savegame_version,  NULL);
-	version = combined_version.version;
+	extended_version_t combined_version = int_version(savegame_version,  NULL);
+	finfo.ext_version.version = combined_version.version;
 
-	const char* pakset_string = this->pak_extension;
+	const char* pakset_string = finfo.pak_extension;
 
 	if(  !is_xml()  ) {
 		char str[8192];
 		size_t len;
-		if(  version<=102002  ) {
+		if(  finfo.ext_version.version<=102002  ) {
 			len = sprintf(str, SAVEGAME_PREFIX "%s%s%s\n", savegame_ver.c_str(), "zip", pakset_string);
 		}
 		else {
@@ -635,98 +480,57 @@ bool loadsave_t::wr_open( const char *filename_utf8, mode_t m, int level, const 
 		ident = 1;
 	}
 
-	loadsave_t::combined_version versions = int_version(savegame_ver.c_str(), NULL);
-	version = versions.version;
-	extended_version = versions.extended_version;
-	extended_revision = versions.extended_revision;
+	finfo.ext_version = int_version(savegame_ver.c_str(), NULL);
 
-	this->filename = filename_utf8;
-
-	if (extended_version >= 12)
+	if (finfo.ext_version.extended_version >= 12)
 	{
-		rdwr_long(extended_revision);
+		rdwr_long(finfo.ext_version.extended_revision);
 	}
 	else
 	{
-		extended_revision = 0;
+		finfo.ext_version.extended_revision = 0;
 	}
 
-	return true;
+	return FILE_STATUS_OK;
 }
 
 
 const char *loadsave_t::close()
 {
-	const char *success = NULL;
+	if (!stream) {
+		return NULL;
+	}
 
-	if(  is_xml()  &&  saving  &&  (!is_bzip2()  ||  fd->bse==BZ_OK)
-	     &&  (is_zipped()  ?  fd->gzfp != NULL :  fd->fp != NULL) ) {
+	if(  is_xml()  && stream->is_writing() && stream->get_status() == rdwr_stream_t::STATUS_OK) {
 		// only write when close and no error occurred
 		const char *end = "\n</Simutrans>\n";
 		write( end, strlen(end) );
 	}
-#if USE_ZSTD
-	if( is_zstd() && fd->fp ) {
-		if( saving ) {
-			// write zero length dummy to indicate end of data
-			fd->zin.src = "";
-			fd->zin.size = 0;
-			fd->zin.pos = 0;
 
-			fd->zout.dst = fd->zbuff;
-			fd->zout.size = LS_BUF_SIZE;
-			fd->zout.pos = 0;
+	if (buffered) {
+		// flush buffers
+		set_buffered(false);
+	}
 
-			size_t ret;
-			do {
-				fd->zout.pos = 0;
-				ret = ZSTD_compressStream2( fd->cctx, &(fd->zout), &(fd->zin), ZSTD_e_end  );
-				fwrite( fd->zout.dst, 1, fd->zout.pos, fd->fp );
-			} while( ret>0 );
-			ZSTD_freeCCtx( fd->cctx );
-			mode = 0; // let default handle the closing errors ...
-		}
-		else {
-			ZSTD_freeDCtx( fd->dctx );
-			mode = zipped; // let zlib handle the closing errors ...
-		}
-		free( fd->zbuff );
-	}
-#endif
-	if(  is_zipped()  &&  fd->gzfp) {
-		int err_no = Z_OK;
-		const char *err_str = gzerror( fd->gzfp, &err_no );
-		if(err_no!=Z_OK  &&  err_no!=Z_STREAM_END) {
-			success =  err_no==Z_ERRNO ? strerror(errno) : err_str;
-		}
-		gzclose(fd->gzfp);
-		fd->gzfp = NULL;
-	}
-	if(  is_bzip2()  &&  fd->fp ) {
-		if(   saving  ) {
-			/* BZLIB seems to eat the last byte, if it is at odd position
-				* => we just write a dummy zero padding byte
-				*/
-			write( "", 1 );
-			BZ2_bzWriteClose( &fd->bse, fd->bzfp, 0, NULL, NULL );
-		}
-		else {
-			BZ2_bzReadClose( &fd->bse, fd->bzfp );
-		}
-		fclose( fd->fp );
-		fd->bzfp = fd->fp = NULL;
-		fd->bse = BZ_STREAM_END;
-	}
-	if(  !is_bzip2()  &&  !is_zipped()  &&  fd->fp  ) {
-		int err_no = ferror(fd->fp);
-		fclose(fd->fp);
-		if(err_no!=0) {
-			success = strerror(err_no);
-		}
-	}
-	fd->fp = NULL;
+	const char *errmsg = NULL;
 
-	return success;
+	switch (stream->get_status()) {
+		case rdwr_stream_t::STATUS_EOF:
+		case rdwr_stream_t::STATUS_OK: errmsg = NULL; break;
+
+		case rdwr_stream_t::STATUS_ERR_CORRUPT:        errmsg = "Corrupt save file";         break;
+		case rdwr_stream_t::STATUS_ERR_DEPRECATED:     errmsg = "Save file version too old"; break;
+		case rdwr_stream_t::STATUS_ERR_FUTURE_VERSION: errmsg = "Save file version too new"; break;
+		case rdwr_stream_t::STATUS_ERR_NO_VERSION:     errmsg = "Unversioned save file";     break;
+		case rdwr_stream_t::STATUS_ERR_FULL:           errmsg = "No space left on device";   break;
+		case rdwr_stream_t::STATUS_ERR_NOT_EXISTING:   errmsg = "File not found";            break;
+		case rdwr_stream_t::STATUS_INVALID:            errmsg = "<Invalid status>";          break;
+	}
+
+	delete stream;
+	stream = NULL;
+
+	return errmsg;
 }
 
 
@@ -737,39 +541,22 @@ const char *loadsave_t::close()
  */
 bool loadsave_t::is_eof()
 {
-	if( is_bzip2() ) {
-		if( buffered ) {
-			bool r;
 #ifdef MULTI_THREAD
-			pthread_mutex_lock( &loadsave_mutex );
-#endif
-			r = buf_pos[ 0 ] >= buf_len[ 0 ] && buf_pos[ 1 ] >= buf_len[ 1 ] && fd->bse != BZ_OK;
-#ifdef MULTI_THREAD
-			pthread_mutex_unlock( &loadsave_mutex );
-#endif
-			return r;
-		}
-		else {
-			// any error is EOF ...
-			return fd->bse != BZ_OK;
-		}
+	if (buffered) {
+		pthread_mutex_lock( &loadsave_mutex );
 	}
-	else {
-		if(  buffered  ) {
-			bool r;
-#ifdef MULTI_THREAD
-			pthread_mutex_lock(&loadsave_mutex);
 #endif
-			r = buf_pos[0]>=buf_len[0]  &&  buf_pos[1]>=buf_len[1]  &&  gzeof(fd->gzfp)!=0;
+
+	const bool eof = (!buffered || (buff[0].pos >= buff[0].len && buff[1].pos >= buff[1].len)) &&
+	stream->get_status() == rdwr_stream_t::STATUS_EOF;
+
 #ifdef MULTI_THREAD
-			pthread_mutex_unlock(&loadsave_mutex);
-#endif
-			return r;
-		}
-		else {
-			return gzeof(fd->gzfp)!=0;
-		}
+	if (buffered) {
+		pthread_mutex_unlock(&loadsave_mutex);
 	}
+#endif
+
+	return eof;
 }
 
 
@@ -792,50 +579,39 @@ int loadsave_t::lsgetc()
 
 size_t loadsave_t::write(const void *buf, size_t len)
 {
-	if(  buffered  ) {
-		if(  buf_pos[curr_buff]+len<=LS_BUF_SIZE  ) {
-			// room in the buffer, copy it all
-			for(  unsigned i=0;  i<len;  i++  ) {
-				ls_buf[curr_buff][buf_pos[curr_buff]++] = ((const char*)buf)[i];
-			}
-			return len;
-		}
-		else {
-			// copy up to full buffer
-			unsigned i = 0;
-			const unsigned left = LS_BUF_SIZE-buf_pos[curr_buff];
-			while(  i<left  ) {
-				ls_buf[curr_buff][buf_pos[curr_buff]++] = ((const char*)buf)[i++];
-			}
+	if (!buffered) {
+		return stream->write(buf, len);
+	}
 
-#ifdef MULTI_THREAD
-			saving_trigger_flush();
-
-			// switch buffers
-			curr_buff = (curr_buff+1)&1;
-#else
-			// not threaded, flush single buffer ourselves
-			flush_buffer(curr_buff);
-#endif
-			// copy the rest
-			while(  i<len  ) {
-				ls_buf[curr_buff][buf_pos[curr_buff]++] = ((const char*)buf)[i++];
-			}
-			return len;
+	if(  buff[curr_buff].pos+len<=LS_BUF_SIZE  ) {
+		// room in the buffer, copy it all
+		for(  unsigned i=0;  i<len;  i++  ) {
+			buff[curr_buff].buf[buff[curr_buff].pos++] = ((const char*)buf)[i];
 		}
+		return len;
 	}
 	else {
-		if(  is_zipped()  ) {
-			return gzwrite(fd->gzfp, const_cast<void *>(buf), len);
+		// copy up to full buffer
+		unsigned i = 0;
+		const unsigned left = LS_BUF_SIZE-buff[curr_buff].pos;
+		while(  i<left  ) {
+			buff[curr_buff].buf[buff[curr_buff].pos++] = ((const char*)buf)[i++];
 		}
-		else if(  is_bzip2()  ) {
-			BZ2_bzWrite( &fd->bse, fd->bzfp, const_cast<void *>(buf), len);
-			assert(fd->bse==BZ_OK);
-			return len;
+
+#ifdef MULTI_THREAD
+		saving_trigger_flush();
+
+		// switch buffers
+		curr_buff = (curr_buff+1)&1;
+#else
+		// not threaded, flush single buffer ourselves
+		flush_buffer(curr_buff);
+#endif
+		// copy the rest
+		while(  i<len  ) {
+			buff[curr_buff].buf[buff[curr_buff].pos++] = ((const char*)buf)[i++];
 		}
-		else {
-			return fwrite(buf, 1, len, fd->fp);
-		}
+		return len;
 	}
 }
 
@@ -845,40 +621,11 @@ void loadsave_t::flush_buffer(int buf_num)
 #ifdef MULTI_THREAD
 	pthread_mutex_lock(&loadsave_mutex);
 #endif
-	int bse = fd->bse;
-	if(  is_zipped()  ) {
-		gzwrite(fd->gzfp, ls_buf[buf_num], buf_pos[buf_num]);
-	}
-	else if(  is_bzip2()  ) {
-		BZ2_bzWrite( &bse, fd->bzfp, ls_buf[buf_num], buf_pos[buf_num]);
-		assert(bse==BZ_OK);
-	}
-	else if(  is_zstd()  ) {
-#if USE_ZSTD
-		size_t ret;
-		// first write, whatever remained in buffer
-		gzwrite( fd->gzfp, fd->zout.dst, fd->zout.pos );
-		// then compress the next data
-		fd->zin.src = ls_buf[ buf_num ];
-		fd->zin.size = buf_pos[ buf_num ];
-		fd->zin.pos = 0;
 
-		while(  fd->zin.pos < fd->zin.size  ) {
-			fd->zout.pos = 0;
-			ret = ZSTD_compressStream2( fd->cctx, &(fd->zout), &(fd->zin), ZSTD_e_continue );
-			fwrite( fd->zout.dst, 1, fd->zout.pos, fd->fp );
-		}
-#else
-		dbg->fatal( "loadsave_t::flush_buffer", "Should never happen!" );
-#endif
-	}
-	else {
-		fwrite(ls_buf[buf_num], 1, buf_pos[buf_num], fd->fp);
-	}
-	if(  is_bzip2()  ) {
-		fd->bse = bse;
-	}
-	buf_pos[buf_num] = 0;
+	const size_t sz = stream->write(buff[buf_num].buf, buff[buf_num].pos);
+	assert(sz == buff[buf_num].pos); (void)sz;
+	buff[buf_num].pos = 0;
+
 #ifdef MULTI_THREAD
 	pthread_mutex_unlock(&loadsave_mutex);
 #endif
@@ -887,121 +634,79 @@ void loadsave_t::flush_buffer(int buf_num)
 
 size_t loadsave_t::read(void *buf, size_t len)
 {
-	if(  buffered  ) {
-		if(  len>=LS_BUF_SIZE*2  ) {
-			dbg->fatal("loadsave_t::read()","Request for %d too long", len);
+	if (!buffered) {
+		return stream->read( buf, len);
+	}
+
+	if(  len>=LS_BUF_SIZE*2  ) {
+		dbg->fatal("loadsave_t::read()","Request for %d too long", len);
+		return 0;
+	}
+	if(  buff[curr_buff].pos+len<=buff[curr_buff].len  ) {
+		// room in the buffer, copy it all
+		for(  unsigned i=0;  i<len;  i++  ) {
+			((char*)buf)[i] = buff[curr_buff].buf[buff[curr_buff].pos++];
+		}
+
+		return len;
+	}
+	else {
+		// copy up to full buffer
+		unsigned i = 0;
+		if(  buff[curr_buff].len>0  ) {
+			const unsigned left = buff[curr_buff].len-buff[curr_buff].pos;
+			while(  i<left  ) {
+				((char*)buf)[i++] = buff[curr_buff].buf[buff[curr_buff].pos++];
+			}
+		}
+#ifdef MULTI_THREAD
+		loading_trigger_fill_buffer();
+
+		// switch buffers
+		curr_buff = (curr_buff+1)&1;
+#else
+		// not threaded, read more into single buffer ourselves
+		fill_buffer(curr_buff);
+#endif
+		// check if enough read
+		if(  len-i>buff[curr_buff].len  ) {
+			dbg->fatal("loadsave_t::read","savegame corrupt, not enough data");
 			return 0;
 		}
-		if(  buf_pos[curr_buff]+len<=buf_len[curr_buff]  ) {
-			// room in the buffer, copy it all
-			for(  unsigned i=0;  i<len;  i++  ) {
-				((char*)buf)[i] = ls_buf[curr_buff][buf_pos[curr_buff]++];
-			}
-			return len;
-		}
-		else {
-			// copy up to full buffer
-			unsigned i = 0;
-			if(  buf_len[curr_buff]>0  ) {
-				const unsigned left = buf_len[curr_buff]-buf_pos[curr_buff];
-				while(  i<left  ) {
-					((char*)buf)[i++] = ls_buf[curr_buff][buf_pos[curr_buff]++];
-				}
-			}
-#ifdef MULTI_THREAD
-			loading_trigger_fill_buffer();
 
-			// switch buffers
-			curr_buff = (curr_buff+1)&1;
-#else
-			// not threaded, read more into single buffer ourselves
-			fill_buffer(curr_buff);
-#endif
-			// check if enough read
-			if(  len-i>buf_len[curr_buff]  ) {
-				dbg->fatal("loadsave_t::read","savegame corrupt, not enough data");
-				return 0;
-			}
+		// copy the rest
+		while(  i<len  ) {
+			((char*)buf)[i++] = buff[curr_buff].buf[buff[curr_buff].pos++];
+		}
 
-			// copy the rest
-			while(  i<len  ) {
-				((char*)buf)[i++] = ls_buf[curr_buff][buf_pos[curr_buff]++];
-			}
-			return len;
-		}
-	}
-	else {
-		if(  is_bzip2()  ) {
-			if(  fd->bse==BZ_OK  ) {
-				BZ2_bzRead( &fd->bse, fd->bzfp, buf, len);
-			}
-			return fd->bse==BZ_OK ? len : 0;
-		}
-		else {
-			return gzread(fd->gzfp, buf, len);
-		}
+		return len;
 	}
 }
 
 
-int loadsave_t::fill_buffer( int buf_num )
+size_t loadsave_t::fill_buffer( int buf_num )
 {
-	int r;
-	int bse = fd->bse;
+	assert(buffered);
 
-	if( is_bzip2() ) {
-		if( bse == BZ_OK ) {
-			r = BZ2_bzRead( &bse, fd->bzfp, ls_buf[ buf_num ], LS_BUF_SIZE );
-			if( bse != BZ_OK  &&  bse != BZ_STREAM_END ) {
-				r = -1; // an error occurred
-			}
-		}
-		else {
-			assert( bse == BZ_STREAM_END );
-			r = 0;
-		}
-	}
-#if USE_ZSTD
-	else if(  is_zstd()  ) {
-		fd->zout.dst = ls_buf[ buf_num ];
-		fd->zout.size = LS_BUF_SIZE;
-		fd->zout.pos = 0;
+	const size_t sz = stream->read(buff[ buf_num ].buf, LS_BUF_SIZE);
 
-		do {
-			// first decompress from remaining input buffer
-			while(  fd->zin.pos < fd->zin.size  &&  fd->zout.pos < fd->zout.size  ) {
-				size_t ret = ZSTD_decompressStream( fd->dctx, &fd->zout, &fd->zin );
-				if(  ret == 0  ) {
-					fd->zout.size = fd->zout.pos;
-				}
-			}
-			// not enough data to fill buffer => read more ...
-			if(  fd->zout.pos < fd->zout.size  ) {
-				r = fread( (void *)(fd->zin.src), 1, LS_BUF_SIZE, fd->fp );
-				fd->zin.pos = 0;
-				fd->zin.size = r;
-			}
-		}
-		while(  fd->zin.pos < fd->zin.size  &&  fd->zout.pos < fd->zout.size  );
-		r = fd->zout.pos; // number of bytes decompressed
-	}
-#endif
-	else {
-		r = gzread(fd->gzfp, ls_buf[buf_num], LS_BUF_SIZE);
-	}
-#ifdef MULTI_THREAD
+	#ifdef MULTI_THREAD
 	pthread_mutex_lock(&loadsave_mutex);
-#endif
-	if(  is_bzip2()  ) {
-		fd->bse = bse;
-	}
-	buf_pos[buf_num] = 0;
-	buf_len[buf_num] = r>=0 ? r : 0; // buf_len is unsigned, set to zero in case of error
-#ifdef MULTI_THREAD
+	#endif
+
+	const rdwr_stream_t::status_t status = stream->get_status();
+	const bool stream_ok = (status == rdwr_stream_t::STATUS_EOF || status == rdwr_stream_t::STATUS_OK);
+
+	assert((status == rdwr_stream_t::STATUS_OK) == (sz == LS_BUF_SIZE));
+	buff[buf_num].pos = 0;
+	buff[buf_num].len = stream_ok ? sz : 0; // buf_len is unsigned, set to zero in case of error
+
+	#ifdef MULTI_THREAD
 	pthread_mutex_unlock(&loadsave_mutex);
-#endif
-	return r;
+	#endif
+	return sz;
 }
+
 
 
 /*************** High level routines to read/write data types *************
@@ -1012,7 +717,7 @@ int loadsave_t::fill_buffer( int buf_num )
 void loadsave_t::rdwr_byte(sint8 &c)
 {
 	if(!is_xml()) {
-		if(saving) {
+		if(is_saving()) {
 			lsputc(c);
 		}
 		else {
@@ -1038,7 +743,7 @@ void loadsave_t::rdwr_byte(uint8 &c)
 void loadsave_t::rdwr_short(sint16 &i)
 {
 	if(!is_xml()) {
-		if (saving) {
+		if (is_saving()) {
 #ifdef SIM_BIG_ENDIAN
 			sint16 ii = endian(i);
 			write(&ii, sizeof(sint16));
@@ -1074,7 +779,7 @@ void loadsave_t::rdwr_short(uint16 &i)
 void loadsave_t::rdwr_long(sint32 &l)
 {
 	if(!is_xml()) {
-		if (saving) {
+		if (is_saving()) {
 #ifdef SIM_BIG_ENDIAN
 			uint32 ii = endian(l);
 			write(&ii, sizeof(uint32));
@@ -1110,7 +815,7 @@ void loadsave_t::rdwr_long(uint32 &l)
 void loadsave_t::rdwr_longlong(sint64 &ll)
 {
 	if(!is_xml()) {
-		if (saving) {
+		if (is_saving()) {
 #ifdef SIM_BIG_ENDIAN
 			sint64 ii = endian(ll);
 			write(&ii, sizeof(sint64));
@@ -1136,7 +841,7 @@ void loadsave_t::rdwr_longlong(sint64 &ll)
 void loadsave_t::rdwr_double(double &dbl)
 {
 	if(!is_xml()) {
-		if(saving) {
+		if(is_saving()) {
 			write(&dbl, sizeof(double));
 		}
 		else {
@@ -1155,7 +860,7 @@ void loadsave_t::rdwr_double(double &dbl)
 void loadsave_t::rdwr_bool(bool &i)
 {
 	if(  !is_xml()  ) {
-		if(saving) {
+		if(is_saving()) {
 			lsputc(i ? '1' : '0');
 		}
 		else {
@@ -1164,7 +869,7 @@ void loadsave_t::rdwr_bool(bool &i)
 	}
 	else {
 		// bool xml
-		if(saving) {
+		if(is_saving()) {
 			write( "                                                                ", min(64,ident) );
 			if(  i  ) {
 				write( "<bool>true</bool>\n", sizeof("<bool>true</bool>\n")-1 );
@@ -1199,7 +904,7 @@ void loadsave_t::rdwr_bool(bool &i)
 
 void loadsave_t::rdwr_xml_number(sint64 &s, const char *typ)
 {
-	if(saving) {
+	if(is_saving()) {
 		static char nr[256];
 		size_t len = sprintf( nr, "%*s<%s>%.0f</%s>\n", ident, "", typ, (double)s, typ );
 		write( nr, len );
@@ -1279,7 +984,7 @@ void loadsave_t::rdwr_str(const char *&s)
 {
 	if(!is_xml()) {
 		sint16 size;
-		if(saving) {
+		if(is_saving()) {
 			size = s ? (sint16)min(32767,strlen(s)) : 0;
 #ifdef SIM_BIG_ENDIAN
 			{
@@ -1317,7 +1022,7 @@ void loadsave_t::rdwr_str(const char *&s)
 	}
 	else {
 		// use CDATA tag: <![CDATA[%s]]>
-		if(saving) {
+		if(is_saving()) {
 			write( "                                                                ", min(64,ident) );
 			write( "<![CDATA[", 9 );
 			if(s) {
@@ -1342,7 +1047,7 @@ void loadsave_t::rdwr_str( char* result_buffer, size_t const size)
 {
 	if(!is_xml()) {
 		uint16 len;
-		if(saving) {
+		if(is_saving()) {
 			len = (uint16)min(32767,strlen(result_buffer));
 #ifdef SIM_BIG_ENDIAN
 			{
@@ -1367,7 +1072,7 @@ void loadsave_t::rdwr_str( char* result_buffer, size_t const size)
 	else {
 		// use CDATA tag: <![CDATA[%s]]>
 		char *s = result_buffer;
-		if(saving) {
+		if(is_saving()) {
 			write( "                                                                ", min(64,ident) );
 			write( "<![CDATA[", 9 );
 			if(s) {
@@ -1454,7 +1159,7 @@ void loadsave_t::rdwr_str(plainstring& s)
 void loadsave_t::start_tag(const char *tag)
 {
 	if(  is_xml()  ) {
-		if(saving) {
+		if(is_saving()) {
 			write( "                                                                ", min(64,ident) );
 			write( "<", 1 );
 			write( tag, strlen(tag) );
@@ -1478,7 +1183,7 @@ void loadsave_t::start_tag(const char *tag)
 void loadsave_t::end_tag(const char *tag)
 {
 	if(  is_xml()  ) {
-		if(saving) {
+		if(is_saving()) {
 			ident --;
 			write( "                                                                ", min(64,ident) );
 			write( "</", 2 );
@@ -1498,7 +1203,7 @@ void loadsave_t::end_tag(const char *tag)
 
 void loadsave_t::wr_obj_id(sint16 id)
 {
-	if(!saving) {
+	if(!is_saving()) {
 		dbg->fatal( "loadsave_t::wr_obj_id()", "must be only called during saving!" );
 	}
 	if(!is_xml()) {
@@ -1513,7 +1218,7 @@ void loadsave_t::wr_obj_id(sint16 id)
 
 sint16 loadsave_t::rd_obj_id()
 {
-	if(saving) {
+	if(is_saving()) {
 		dbg->fatal( "loadsave_t::rd_obj_id()", "must be only called during reading!" );
 		return INVALID_RDWR_ID;
 	}
@@ -1532,7 +1237,7 @@ sint16 loadsave_t::rd_obj_id()
 
 void loadsave_t::wr_obj_id(const char *id_text)
 {
-	if(saving) {
+	if(is_saving()) {
 		if(  !is_xml()  ) {
 			write( id_text, strlen(id_text) );
 			lsputc( 10 );
@@ -1548,7 +1253,7 @@ void loadsave_t::wr_obj_id(const char *id_text)
 
 void loadsave_t::rd_obj_id(char *id_buf, int size)
 {
-	if(!saving) {
+	if(!is_saving()) {
 		if(  !is_xml()  ) {
 			int i=0;
 			*id_buf = 0;
@@ -1586,7 +1291,7 @@ void loadsave_t::rd_obj_id(char *id_buf, int size)
 }
 
 
-loadsave_t::combined_version loadsave_t::int_version(const char *version_text, char *pak_extension_str)
+extended_version_t loadsave_t::int_version(const char *version_text, char *pak_extension_str)
 {
 	uint32 extended_version = 0;
 	// major number (0..)
@@ -1594,10 +1299,7 @@ loadsave_t::combined_version loadsave_t::int_version(const char *version_text, c
 	while(*version_text  &&  *version_text++ != '.')
 		;
 	if(!*version_text) {
-		combined_version dud;
-		dud.version = 0;
-		dud.extended_version = 0;
-		return dud;
+		return { 0, 0, 0 };
 	}
 
 	// middle number (.99.)
@@ -1605,10 +1307,7 @@ loadsave_t::combined_version loadsave_t::int_version(const char *version_text, c
 	while(*version_text  &&  *version_text++ != '.')
 		;
 	if(!*version_text) {
-		combined_version dud;
-		dud.version = 0;
-		dud.extended_version = 0;
-		return dud;
+		return { 0, 0, 0 };
 	}
 
 	// minor number (..08)
@@ -1685,10 +1384,5 @@ loadsave_t::combined_version loadsave_t::int_version(const char *version_text, c
 		*pak_extension_str = 0;
 	}
 
-	combined_version loadsave_version;
-	loadsave_version.version = version;
-	loadsave_version.extended_version = extended_version;
-	loadsave_version.extended_revision = EX_SAVE_MINOR;
-
-	return loadsave_version;
+	return { version, extended_version, EX_SAVE_MINOR };
 }

--- a/dataobj/loadsave.h
+++ b/dataobj/loadsave.h
@@ -11,6 +11,9 @@
 #include <string>
 
 #include "../simtypes.h"
+#include "../io/classify_file.h"
+#include "../io/rdwr/rdwr_stream.h"
+
 
 class plainstring;
 struct file_descriptors_t;
@@ -24,45 +27,46 @@ struct file_descriptors_t;
  */
 class loadsave_t
 {
-public:
-	enum mode_t {
-		binary=0,
-		text=1,
-		xml=2,
-		zipped=4,
-		xml_zipped=6,
-		bzip2=8,
-		xml_bzip2=10,
-		zstd=16,
-		xml_zstd=18
+private:
+	struct buf_t
+	{
+		size_t pos;
+		size_t len;
+		char *buf;
 	};
 
-	enum file_error_t {
-		FILE_ERROR_OK=0,
-		FILE_ERROR_NOT_EXISTING,
-		FILE_ERROR_BZ_CORRUPT,
-		FILE_ERROR_GZ_CORRUPT,
-		FILE_ERROR_NO_VERSION,
-		FILE_ERROR_FUTURE_VERSION,
-		FILE_ERROR_UNSUPPORTED_COMPRESSION
+public:
+	enum mode_t {
+		binary     = 0,
+		text       = 1 << 0,
+		xml        = 1 << 1,
+		zipped     = 1 << 2,
+		bzip2      = 1 << 3,
+		zstd       = 1 << 4,
+		xml_zipped = xml | zipped,
+		xml_bzip2  = xml | bzip2,
+		xml_zstd   = xml | zstd
+	};
+
+	enum file_status_t {
+		FILE_STATUS_OK = 0,
+		FILE_STATUS_ERR_NOT_EXISTING,
+		FILE_STATUS_ERR_CORRUPT,
+		FILE_STATUS_ERR_NO_VERSION,
+		FILE_STATUS_ERR_FUTURE_VERSION,
+		FILE_STATUS_ERR_UNSUPPORTED_COMPRESSION
 	};
 
 private:
-	file_error_t last_error;
 	int mode; ///< See mode_t
-	bool saving;
 	bool buffered;
 	unsigned curr_buff;
-	unsigned buf_pos[2];
-	unsigned buf_len[2];
-	char* ls_buf[2];
-	uint32 version; ///< savegame version
-	uint32 extended_version;
-	uint32 extended_revision; // Secondary saved game identifier for changing the save format without changing the major version.
-	int ident;		// only for XML formatting
-	char pak_extension[256];	// name of the pak folder during savetime
+	buf_t buff[2];
 
-	std::string filename;	// the current name ...
+	int ident;              // only for XML formatting
+	file_info_t finfo;
+
+	rdwr_stream_t *stream;
 
 	file_descriptors_t *fd;
 
@@ -87,13 +91,13 @@ private:
 	* Reads into buffer number @p buf_num.
 	* @returns number of bytes read or -1 in case of error
 	*/
-	int fill_buffer(int buf_num);
+	size_t fill_buffer(int buf_num);
 
 	void flush_buffer(int buf_num);
 
-public:
-	struct combined_version { uint32 version; uint32 extended_version; uint32 extended_revision; };
+	bool is_xml() const { return mode&xml; }
 
+public:
 	static mode_t save_mode;     ///< default to use for saving
 	static mode_t autosave_mode; ///< default to use for autosaves and network mode client temp saves
 	static int save_level;    ///< default to use for compression (various libraries allow for szie/speed settings)
@@ -107,16 +111,14 @@ public:
 	 * @retval !=0 the save version; in this case we can read the save file.
 	 */
 	//static uint32 int_version(const char *version_text, char *pak);
-	static combined_version int_version(const char *version_text, char *pak);
+	static extended_version_t int_version(const char *version_text, char *pak);
 
 	loadsave_t();
 	~loadsave_t();
 
-	bool rd_open(const char *filename);
-	bool wr_open(const char *filename, mode_t mode, int level, const char *pak_extension, const char *savegame_version, const char *savegame_version_ex, const char *savegame_revision_ex);
+	file_status_t rd_open(const char *filename);
+	file_status_t wr_open(const char *filename, mode_t mode, int level, const char *pak_extension, const char *savegame_version, const char *savegame_version_ex, const char *savegame_revision_ex);
 	const char *close();
-
-	file_error_t get_last_error() { return last_error; }
 
 	static void set_savemode(mode_t mode) { save_mode = mode; }
 	static void set_autosavemode(mode_t mode) { autosave_mode = mode; }
@@ -129,17 +131,14 @@ public:
 	bool is_eof();
 
 	void set_buffered(bool enable);
-	unsigned get_buf_pos(int buf_num) const { return buf_pos[buf_num]; }
-	bool is_loading() const { return !saving; }
-	bool is_saving() const { return saving; }
-	bool is_zipped() const { return mode&zipped; }
-	bool is_bzip2() const { return mode&bzip2; }
-	bool is_zstd() const { return mode&zstd; }
-	bool is_xml() const { return mode&xml; }
-	uint32 get_version_int() const { return version; }
-	uint32 get_extended_version() const { return extended_version; }
-	uint32 get_extended_revision() const { return extended_revision; }
-	const char *get_pak_extension() const { return pak_extension; }
+	unsigned get_buf_pos(int buf_num) const { return buff[buf_num].pos; }
+	bool is_loading() const { return stream && !stream->is_writing(); }
+	bool is_saving() const { return stream && stream->is_writing(); }
+	const char *get_pak_extension() const { return finfo.pak_extension; }
+
+	uint32 get_version_int() const { return finfo.ext_version.version; }
+	uint32 get_extended_version() const { return finfo.ext_version.extended_version; }
+	uint32 get_extended_revision() const { return finfo.ext_version.extended_revision; }
 
 	void rdwr_byte(sint8 &c);
 	void rdwr_byte(uint8 &c);

--- a/dataobj/settings.cc
+++ b/dataobj/settings.cc
@@ -2065,7 +2065,7 @@ void settings_t::parse_simuconf(tabfile_t& simuconf, sint16& disp_width, sint16&
 	env_t::network_frames_per_step = contents.get_int("server_frames_per_step", env_t::network_frames_per_step );
 	env_t::server_sync_steps_between_checks = contents.get_int("server_frames_between_checks", env_t::server_sync_steps_between_checks );
 	env_t::pause_server_no_clients = contents.get_int("pause_server_no_clients", env_t::pause_server_no_clients );
-	env_t::server_runs_background_tasks_when_paused = contents.get_int("server_runs_background_tasks_when_paused", env_t::server_runs_background_tasks_when_paused); 
+	env_t::server_runs_background_tasks_when_paused = contents.get_int("server_runs_background_tasks_when_paused", env_t::server_runs_background_tasks_when_paused);
 	env_t::server_save_game_on_quit = contents.get_int("server_save_game_on_quit", env_t::server_save_game_on_quit );
 	env_t::reload_and_save_on_quit = contents.get_int("reload_and_save_on_quit", env_t::reload_and_save_on_quit );
 

--- a/gui/loadsave_frame.cc
+++ b/gui/loadsave_frame.cc
@@ -150,7 +150,7 @@ loadsave_frame_t::loadsave_frame_t(bool do_load) : savegame_frame_t(".sve", fals
 		remove( SAVE_PATH_X "_load_cached_exp.xml" );
 		rename( SAVE_PATH_X "_cached_exp.xml", SAVE_PATH_X "_load_cached_exp.xml" );
 		const char *cache_file = SAVE_PATH_X "_load_cached_exp.xml";
-		if (file.rd_open(cache_file) && file.get_extended_version() == EX_VERSION_MAJOR) {
+		if (file.rd_open(cache_file) == loadsave_t::FILE_STATUS_OK && file.get_extended_version() == EX_VERSION_MAJOR) {
 			// ignore comment
 			const char *text=NULL;
 			file.rdwr_str(text);
@@ -202,7 +202,7 @@ void loadsave_frame_t::add_file(const char *fullpath, const char *filename, cons
 	file_table.add_row( new gui_loadsave_table_row_t( fullpath, buttontext ));
 }
 
-/*
+
 gui_loadsave_table_row_t::gui_loadsave_table_row_t(const char *pathname, const char *buttontext) : gui_file_table_row_t(pathname, buttontext)
 {
 	if (error.empty()) {
@@ -342,7 +342,7 @@ const char *loadsave_frame_t::get_info(const char *fname)
 		/*
 		// read pak_extension from file
 		loadsave_t test;
-		test.rd_open(fname);
+		test.rd_open(fname); // == loadsave_t::FILE_STATUS_OK
 		// add pak extension
 		pak_extension = test.get_pak_extension();
 
@@ -378,7 +378,7 @@ loadsave_frame_t::~loadsave_frame_t()
 	// save hashtable
 	loadsave_t file;
 	const char *cache_file = SAVE_PATH_X "_cached_exp.xml";
-	if(  file.wr_open(cache_file, loadsave_t::xml, 0, "cache", SAVEGAME_VER_NR, EXTENDED_VER_NR, EXTENDED_REVISION_NR)  )
+	if(  file.wr_open(cache_file, loadsave_t::xml, 0, "cache", SAVEGAME_VER_NR, EXTENDED_VER_NR, EXTENDED_REVISION_NR) == loadsave_t::FILE_STATUS_OK  )
 	{
 		const char *text="Automatically generated file. Do not edit. An invalid file may crash the game. Deleting is allowed though.";
 		file.rdwr_str(text);

--- a/gui/settings_frame.cc
+++ b/gui/settings_frame.cc
@@ -126,7 +126,7 @@ bool settings_frame_t::action_triggered( gui_action_creator_t *comp, value_t )
 		// load settings of last generated map
 		loadsave_t file;
 		dr_chdir( env_t::user_dir  );
-		if(  file.rd_open("default.sve")  ) {
+		if(  file.rd_open("default.sve") == loadsave_t::FILE_STATUS_OK  ) {
 			sets->rdwr(&file);
 			file.close();
 		}

--- a/gui/settings_stats.cc
+++ b/gui/settings_stats.cc
@@ -227,8 +227,8 @@ void settings_extended_general_stats_t::init( settings_t *sets )
 
 	SEPERATOR;
 
-	INIT_BOOL("pause_server_no_clients", env_t::pause_server_no_clients); 
-	INIT_BOOL("server_runs_background_tasks_when_paused", env_t::server_runs_background_tasks_when_paused); 
+	INIT_BOOL("pause_server_no_clients", env_t::pause_server_no_clients);
+	INIT_BOOL("server_runs_background_tasks_when_paused", env_t::server_runs_background_tasks_when_paused);
 
 	SEPERATOR;
 
@@ -338,7 +338,7 @@ void settings_extended_general_stats_t::read(settings_t *sets)
 	READ_BOOL_VALUE(sets->save_path_explorer_data);
 
 	READ_BOOL_VALUE(env_t::pause_server_no_clients);
-	READ_BOOL_VALUE(env_t::server_runs_background_tasks_when_paused); 
+	READ_BOOL_VALUE(env_t::server_runs_background_tasks_when_paused);
 
 	READ_BOOL_VALUE(sets->show_future_vehicle_info);
 

--- a/gui/simwin.cc
+++ b/gui/simwin.cc
@@ -1587,12 +1587,12 @@ void win_poll_event(event_t* const ev)
 	if(  ev->ev_class==EVENT_SYSTEM  &&  ev->ev_code==SYSTEM_RELOAD_WINDOWS  ) {
 		dr_chdir( env_t::user_dir );
 		loadsave_t dlg;
-		if(  dlg.wr_open( "dlgpos.xml", loadsave_t::xml_zipped, 1, "temp", SERVER_SAVEGAME_VER_NR, EXTENDED_VER_NR, EXTENDED_REVISION_NR )  ) {
+		if(  dlg.wr_open( "dlgpos.xml", loadsave_t::xml_zipped, 1, "temp", SERVER_SAVEGAME_VER_NR, EXTENDED_VER_NR, EXTENDED_REVISION_NR ) == loadsave_t::FILE_STATUS_OK   ) {
 			// save all
 			rdwr_all_win( &dlg );
 			dlg.close();
 			destroy_all_win( true );
-			if(  dlg.rd_open( "dlgpos.xml" )  ) {
+			if(  dlg.rd_open( "dlgpos.xml" ) == loadsave_t::FILE_STATUS_OK  ) {
 				// and reload them ...
 				rdwr_all_win( &dlg );
 			}

--- a/gui/welt.cc
+++ b/gui/welt.cc
@@ -593,7 +593,7 @@ bool welt_gui_t::action_triggered( gui_action_creator_t *comp,value_t v)
 		welt->set_pause(false);
 		// save setting ...
 		loadsave_t file;
-		if(file.wr_open("default.sve",loadsave_t::binary,0,"settings only",SAVEGAME_VER_NR, EXTENDED_VER_NR, EXTENDED_REVISION_NR)) {
+		if(file.wr_open("default.sve",loadsave_t::binary,0,"settings only",SAVEGAME_VER_NR, EXTENDED_VER_NR, EXTENDED_REVISION_NR) == loadsave_t::FILE_STATUS_OK) {
 			// save default setting
 			env_t::default_settings.rdwr(&file);
 			welt->set_scale();

--- a/io/classify_file.cc
+++ b/io/classify_file.cc
@@ -1,0 +1,282 @@
+/*
+ * This file is part of the Simutrans project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#include "classify_file.h"
+
+#include "rdwr/bzip2_file_rdwr_stream.h"
+#include "rdwr/raw_file_rdwr_stream.h"
+#include "rdwr/zlib_file_rdwr_stream.h"
+#if USE_ZSTD
+#include "rdwr/zstd_file_rdwr_stream.h"
+#endif
+
+#include "../dataobj/loadsave.h"
+#include "../simdebug.h"
+#include "../simversion.h"
+#include "../sys/simsys.h"
+#include "../utils/simstring.h"
+#include "../macros.h"
+
+#include <cstring>
+
+
+const extended_version_t extended_version_t::INVALID = extended_version_t();
+
+
+bool classify_as_zstd(FILE *f, file_info_t *info);
+bool classify_as_bzip2(FILE *f, file_info_t *info);
+bool classify_as_zip(FILE *f, file_info_t *info);
+bool classify_file_data(rdwr_stream_t *stream, file_info_t *info);
+
+
+file_info_t::file_info_t() :
+	file_type(TYPE_RAW),
+	header_size(0)
+{
+	pak_extension[0] = 0;
+}
+
+
+file_info_t::file_info_t(file_type_t file_type, extended_version_t version) :
+	file_type(file_type),
+	ext_version(version)
+{
+	pak_extension[0] = 0;
+}
+
+
+file_classify_status_t classify_file(const char *path, file_info_t *info)
+{
+	if (!info) {
+		dbg->error("classify_file()", "Cannot classify file: info is NULL");
+		return FILE_CLASSIFY_INVALID_ARGS;
+	}
+	else if(  !path  ||  !*path  ) {
+		dbg->error("classify_file()", "Invalid path");
+		return FILE_CLASSIFY_INVALID_ARGS;
+	}
+
+	FILE *f = dr_fopen((const char *)path, "rb");
+
+	if (!f) {
+		// Do not warn about this since we can also use this function to check whether a file exists
+		return FILE_CLASSIFY_NOT_EXISTING;
+	}
+
+	fseek(f, 0, SEEK_SET);
+	if (classify_as_zstd(f, info)) {
+		fclose(f);
+
+#if USE_ZSTD // otherwise we cannot read it
+		zstd_file_rdwr_stream_t s(path, false, 0);
+		if (!classify_file_data(&s, info)) {
+			info->file_type = file_info_t::TYPE_RAW;
+			info->ext_version = extended_version_t::INVALID;
+			info->header_size = 0;
+		}
+		return FILE_CLASSIFY_OK;
+#else
+		dbg->fatal( "classify_file()", "Compiled without zstd support but zstd savegame!" );
+#endif
+	}
+
+	fseek(f, 0, SEEK_SET);
+	if (classify_as_bzip2(f, info)) {
+		fclose(f);
+
+		bzip2_file_rdwr_stream_t s(path, false);
+		if (!classify_file_data(&s, info)) {
+			info->file_type = file_info_t::TYPE_RAW;
+			info->ext_version = extended_version_t::INVALID;
+			info->header_size = 0;
+		}
+
+		return FILE_CLASSIFY_OK;
+	}
+
+	fseek(f, 0, SEEK_SET);
+	if (classify_as_zip(f, info)) {
+		fclose(f);
+
+		zlib_file_rdwr_stream_t s(path, false, 0);
+		if (!classify_file_data(&s, info)) {
+			info->file_type = file_info_t::TYPE_RAW;
+			info->ext_version = extended_version_t::INVALID;
+			info->header_size = 0;
+		}
+
+		return FILE_CLASSIFY_OK;
+	}
+
+	fseek(f, 0, SEEK_SET);
+
+	raw_file_rdwr_stream_t s(f, false);
+	if (!classify_file_data(&s, info)) {
+		info->file_type = file_info_t::TYPE_RAW;
+		info->ext_version = extended_version_t::INVALID;
+		info->header_size = 0;
+	}
+
+	return FILE_CLASSIFY_OK;
+}
+
+
+bool classify_as_bzip2(FILE *f, file_info_t *info)
+{
+	char buf[80];
+	if (fread(buf, 1, 2, f) != 2) {
+		return false;
+	}
+
+	if(  memcmp(buf, "BZ", 2) != 0) {
+		return false; // not bzip2 compressed
+	}
+
+	info->file_type = file_info_t::TYPE_BZIP2;
+	return true;
+}
+
+
+bool classify_as_zstd(FILE *f, file_info_t *info)
+{
+	char buf[80];
+	if (fread(buf, 1, 2, f) != 2) {
+		return false;
+	}
+
+	if(  memcmp(buf, "ZD", 2) != 0) {
+		return false; // not zstd compressed
+	}
+
+	info->file_type = file_info_t::TYPE_ZSTD;
+	return true;
+}
+
+
+bool classify_as_zip(FILE *f, file_info_t *info)
+{
+	char buf[80];
+	if (fread(buf, 1, 2, f) != 2) {
+		return false;
+	}
+
+	if(  memcmp(buf, "\x1f\x8b", 2) != 0  &&  buf[0] != 0x78  ) {
+		return false; // not zlib/gzip compressed
+	}
+
+	info->file_type = file_info_t::TYPE_ZIPPED;
+	return true;
+}
+
+
+bool classify_file_data(rdwr_stream_t *stream, file_info_t *info)
+{
+	char buf[80];
+	MEMZERO(buf);
+
+	if(  stream->read( buf, sizeof( SAVEGAME_PREFIX ) ) != sizeof( SAVEGAME_PREFIX )  ) {
+		info->ext_version = extended_version_t::INVALID;
+		return false; // file too short
+	}
+
+	info->header_size = sizeof(SAVEGAME_PREFIX);
+
+	// get the rest of the string
+	for( int i = sizeof( SAVEGAME_PREFIX ); i < 79; ) {
+		char ch;
+		stream->read(&ch, 1);
+		info->header_size++;
+		if( ch < ' ' ) {
+			break;
+		}
+		buf[ i++ ] = (char)ch;
+		buf[ i ] = 0;
+	}
+
+	if (strstart(buf, SAVEGAME_PREFIX)) {
+		info->ext_version = loadsave_t::int_version(buf + sizeof(SAVEGAME_PREFIX) - 1, info->pak_extension);
+		if(  info->ext_version.version == 0  ) {
+			info->ext_version = extended_version_t::INVALID;
+			return false;
+		}
+	}
+	else if (strstart(buf, XML_SAVEGAME_PREFIX)) {
+		info->file_type |= file_info_t::TYPE_XML;
+
+		char ch;
+		do {
+			info->header_size++;
+			stream->read(&ch, 1);
+		} while (ch != '<');
+
+		stream->read(buf, sizeof(SAVEGAME_PREFIX) - 1);
+		info->header_size += sizeof(SAVEGAME_PREFIX) -1;
+
+		if (!strstart(buf, SAVEGAME_PREFIX)) {
+			// not a simutrans XML file ...
+			info->ext_version = extended_version_t::INVALID;
+			return false;
+		}
+
+		stream->read(buf, sizeof("version=\"") - 1);
+		info->header_size += sizeof("version=\"") - 1;
+
+		char str[256];
+		char *s = str;
+		for (int i = 0; i < 255; i++) {
+			char c;
+			stream->read(&c, 1);
+			info->header_size++;
+			if (c=='\"') {
+				break;
+			}
+			*s++ = c;
+		}
+		*s = 0;
+
+		info->ext_version = loadsave_t::int_version(str, info->pak_extension);
+		if(  info->ext_version.version == 0  ) {
+			info->ext_version = extended_version_t::INVALID;
+			info->header_size = 0;
+			return false;
+		}
+
+		stream->read(buf, sizeof(" pak=\"") - 1);
+		info->header_size += sizeof(" pak=\"") - 1;
+
+		if (info->ext_version.version > 0) {
+			s = info->pak_extension;
+			for (int i = 0; i < 63; i++) {
+				char c;
+				stream->read(&c, 1);
+				info->header_size++;
+
+				if (c=='\"') {
+					break;
+				}
+				*s++ = c;
+			}
+			*s = 0;
+
+			char c;
+			do {
+				info->header_size++;
+				stream->read(&c, 1);
+			} while (c != '>');
+		}
+	}
+	else {
+		// not a Simutrans specific file
+		info->ext_version = extended_version_t::INVALID;
+		info->header_size = 0;
+		return false;
+	}
+
+	if(*info->pak_extension == 0) {
+		strcpy( info->pak_extension, "(unknown)" );
+	}
+
+	return true;
+}

--- a/io/classify_file.h
+++ b/io/classify_file.h
@@ -1,0 +1,74 @@
+/*
+ * This file is part of the Simutrans project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#ifndef IO_CLASSIFY_FILE_H
+#define IO_CLASSIFY_FILE_H
+
+
+#include "../unicode.h"
+#include "../simtypes.h"
+
+
+enum file_classify_status_t {
+	FILE_CLASSIFY_OK = 0,
+	FILE_CLASSIFY_INVALID_ARGS,
+	FILE_CLASSIFY_NOT_EXISTING
+};
+
+
+#define INVALID_FILE_VERSION 0xFFFFFFFFu
+
+
+struct extended_version_t
+{
+public:
+	extended_version_t() : version(INVALID_FILE_VERSION), extended_version(0), extended_revision(0) {}
+	extended_version_t(uint32 version, uint32 extended_version, uint32 extended_revision) : version(version), extended_version(extended_version), extended_revision(extended_revision) {}
+
+	static const extended_version_t INVALID;
+
+public:
+	uint32 version;
+	uint32 extended_version;
+	uint32 extended_revision;
+};
+
+struct file_info_t
+{
+	enum file_type_t {
+		TYPE_RAW        = 0, // either raw binary or text (dat etc)
+		TYPE_XML        = 1 << 1,
+		TYPE_ZIPPED     = 1 << 2,
+		TYPE_BZIP2      = 1 << 3,
+		TYPE_ZSTD       = 1 << 4,
+		TYPE_XML_ZIPPED = TYPE_XML | TYPE_ZIPPED,
+		TYPE_XML_BZIP2  = TYPE_XML | TYPE_BZIP2,
+		TYPE_XML_ZSTD   = TYPE_XML | TYPE_ZSTD
+	};
+
+public:
+	file_info_t();
+	explicit file_info_t(file_type_t file_type, extended_version_t version = extended_version_t());
+
+public:
+	file_type_t file_type;
+	extended_version_t ext_version;
+	char pak_extension[256]; ///< Pak extension of saved game.
+	size_t header_size;      ///< Header size in bytes
+};
+ENUM_BITSET(file_info_t::file_type_t);
+
+
+/**
+ * Classify a file.
+ * @param path must a valid system name, either a short name for windows or UTF8 for other plattforms
+ * @param file_info_t If successfully classified, holds information about file format and version.
+ *                    Must not be NULL.
+ * @returns FILE_ERROR_OK iff successfully classified.
+ */
+file_classify_status_t classify_file(const char *path, file_info_t *info);
+
+
+#endif

--- a/io/rdwr/bzip2_file_rdwr_stream.cc
+++ b/io/rdwr/bzip2_file_rdwr_stream.cc
@@ -1,0 +1,75 @@
+/*
+ * This file is part of the Simutrans project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#include "bzip2_file_rdwr_stream.h"
+
+#include "../../sys/simsys.h"
+
+#include <cassert>
+
+
+bzip2_file_rdwr_stream_t::bzip2_file_rdwr_stream_t(const std::string &filename, bool writing) :
+	rdwr_stream_t(writing)
+{
+	if (is_writing()) {
+		fp = dr_fopen(filename.c_str(), "wb");
+		bzfp = BZ2_bzWriteOpen( &bse, fp, 9, 0, 30 /* default is 30 */ );
+	}
+	else {
+		fp = dr_fopen(filename.c_str(), "rb");
+		bzfp = BZ2_bzReadOpen( &bse, fp, 0, 0, NULL, 0 );
+	}
+
+	if(  bse!=BZ_OK  ) {
+		status = STATUS_ERR_CORRUPT;
+	}
+
+	status = STATUS_OK;
+}
+
+
+bzip2_file_rdwr_stream_t::~bzip2_file_rdwr_stream_t()
+{
+	if (is_writing()) {
+		// BZLIB seems to eat the last byte if it is at an odd position
+		// => we just write a dummy zero padding byte
+		write( "", 1 );
+		BZ2_bzWriteClose( &bse, bzfp, 0, NULL, NULL );
+	}
+	else {
+		BZ2_bzReadClose( &bse, bzfp );
+	}
+
+	fclose( fp );
+}
+
+
+size_t bzip2_file_rdwr_stream_t::read(void *buf, size_t len)
+{
+	assert(!is_writing());
+	assert(bse == BZ_OK || bse == BZ_STREAM_END);
+	assert(len < 0x7FFFFFFFU);
+
+	const int bytes_read = (bse == BZ_OK) ? BZ2_bzRead(&bse, bzfp, buf, len) : 0;
+
+	switch (bse) {
+	case BZ_OK:         status = STATUS_OK;          return bytes_read;
+	case BZ_STREAM_END: status = STATUS_EOF;         return bytes_read;
+	default:            status = STATUS_ERR_CORRUPT; return 0;
+	}
+}
+
+
+size_t bzip2_file_rdwr_stream_t::write(const void* buf, size_t len)
+{
+	assert(is_writing());
+	assert(bse==BZ_OK);
+
+	BZ2_bzWrite( &bse, bzfp, const_cast<void *>(buf), len);
+	assert(bse==BZ_OK);
+
+	return len;
+}
+

--- a/io/rdwr/bzip2_file_rdwr_stream.h
+++ b/io/rdwr/bzip2_file_rdwr_stream.h
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the Simutrans project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#ifndef IO_RDWR_BZIP2_FILE_RDWR_STREAM_H
+#define IO_RDWR_BZIP2_FILE_RDWR_STREAM_H
+
+
+#include "rdwr_stream.h"
+
+#include <bzlib.h>
+
+
+/// Reads/writes data from/to a bzip2 compressed file.
+class bzip2_file_rdwr_stream_t : public rdwr_stream_t
+{
+public:
+	bzip2_file_rdwr_stream_t(const std::string &filename, bool writing);
+	~bzip2_file_rdwr_stream_t();
+
+public:
+	/// @copydoc rdwr_stream_t::read
+	size_t read(void *buf, size_t len) OVERRIDE;
+
+	/// @copydoc rdwr_stream_t::write
+	size_t write(const void *buf, size_t len) OVERRIDE;
+
+private:
+	FILE *fp;
+	BZFILE *bzfp;
+	int bse;
+};
+
+
+#endif

--- a/io/rdwr/raw_file_rdwr_stream.cc
+++ b/io/rdwr/raw_file_rdwr_stream.cc
@@ -1,0 +1,84 @@
+/*
+ * This file is part of the Simutrans project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#include "raw_file_rdwr_stream.h"
+
+#include "../../sys/simsys.h"
+
+#include <cassert>
+
+
+raw_file_rdwr_stream_t::raw_file_rdwr_stream_t(const std::string &filename, bool writing) :
+	rdwr_stream_t(writing)
+{
+	file = dr_fopen(filename.c_str(), writing ? "wb" : "rb");
+	if (!file) {
+		status = STATUS_ERR_NOT_EXISTING;
+	}
+
+	status = STATUS_OK;
+}
+
+
+raw_file_rdwr_stream_t::raw_file_rdwr_stream_t(FILE *f, bool writing) :
+	rdwr_stream_t(writing),
+	file(f)
+{
+	if (!file) {
+		status = STATUS_ERR_NOT_EXISTING;
+	}
+	else if (ferror(file)) {
+		status = STATUS_ERR_CORRUPT;
+	}
+	else if (feof(file)) {
+		status = STATUS_EOF;
+	}
+	else {
+		status = STATUS_OK;
+	}
+}
+
+
+raw_file_rdwr_stream_t::~raw_file_rdwr_stream_t()
+{
+	fflush(file);
+	fclose(file);
+}
+
+
+size_t raw_file_rdwr_stream_t::read(void *buf, size_t len)
+{
+	assert(!is_writing());
+	const size_t bytes_read = fread(buf, 1, len, file);
+
+	if (bytes_read == len) {
+		status = STATUS_OK;
+		return bytes_read;
+	}
+	else if (feof(file)) {
+		status = STATUS_EOF;
+		return bytes_read;
+	}
+	else {
+		status = STATUS_ERR_CORRUPT;
+		return 0;
+	}
+}
+
+
+size_t raw_file_rdwr_stream_t::write(const void *buf, size_t len)
+{
+	assert(is_writing());
+	const size_t bytes_written = fwrite(buf, 1, len, file);
+
+	if (bytes_written == len) {
+		status = STATUS_OK;
+	}
+	else {
+		status = STATUS_ERR_FULL;
+	}
+
+	return bytes_written;
+}

--- a/io/rdwr/raw_file_rdwr_stream.h
+++ b/io/rdwr/raw_file_rdwr_stream.h
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the Simutrans project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#ifndef IO_RDWR_RAW_FILE_RDWR_STREAM_H
+#define IO_RDWR_RAW_FILE_RDWR_STREAM_H
+
+
+#include "rdwr_stream.h"
+
+#include <cstdio>
+
+
+/// Reads/writes raw data from/to a file.
+class raw_file_rdwr_stream_t : public rdwr_stream_t
+{
+public:
+	raw_file_rdwr_stream_t(const std::string &filename, bool writing);
+
+	/// Takes ownership of an already open file.
+	/// @p writing must match the mode with which the file was opened.
+	raw_file_rdwr_stream_t(FILE *f, bool writing);
+
+	~raw_file_rdwr_stream_t();
+
+public:
+	/// @copydoc rdwr_stream_t::read
+	size_t read(void *buf, size_t len) OVERRIDE;
+
+	/// @copydoc rdwr_stream_t::write
+	size_t write(const void *buf, size_t len) OVERRIDE;
+
+private:
+	FILE *file;
+};
+
+
+#endif

--- a/io/rdwr/rdwr_stream.cc
+++ b/io/rdwr/rdwr_stream.cc
@@ -1,0 +1,13 @@
+/*
+ * This file is part of the Simutrans project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#include "rdwr_stream.h"
+
+
+rdwr_stream_t::rdwr_stream_t(bool writing) :
+	status(STATUS_INVALID),
+	writing(writing)
+{
+}

--- a/io/rdwr/rdwr_stream.h
+++ b/io/rdwr/rdwr_stream.h
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the Simutrans project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#ifndef IO_RDWR_RDWR_STREAM_H
+#define IO_RDWR_RDWR_STREAM_H
+
+
+#include "../../simtypes.h"
+
+#include <string>
+
+
+/// Either reads or writes data (but not both at the same time).
+class rdwr_stream_t
+{
+public:
+	/// Note: On failure, this does not throw. Instead, call @ref get_status() to check if
+	/// @ref read() or @ref write() can be called. Derived classes must update @ref status accordingly.
+	rdwr_stream_t(bool writing);
+	virtual ~rdwr_stream_t() {}
+
+public:
+	enum status_t
+	{
+		STATUS_INVALID = -1,     ///< Not initialized
+		STATUS_OK = 0,
+		STATUS_EOF,              ///< (when reading) end of file/buffer reached
+		STATUS_ERR_NOT_EXISTING, ///< (when reading) File does not exist
+		STATUS_ERR_FULL,         ///< (when writing) No space left in buffer or hard drive
+		STATUS_ERR_NO_VERSION,
+		STATUS_ERR_FUTURE_VERSION,
+		STATUS_ERR_DEPRECATED,   ///< Version too old
+		STATUS_ERR_CORRUPT       ///< ex.: file malformed, file no longer accessible
+	};
+
+	status_t get_status() const { return status; }
+	bool is_writing() const { return writing; }
+	bool is_reading() const { return !writing; }
+
+public:
+	/// Read at most @p len bytes into @p buf; must not be called when writing.
+	/// If this function fails, call @ref get_status() to get information about the type of error.
+	///
+	/// @param buf Must not be NULL.
+	/// @param len Must not be 0.
+	///
+	/// @returns @p len, if successful.
+	/// @returns The number of bytes successfully read, if end-of-data occurs.
+	/// @returns Undefined (but not @p len), if an error occurred.
+	virtual size_t read(void *buf, size_t len) = 0;
+
+	/// Write at most @p len bytes from @p buf; must not be called when reading.
+	/// If this function fails, call @ref get_status() to get information about the type of error.
+	///
+	/// @param buf Must not be NULL.
+	/// @param len Must not be 0.
+	///
+	/// @returns @p len, if successful.
+	/// @returns Undefined (but not @p len), if an error occurred.
+	virtual size_t write(const void *buf, size_t len) = 0;
+
+protected:
+	/// @warning This must be updated to the correct value when @p read() or @p write() or the constructor fails.
+	status_t status;
+
+private:
+	const bool writing;
+};
+
+
+#endif

--- a/io/rdwr/zlib_file_rdwr_stream.cc
+++ b/io/rdwr/zlib_file_rdwr_stream.cc
@@ -1,0 +1,85 @@
+/*
+ * This file is part of the Simutrans project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#include "zlib_file_rdwr_stream.h"
+
+#include "../../sys/simsys.h"
+#include "../../macros.h"
+#include "../../simdebug.h"
+
+#include <cassert>
+
+
+zlib_file_rdwr_stream_t::zlib_file_rdwr_stream_t(const std::string &filename, bool writing, int compression) :
+	rdwr_stream_t(writing)
+{
+	if (is_writing()) {
+		compression = clamp( compression, 1, 9 );
+		char compr[4] = { 'w', 'b', (char)('0' + compression), 0 };
+		gzfp = dr_gzopen(filename.c_str(), compr);
+	}
+	else {
+		gzfp = dr_gzopen(filename.c_str(), "rb");
+	}
+	gzbuffer(gzfp, 65536);
+	status = STATUS_OK;
+}
+
+
+zlib_file_rdwr_stream_t::~zlib_file_rdwr_stream_t()
+{
+	if (is_writing()) {
+		gzflush(gzfp, Z_FINISH);
+	}
+
+	gzclose(gzfp);
+}
+
+
+size_t zlib_file_rdwr_stream_t::read(void *buf, size_t len)
+{
+	assert(!is_writing());
+
+	const int bytes_read = gzread(gzfp, buf, len);
+
+	if (bytes_read >= 0 && (size_t)bytes_read == len) {
+		status = STATUS_OK;
+		return bytes_read;
+	}
+	else if (bytes_read != -1) {
+		// not error => eof reached
+		status = STATUS_EOF;
+		return bytes_read;
+	}
+	else {
+		// error
+		int errnum = 0;
+		const char *errmsg = gzerror(gzfp, &errnum);
+		if (!errmsg) errmsg = "<unknown error>";
+
+		dbg->error("zlib_file_rdwr_stream_t::read", "Error: %s", errmsg);
+
+		status = STATUS_ERR_CORRUPT;
+		return 0;
+	}
+}
+
+
+size_t zlib_file_rdwr_stream_t::write(const void *buf, size_t len)
+{
+	assert(is_writing());
+	const int bytes_written = gzwrite(gzfp, const_cast<void *>(buf), len);
+
+	if (bytes_written == 0) {
+		status = STATUS_ERR_FULL;
+		return 0;
+	}
+	else {
+		status = STATUS_OK;
+		return bytes_written;
+	}
+}
+
+

--- a/io/rdwr/zlib_file_rdwr_stream.h
+++ b/io/rdwr/zlib_file_rdwr_stream.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the Simutrans project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#ifndef IO_RDWR_ZLIB_FILE_RDWR_STREAM_H
+#define IO_RDWR_ZLIB_FILE_RDWR_STREAM_H
+
+
+#include "rdwr_stream.h"
+
+#include <zlib.h>
+
+
+/// Reads/writes data from/to a zlib/gzip (deflate) compressed file.
+class zlib_file_rdwr_stream_t : public rdwr_stream_t
+{
+public:
+	zlib_file_rdwr_stream_t(const std::string &filename, bool writing, int compression);
+	~zlib_file_rdwr_stream_t();
+
+public:
+	/// @copydoc rdwr_stream_t::read
+	size_t read(void *buf, size_t len) OVERRIDE;
+
+	/// @copydoc rdwr_stream_t::write
+	size_t write(const void *buf, size_t len) OVERRIDE;
+
+private:
+	gzFile gzfp;
+};
+
+
+#endif

--- a/io/rdwr/zstd_file_rdwr_stream.cc
+++ b/io/rdwr/zstd_file_rdwr_stream.cc
@@ -1,0 +1,211 @@
+/*
+ * This file is part of the Simutrans project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#include "zstd_file_rdwr_stream.h"
+
+#include "../../dataobj/environment.h"
+#include "../../simdebug.h"
+#include "../../simmem.h"
+
+
+#define ZSTD_FILE_BUF_SIZE (1 << 20) // 1MiB
+
+
+zstd_file_rdwr_stream_t::zstd_file_rdwr_stream_t(const std::string &filename, bool writing, int compression_level) :
+	raw_file_rdwr_stream_t(filename, writing),
+	zbuff(NULL)
+{
+	if (status != STATUS_OK) {
+		return; // Could not open file
+	}
+
+	if (writing) {
+		// compressing
+		compression_context = ZSTD_createCCtx();
+		if(  compression_context == NULL  ) {
+			// zstd could not init
+			status = STATUS_ERR_CORRUPT;
+			return;
+		}
+
+		size_t ret1 = ZSTD_CCtx_setParameter( compression_context, ZSTD_c_compressionLevel, compression_level );
+		if (ZSTD_isError(ret1)) {
+			dbg->error("zstd_file_rdwr_stream_t::zstd_file_rdwr_stream_t", "Cannot set compression level: %s", ZSTD_getErrorName(ret1));
+			status = STATUS_ERR_CORRUPT;
+			return;
+		}
+
+// 		const size_t ret2 = ZSTD_CCtx_setParameter( compression_context, ZSTD_c_checksumFlag, 1 );
+// 		if (ZSTD_isError(ret2)) {
+// 			dbg->error("zstd_file_rdwr_stream_t::zstd_file_rdwr_stream_t", "Cannot enable file checksumming: %s", ZSTD_getErrorName(ret2));
+// 			status = STATUS_ERR_CORRUPT;
+// 			return;
+// 		}
+
+		// the additional magic for zstd
+		if (raw_file_rdwr_stream_t::write("ZD", 2) != 2) {
+			return;
+		}
+
+#if MULTI_THREAD
+		ret1 = ZSTD_CCtx_setParameter( compression_context, ZSTD_c_nbWorkers, env_t::num_threads );
+		if (ZSTD_isError(ret1)) {
+			dbg->error("zstd_file_rdwr_stream_t::zstd_file_rdwr_stream_t", "Cannot set wrokers: %s", ZSTD_getErrorName(ret1));
+			status = STATUS_ERR_CORRUPT;
+			return;
+		}
+#endif
+	}
+	else {
+		// decompressing
+		decompression_context = ZSTD_createDCtx();
+
+		if (decompression_context == NULL) {
+			status = STATUS_ERR_CORRUPT;
+			return;
+		}
+
+		char buf[2];
+		if (raw_file_rdwr_stream_t::read(buf, 2) != 2) {
+			status = STATUS_ERR_CORRUPT;
+			return;
+		}
+		else if (buf[0] != 'Z' || buf[1] != 'D') {
+			status = STATUS_ERR_CORRUPT;
+			return;
+		}
+	}
+
+	zbuff = xmalloc(ZSTD_FILE_BUF_SIZE);
+
+	if (writing) {
+		zin.src = NULL;
+		zin.size = 0;
+		zin.pos = 0;
+
+		zout.dst = zbuff;
+		zout.size = ZSTD_FILE_BUF_SIZE;
+		zout.pos = 0;
+	}
+	else {
+		zin.src = zbuff;
+		zin.size = ZSTD_FILE_BUF_SIZE;
+		zin.pos = ZSTD_FILE_BUF_SIZE;
+
+		zout.dst = NULL;
+		zout.size = 0;
+		zout.pos = 0;
+	}
+
+	status = STATUS_OK;
+}
+
+
+zstd_file_rdwr_stream_t::~zstd_file_rdwr_stream_t()
+{
+	if (is_writing()) {
+		// write zero length dummy to indicate end of data
+		zin.src = "";
+		zin.size = 0;
+		zin.pos = 0;
+
+		zout.dst = zbuff;
+		zout.size = ZSTD_FILE_BUF_SIZE;
+		zout.pos = 0;
+
+		size_t ret;
+		do {
+			zout.pos = 0;
+			ret = ZSTD_compressStream2( compression_context, &zout, &zin, ZSTD_e_end  );
+			if (ZSTD_isError(ret)) {
+				dbg->error("zstd_file_rdwr_stream_t::~zstd_file_rdwr_stream_t", "Error flushing stream: %s", ZSTD_getErrorName(ret));
+			}
+
+			raw_file_rdwr_stream_t::write( zout.dst, zout.pos );
+		} while( ret>0 );
+
+		ZSTD_freeCCtx( compression_context );
+	}
+	else {
+		ZSTD_freeDCtx( decompression_context );
+	}
+
+	free( zbuff );
+}
+
+
+size_t zstd_file_rdwr_stream_t::read(void *buf, size_t len)
+{
+	zout.dst = buf;
+	zout.size = len;
+	zout.pos = 0;
+
+	do {
+		// first decompress from remaining input buffer
+		while(  zin.pos < zin.size  &&  zout.pos < zout.size  ) {
+			const size_t ret = ZSTD_decompressStream( decompression_context, &zout, &zin );
+			if (ZSTD_isError(ret)) {
+				dbg->error("zstd_file_rdwr_stream_t::read", "Error during decompression: %s", ZSTD_getErrorName(ret));
+				status = STATUS_ERR_CORRUPT;
+				return 0;
+			}
+
+			if(  ret == 0  ) {
+				zout.size = zout.pos;
+			}
+		}
+
+		// not enough data to fill output buffer => read more data from file
+		if(  zout.pos < zout.size  ) {
+			const size_t bytes_read = raw_file_rdwr_stream_t::read(zbuff, ZSTD_FILE_BUF_SIZE);
+			zin.pos = 0;
+			zin.size = bytes_read;
+
+			if (status != rdwr_stream_t::STATUS_OK && status != rdwr_stream_t::STATUS_EOF) {
+				// an error occurred, status is already set to the appropriate value
+				return 0;
+			}
+
+			// reset status since EOF is indicated by end of decompressed data,
+			// not end of compressed data
+			status = STATUS_OK;
+		}
+	} while(  zin.pos < zin.size  &&  zout.pos < zout.size  );
+
+
+	if (zout.pos < len) {
+		// end of decompressed data reached
+		status = STATUS_EOF;
+	}
+
+	return zout.pos;
+}
+
+
+size_t zstd_file_rdwr_stream_t::write(const void *buf, size_t len)
+{
+	// compress the next data
+	zin.src = buf;
+	zin.size = len;
+	zin.pos = 0;
+
+	while(  zin.pos < zin.size  ) {
+		zout.pos = 0;
+
+		const size_t ret = ZSTD_compressStream2( compression_context, &zout, &zin, ZSTD_e_continue );
+		if (ZSTD_isError(ret)) {
+			dbg->error("zstd_file_rdwr_stream_t::write", "Error during compression: %s", ZSTD_getErrorName(ret));
+			status = STATUS_ERR_CORRUPT;
+			return 0;
+		}
+
+		if (raw_file_rdwr_stream_t::write( zout.dst, zout.pos ) != zout.pos) {
+			status = STATUS_ERR_FULL;
+			return 0;
+		}
+	}
+
+	return zin.pos;
+}

--- a/io/rdwr/zstd_file_rdwr_stream.h
+++ b/io/rdwr/zstd_file_rdwr_stream.h
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the Simutrans project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#ifndef IO_RDWR_ZSTD_FILE_RDWR_STREAM_H
+#define IO_RDWR_ZSTD_FILE_RDWR_STREAM_H
+
+
+#include "raw_file_rdwr_stream.h"
+
+#include <zstd.h>
+
+
+#if !USE_ZSTD
+#  error "Cannot use zstd_file_rdwr_stream_t: zstd not enabled"
+#endif
+
+
+/// Reads/writes data data from/to a zstd compressed file.
+class zstd_file_rdwr_stream_t : public raw_file_rdwr_stream_t
+{
+public:
+	zstd_file_rdwr_stream_t(const std::string &filename, bool writing, int compression);
+	~zstd_file_rdwr_stream_t();
+
+public:
+	/// @copydoc rdwr_stream_t::read
+	size_t read(void *buf, size_t len) OVERRIDE;
+
+	/// @copydoc rdwr_stream_t::write
+	size_t write(const void *buf, size_t len) OVERRIDE;
+
+private:
+	void *zbuff; // buffer for compressed data, i.e. file <-> zbuff
+
+	ZSTD_inBuffer zin;
+	ZSTD_outBuffer zout;
+	ZSTD_CCtx *compression_context;
+	ZSTD_DCtx *decompression_context;
+};
+
+#endif

--- a/network/network_cmd_ingame.cc
+++ b/network/network_cmd_ingame.cc
@@ -88,7 +88,7 @@ bool nwc_gameinfo_t::execute(karte_t *welt)
 		// init the rest of the packet
 		SOCKET s = packet->get_sender();
 		loadsave_t fd;
-		if(  fd.wr_open( "serverinfo.sve", loadsave_t::xml_bzip2, 0, "info", SERVER_SAVEGAME_VER_NR, EXTENDED_VER_NR, EXTENDED_REVISION_NR )  ) {
+		if(  fd.wr_open( "serverinfo.sve", loadsave_t::xml_bzip2, 0, "info", SERVER_SAVEGAME_VER_NR, EXTENDED_VER_NR, EXTENDED_REVISION_NR ) == loadsave_t::FILE_STATUS_OK   ) {
 			gameinfo_t gi(welt);
 			gi.rdwr( &fd );
 			fd.close();
@@ -716,13 +716,13 @@ void nwc_sync_t::do_command(karte_t *welt)
 		// first save password hashes
 		sprintf( fn, "server%d-pwdhash.sve", env_t::server );
 		loadsave_t file;
-		if(file.wr_open(fn, loadsave_t::zipped, 1, "hashes", SAVEGAME_VER_NR, EXTENDED_VER_NR, EXTENDED_REVISION_NR)) {
+		if(file.wr_open(fn, loadsave_t::zipped, 1, "hashes", SAVEGAME_VER_NR, EXTENDED_VER_NR, EXTENDED_REVISION_NR) == loadsave_t::FILE_STATUS_OK) {
 			welt->rdwr_player_password_hashes( &file );
 			file.close();
 		}
 		else
 		{
-			dbg->warning("nwc_sync_t::do_command", "Could not save %s. Passwords may be reset on loading game.", fn); 
+			dbg->warning("nwc_sync_t::do_command", "Could not save %s. Passwords may be reset on loading game.", fn);
 		}
 
 		// remove passwords before transfer on the server and set default client mask

--- a/network/network_file_transfer.cc
+++ b/network/network_file_transfer.cc
@@ -141,16 +141,20 @@ const char *network_gameinfo(const char *cp, gameinfo_t *gi)
 		sprintf( filename, "client%i-network.sve", nwgi->len );
 		err = network_receive_file( my_client_socket, filename, len );
 
-		// now into gameinfo
-		if(  fd.rd_open( filename )  ) {
-			gameinfo_t *pgi = new gameinfo_t( &fd );
-			*gi = *pgi;
-			delete pgi;
-			fd.close();
-		}
-		else {
-			// some more insets, while things may have failed
-			err = fd.get_last_error() == loadsave_t::FILE_ERROR_FUTURE_VERSION ? "Server version too new" : "Server busy";
+		if (err == NULL) {
+			// now into gameinfo
+			const loadsave_t::file_status_t err_code = fd.rd_open( filename );
+
+			if(  err_code == loadsave_t::FILE_STATUS_OK  ) {
+				gameinfo_t *pgi = new gameinfo_t( &fd );
+				*gi = *pgi;
+				delete pgi;
+				fd.close();
+			}
+			else {
+				// some more insets, while things may have failed
+				err = (err_code == loadsave_t::FILE_STATUS_ERR_FUTURE_VERSION) ? "Server version too new" : "Server busy";
+			}
 		}
 		dr_remove( filename );
 end:

--- a/simfab.cc
+++ b/simfab.cc
@@ -706,7 +706,7 @@ bool fabrik_t::disconnect_consumer(koord pos) //Returns true if must be destroye
 		// If there are no consumers left, industry is orphaned.
 		// Reconnect or close.
 
-		// Attempt to reconnect. 
+		// Attempt to reconnect.
 
 		for(sint16 i = welt->get_fab_list().get_count() - 1; i >= 0; i --)
 		{
@@ -749,7 +749,7 @@ bool fabrik_t::disconnect_supplier(koord pos) //Returns true if must be destroye
 		}
 	}
 
-	vector_tpl<const goods_desc_t*> unfulfilled_requirements; 
+	vector_tpl<const goods_desc_t*> unfulfilled_requirements;
 	// Check to ensure that all supply types are still connected
 	for (const auto input_type : input)
 	{
@@ -764,7 +764,7 @@ bool fabrik_t::disconnect_supplier(koord pos) //Returns true if must be destroye
 		}
 		if (!fulfilled)
 		{
-			unfulfilled_requirements.append(input_type.get_typ()); 
+			unfulfilled_requirements.append(input_type.get_typ());
 		}
 	}
 

--- a/siminteraction.cc
+++ b/siminteraction.cc
@@ -314,7 +314,7 @@ bool interaction_t::process_event( event_t &ev )
 			char fn[256];
 			sprintf( fn, "server%d-pwdhash.sve", env_t::server );
 			loadsave_t file;
-			if(file.wr_open(fn, loadsave_t::zipped, 1, "hashes", SAVEGAME_VER_NR, EXTENDED_VER_NR, EXTENDED_REVISION_NR)) {
+			if(file.wr_open(fn, loadsave_t::zipped, 1, "hashes", SAVEGAME_VER_NR, EXTENDED_VER_NR, EXTENDED_REVISION_NR) == loadsave_t::FILE_STATUS_OK) {
 				world->rdwr_player_password_hashes( &file );
 				file.close();
 			}

--- a/simmain.cc
+++ b/simmain.cc
@@ -672,7 +672,7 @@ int simu_main(int argc, char** argv)
 #else
 	const char xml_filename[26] = "settings-extended.xml";
 #endif
-	bool xml_settings_found = file.rd_open(xml_filename);
+	bool xml_settings_found = file.rd_open(xml_filename) == loadsave_t::FILE_STATUS_OK;
 	if(!xml_settings_found)
 	{
 		// Again, attempt to use the Debian directory.
@@ -680,7 +680,7 @@ int simu_main(int argc, char** argv)
 		strcpy(backup_data_dir, env_t::data_dir);
 		strcpy( env_t::data_dir, "/usr/share/games/simutrans-extended/" );
 		dr_chdir( env_t::data_dir );
-		xml_settings_found = file.rd_open(xml_filename);
+		xml_settings_found = file.rd_open(xml_filename) == loadsave_t::FILE_STATUS_OK;
 		if(!xml_settings_found)
 		{
 			 strcpy(env_t::data_dir, backup_data_dir);
@@ -759,7 +759,7 @@ int simu_main(int argc, char** argv)
 		std::string fn = env_t::user_dir;
 		fn += "save/";
 		fn += filename;
-		if(  test.rd_open(fn.c_str())  ) {
+		if(  test.rd_open(fn.c_str()) == loadsave_t::FILE_STATUS_OK  ) {
 			// add pak extension
 			std::string pak_extension = test.get_pak_extension();
 			if(  pak_extension!="(unknown)"  ) {
@@ -1249,7 +1249,7 @@ int simu_main(int argc, char** argv)
 		static char servername[128];
 		sprintf( servername, "server%d-network.sve", env_t::server );
 		// try recover with the latest savegame
-		if(  file.rd_open(servername)  ) {
+		if(  file.rd_open(servername) == loadsave_t::FILE_STATUS_OK  ) {
 			// compare pakset (objfilename has trailing path separator, pak_extension not)
 			if (strstart(env_t::objfilename.c_str(), file.get_pak_extension())) {
 				// same pak directory - load this
@@ -1554,7 +1554,7 @@ int simu_main(int argc, char** argv)
 
 	// save setting ...
 	dr_chdir( env_t::user_dir );
-	if(  file.wr_open(xml_filename,loadsave_t::xml,0,"settings only/",SAVEGAME_VER_NR, EXTENDED_VER_NR, EXTENDED_REVISION_NR)  ) {
+	if(  file.wr_open(xml_filename,loadsave_t::xml,0,"settings only/",SAVEGAME_VER_NR, EXTENDED_VER_NR, EXTENDED_REVISION_NR)==loadsave_t::FILE_STATUS_OK   ) {
 		env_t::rdwr(&file);
 		env_t::default_settings.rdwr(&file);
 		file.close();

--- a/simworld.h
+++ b/simworld.h
@@ -2172,7 +2172,7 @@ public:
 	 * File version used when loading (or current if generated)
 	 * @note Useful for finish_rd
 	 */
-	loadsave_t::combined_version load_version;
+	extended_version_t load_version;
 
 	/**
 	 * Checks if the planquadrat (tile) at coordinate (x,y)


### PR DESCRIPTION
CODE: Add rdwr_stream_t to read or write data
ADD: classify_file() to determine file format
FIX: Data race potentially causing hang when reading zstd saves multi-threaded

Cherry-pick of commit 1f61ea16e from Standard.