### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,9 +102,11 @@ endif
 USE_UPNP ?= 0
 USE_FREETYPE ?= 0
 
-ALLEGRO_CONFIG ?= allegro-config
-#SDL2_CONFIG    ?= sdl2-config
-FREETYPE_CONFIG ?= freetype-config
+ALLEGRO_CONFIG   ?= allegro-config
+SDL2_CONFIG      ?= pkg-config sdl2
+#SDL2_CONFIG     ?= sdl2-config
+FREETYPE_CONFIG  ?= pkg-config freetype2
+#FREETYPE_CONFIG ?= freetype-config
 
 ifneq ($(OPTIMISE),)
   CFLAGS += -O3


### PR DESCRIPTION
This Makefile code imported from Standard will fix the Makefile compilation (specifically SDL2 and Freetype libraries not being found).

Instead of using the deprecated freetype-config and sld2-config, pkg-config (aka pkgconf) is used to locate the libraries.