### PR TITLE
Fix: Pure express mail routes were ignored by express mail

### DIFF
--- a/simhalt.cc
+++ b/simhalt.cc
@@ -2137,27 +2137,18 @@ uint32 haltestelle_t::find_route(const vector_tpl<halthandle_t>& destination_hal
 
  	koord destination_stop_pos = destination_pos;
 
-	bool is_freight = false;
+	bool is_freight;
 	uint8 g_class;
 	uint8 ware_catg;
 
-	if (ware.is_freight())
-	{
-		is_freight = true;
-		ware_catg = ware.get_desc()->get_catg_index();
-		g_class = 0;
-	}
-	else if (ware.is_mail())
-	{
-		ware_catg = goods_manager_t::INDEX_MAIL;
-		g_class = 0;
-	}
-	else // Passengers
-	{
-		// Class only matters for passengers
-		g_class = ware.g_class;
-		ware_catg = goods_manager_t::INDEX_PAS;
-	}
+
+	assert(ware.is_passenger() == (ware.get_desc()->get_catg_index() == goods_manager_t::INDEX_PAS));
+	assert(ware.is_mail() == (ware.get_desc()->get_catg_index() == goods_manager_t::INDEX_MAIL));
+
+	is_freight = ware.is_freight(); //Obvious
+    ware_catg = ware.get_desc()->get_catg_index(); //pax will always return 0 here; mail will always return 1 here
+    g_class = ware.g_class; //In case of freight always 0
+
 
 	bool found_a_halt = false;
 


### PR DESCRIPTION
The path explorer correctly explored the prioritymail network but express mail used the precalculated normal mail network to move around.
This effectively led to pure express mail routes being entirely ignored by any mail (except from very small amounts of mail. It is yet unclear to me how those few units made their way into pure priority mail routes)

This fix also comes with a slight code cleanup as it was caused by a mistaken conditional handling where no condition was needed at all.