### PR TITLE
Minimap fixes

### DIFF
--- a/display/simgraph.h
+++ b/display/simgraph.h
@@ -75,12 +75,8 @@ enum control_alignments_t {
 };
 typedef uint16 control_alignment_t;
 
-// size of koordinates
-typedef short KOORD_VAL;
-
-
 struct clip_dimension {
-	KOORD_VAL x, xx, w, y, yy, h;
+	scr_coord_val x, xx, w, y, yy, h;
 };
 
 // helper macros
@@ -127,16 +123,17 @@ void clear_all_poly_clip(CLIP_NUM_DEF0);
 void activate_ribi_clip(int ribi  CLIP_NUM_DEF);
 
 /* Do no access directly, use the get_tile_raster_width()
- * macro instead.
+ * function instead.
  */
-#define get_tile_raster_width()    (tile_raster_width)
-extern KOORD_VAL tile_raster_width;
+extern scr_coord_val tile_raster_width;
+inline scr_coord_val get_tile_raster_width(){return tile_raster_width;}
 
-#define get_base_tile_raster_width() (base_tile_raster_width)
-extern KOORD_VAL base_tile_raster_width;
+
+extern scr_coord_val base_tile_raster_width;
+inline scr_coord_val get_base_tile_raster_width(){return base_tile_raster_width;}
 
 /* changes the raster width after loading */
-KOORD_VAL display_set_base_raster_width(KOORD_VAL new_raster);
+scr_coord_val display_set_base_raster_width(scr_coord_val new_raster);
 
 
 int zoom_factor_up();
@@ -168,17 +165,17 @@ void display_free_all_images_above( image_id above );
 // unzoomed offsets
 void display_get_base_image_offset( image_id image, scr_coord_val *xoff, scr_coord_val *yoff, scr_coord_val *xw, scr_coord_val *yw );
 // zoomed offsets
-void display_get_image_offset( image_id image, KOORD_VAL *xoff, KOORD_VAL *yoff, KOORD_VAL *xw, KOORD_VAL *yw );
-void display_mark_img_dirty( image_id image, KOORD_VAL x, KOORD_VAL y );
+void display_get_image_offset( image_id image, scr_coord_val *xoff, scr_coord_val *yoff, scr_coord_val *xw, scr_coord_val *yw );
+void display_mark_img_dirty( image_id image, scr_coord_val x, scr_coord_val y );
 
-void mark_rect_dirty_wc(KOORD_VAL x1, KOORD_VAL y1, KOORD_VAL x2, KOORD_VAL y2); // clips to screen only
-void mark_rect_dirty_clip(KOORD_VAL x1, KOORD_VAL y1, KOORD_VAL x2, KOORD_VAL y2  CLIP_NUM_DEF); // clips to clip_rect
+void mark_rect_dirty_wc(scr_coord_val x1, scr_coord_val y1, scr_coord_val x2, scr_coord_val y2); // clips to screen only
+void mark_rect_dirty_clip(scr_coord_val x1, scr_coord_val y1, scr_coord_val x2, scr_coord_val y2  CLIP_NUM_DEF); // clips to clip_rect
 void mark_screen_dirty();
 
-KOORD_VAL display_get_width();
-KOORD_VAL display_get_height();
-void      display_set_height(KOORD_VAL);
-void      display_set_actual_width(KOORD_VAL);
+scr_coord_val display_get_width();
+scr_coord_val display_get_height();
+void display_set_height(scr_coord_val);
+void display_set_actual_width(scr_coord_val);
 
 // force a certain size on a image (for rescaling tool images)
 void display_fit_img_to_width( const image_id n, sint16 new_w );
@@ -186,7 +183,7 @@ void display_fit_img_to_width( const image_id n, sint16 new_w );
 void display_day_night_shift(int night);
 
 // scrolls horizontally, will ignore clipping etc.
-void display_scroll_band( const KOORD_VAL start_y, const KOORD_VAL x_offset, const KOORD_VAL h );
+void display_scroll_band( const scr_coord_val start_y, const scr_coord_val x_offset, const scr_coord_val h );
 
 // set first and second company color for player
 void display_set_player_color_scheme(const int player, const uint8 col1, const uint8 col2 );
@@ -195,29 +192,29 @@ void display_set_player_color_scheme(const int player, const uint8 col1, const u
 void display_img_aligned( const image_id n, scr_rect area, int align, const int dirty);
 
 // display image with day and night change
-void display_img_aux(const image_id n, KOORD_VAL xp, KOORD_VAL yp, const signed char player_nr, const int daynight, const int dirty  CLIP_NUM_DEF);
+void display_img_aux(const image_id n, scr_coord_val xp, scr_coord_val yp, const signed char player_nr, const int daynight, const int dirty  CLIP_NUM_DEF);
 
 /**
  * draws the images with alpha, either blended or as outline
  */
-void display_rezoomed_img_blend(const image_id n, KOORD_VAL xp, KOORD_VAL yp, const signed char player_nr, const FLAGGED_PIXVAL color_index, const int daynight, const int dirty  CLIP_NUM_DEF);
+void display_rezoomed_img_blend(const image_id n, scr_coord_val xp, scr_coord_val yp, const signed char player_nr, const FLAGGED_PIXVAL color_index, const int daynight, const int dirty  CLIP_NUM_DEF);
 #define display_img_blend( n, x, y, c, dn, d ) display_rezoomed_img_blend( (n), (x), (y), 0, (c), (dn), (d)  CLIP_NUM_DEFAULT)
 
 #define ALPHA_RED 0x1
 #define ALPHA_GREEN 0x2
 #define ALPHA_BLUE 0x4
 
-void display_rezoomed_img_alpha(const image_id n, const image_id alpha_n, const unsigned alpha_flags, KOORD_VAL xp, KOORD_VAL yp, const signed char player_nr, const FLAGGED_PIXVAL color_index, const int daynight, const int dirty  CLIP_NUM_DEF);
+void display_rezoomed_img_alpha(const image_id n, const image_id alpha_n, const unsigned alpha_flags, scr_coord_val xp, scr_coord_val yp, const signed char player_nr, const FLAGGED_PIXVAL color_index, const int daynight, const int dirty  CLIP_NUM_DEF);
 #define display_img_alpha( n, a, f, x, y, c, dn, d ) display_rezoomed_img_alpha( (n), (a), (f), (x), (y), 0, (c), (dn), (d)  CLIP_NUM_DEFAULT)
 
 // display image with color (if there) and optional day and night change
-void display_color_img(const image_id n, KOORD_VAL xp, KOORD_VAL yp, const signed char player_nr, const int daynight, const int dirty  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
+void display_color_img(const image_id n, scr_coord_val xp, scr_coord_val yp, const signed char player_nr, const int daynight, const int dirty  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
 
 // displays image that shows a tooltip when hovering the mouse over
-void display_color_img_with_tooltip(const image_id n, KOORD_VAL xp, KOORD_VAL yp, const signed char player_nr, const int daynight, const int dirty, const char *text  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
+void display_color_img_with_tooltip(const image_id n, scr_coord_val xp, scr_coord_val yp, const signed char player_nr, const int daynight, const int dirty, const char *text  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
 
 // display unzoomed image
-void display_base_img(const image_id n, KOORD_VAL xp, KOORD_VAL yp, const signed char player_nr, const int daynight, const int dirty  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
+void display_base_img(const image_id n, scr_coord_val xp, scr_coord_val yp, const signed char player_nr, const int daynight, const int dirty  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
 
 typedef image_id stretch_map_t[3][3];
 
@@ -228,13 +225,13 @@ void display_img_stretch( const stretch_map_t &imag, scr_rect area );
 void display_img_stretch_blend( const stretch_map_t &imag, scr_rect area, FLAGGED_PIXVAL color );
 
 // display unzoomed image with alpha, either blended or as outline
-void display_base_img_blend(const image_id n, KOORD_VAL xp, KOORD_VAL yp, const signed char player_nr, const FLAGGED_PIXVAL color_index, const int daynight, const int dirty  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
-void display_base_img_alpha(const image_id n, const image_id alpha_n, const unsigned alpha_flags, KOORD_VAL xp, KOORD_VAL yp, const signed char player_nr, const FLAGGED_PIXVAL color_index, const int daynight, const int dirty  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
+void display_base_img_blend(const image_id n, scr_coord_val xp, scr_coord_val yp, const signed char player_nr, const FLAGGED_PIXVAL color_index, const int daynight, const int dirty  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
+void display_base_img_alpha(const image_id n, const image_id alpha_n, const unsigned alpha_flags, scr_coord_val xp, scr_coord_val yp, const signed char player_nr, const FLAGGED_PIXVAL color_index, const int daynight, const int dirty  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
 
 // pointer to image display procedures
-typedef void(*display_image_proc)(const image_id n, KOORD_VAL xp, KOORD_VAL yp, const signed char player_nr, const int daynight, const int dirty  CLIP_NUM_DEF);
-typedef void(*display_blend_proc)(const image_id n, KOORD_VAL xp, KOORD_VAL yp, const signed char player_nr, const FLAGGED_PIXVAL color_index, const int daynight, const int dirty  CLIP_NUM_DEF);
-typedef void(*display_alpha_proc)(const image_id n, const image_id alpha_n, const unsigned alpha_flags, KOORD_VAL xp, KOORD_VAL yp, const signed char player_nr, const FLAGGED_PIXVAL color_index, const int daynight, const int dirty  CLIP_NUM_DEF);
+typedef void(*display_image_proc)(const image_id n, scr_coord_val xp, scr_coord_val yp, const signed char player_nr, const int daynight, const int dirty  CLIP_NUM_DEF);
+typedef void(*display_blend_proc)(const image_id n, scr_coord_val xp, scr_coord_val yp, const signed char player_nr, const FLAGGED_PIXVAL color_index, const int daynight, const int dirty  CLIP_NUM_DEF);
+typedef void(*display_alpha_proc)(const image_id n, const image_id alpha_n, const unsigned alpha_flags, scr_coord_val xp, scr_coord_val yp, const signed char player_nr, const FLAGGED_PIXVAL color_index, const int daynight, const int dirty  CLIP_NUM_DEF);
 
 // variables for storing currently used image procedure set and tile raster width
 extern display_image_proc display_normal;
@@ -269,31 +266,31 @@ inline void display_set_image_proc( bool is_global )
 PIXVAL display_blend_colors(PIXVAL background, PIXVAL foreground, int percent_blend);
 
 // blends a rectangular region
-void display_blend_wh_rgb(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, PIXVAL color, int percent_blend);
+void display_blend_wh_rgb(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, PIXVAL color, int percent_blend);
 
-void display_linear_gradient_wh_rgb(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, PIXVAL color, int percent_blend_start, int percent_blend_end, bool horizontal=false);
+void display_linear_gradient_wh_rgb(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, PIXVAL color, int percent_blend_start, int percent_blend_end, bool horizontal=false);
 #define display_linear_gradient_wh(xp,yp,w,h,color,percent_blend_start,percent_blend_end,horizontal) display_linear_gradient_wh_rgb( xp,yp,w,h,specialcolormap_all_day[(color)&0xFF],percent_blend_start,percent_blend_end,horizontal )
 
-void display_fillbox_wh_rgb(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, PIXVAL color, bool dirty);
+void display_fillbox_wh_rgb(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, PIXVAL color, bool dirty);
 
-void display_fillbox_wh_clip_rgb(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, PIXVAL color, bool dirty  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
+void display_fillbox_wh_clip_rgb(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, PIXVAL color, bool dirty  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
 
-void display_filled_roundbox_clip(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, PIXVAL color, bool dirty);
+void display_filled_roundbox_clip(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, PIXVAL color, bool dirty);
 
-void display_cylinderbar_wh_clip_rgb(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, PIXVAL color, bool dirty  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
+void display_cylinderbar_wh_clip_rgb(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, PIXVAL color, bool dirty  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
 
-void display_colorbox_with_tooltip(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, PIXVAL color, bool dirty, const char *text=NULL);
+void display_colorbox_with_tooltip(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, PIXVAL color, bool dirty, const char *text=NULL);
 
-void display_veh_form_wh_clip_rgb(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, PIXVAL color, bool dirty, uint8 basic_coupling_constraint, uint8 interactivity, bool is_rightside CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
+void display_veh_form_wh_clip_rgb(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, PIXVAL color, bool dirty, uint8 basic_coupling_constraint, uint8 interactivity, bool is_rightside CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
 
 enum {
 	BIDIRECTIONAL = 1,
 	HAS_POWER = 2
 };
 
-void display_vline_wh_rgb(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL h, PIXVAL color, bool dirty);
+void display_vline_wh_rgb(scr_coord_val xp, scr_coord_val yp, scr_coord_val h, PIXVAL color, bool dirty);
 
-void display_vline_wh_clip_rgb(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL h, PIXVAL c, bool dirty  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
+void display_vline_wh_clip_rgb(scr_coord_val xp, scr_coord_val yp, scr_coord_val h, PIXVAL c, bool dirty  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
 
 void display_clear();
 
@@ -304,21 +301,21 @@ void display_set_pointer(int pointer);
 void display_show_load_pointer(int loading);
 
 
-void display_array_wh(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, const PIXVAL *arr);
+void display_array_wh(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, const PIXVAL *arr);
 
 // compound painting routines
-void display_outline_proportional_rgb(KOORD_VAL xpos, KOORD_VAL ypos, PIXVAL text_color, PIXVAL shadow_color, const char *text, int dirty, sint32 len=-1);
-void display_shadow_proportional_rgb(KOORD_VAL xpos, KOORD_VAL ypos, PIXVAL text_color, PIXVAL shadow_color, const char *text, int dirty, sint32 len=-1);
-void display_ddd_box_rgb(KOORD_VAL x1, KOORD_VAL y1, KOORD_VAL w, KOORD_VAL h, PIXVAL tl_color, PIXVAL rd_color, bool dirty);
-void display_ddd_box_clip_rgb(KOORD_VAL x1, KOORD_VAL y1, KOORD_VAL w, KOORD_VAL h, PIXVAL tl_color, PIXVAL rd_color);
-void display_heading_rgb(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, PIXVAL text_color, PIXVAL frame_color, const char *text, int dirty, uint8 style);
+void display_outline_proportional_rgb(scr_coord_val xpos, scr_coord_val ypos, PIXVAL text_color, PIXVAL shadow_color, const char *text, int dirty, sint32 len=-1);
+void display_shadow_proportional_rgb(scr_coord_val xpos, scr_coord_val ypos, PIXVAL text_color, PIXVAL shadow_color, const char *text, int dirty, sint32 len=-1);
+void display_ddd_box_rgb(scr_coord_val x1, scr_coord_val y1, scr_coord_val w, scr_coord_val h, PIXVAL tl_color, PIXVAL rd_color, bool dirty);
+void display_ddd_box_clip_rgb(scr_coord_val x1, scr_coord_val y1, scr_coord_val w, scr_coord_val h, PIXVAL tl_color, PIXVAL rd_color);
+void display_heading_rgb(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, PIXVAL text_color, PIXVAL frame_color, const char *text, int dirty, uint8 style);
 
 
 // unicode save moving in strings
 size_t get_next_char(const char* text, size_t pos);
 sint32 get_prev_char(const char* text, sint32 pos);
 
-KOORD_VAL display_get_char_width(utf32 c);
+scr_coord_val display_get_char_width(utf32 c);
 
 /* returns true, if this is a valid character */
 bool has_character( utf16 char_code );
@@ -329,7 +326,7 @@ bool has_character( utf16 char_code );
  * @param len   length of text buffer to evaluate. If set to 0,
  *              evaluate until null termination.
  */
-KOORD_VAL display_get_char_max_width(const char* text, size_t len=0);
+scr_coord_val display_get_char_max_width(const char* text, size_t len=0);
 
 /**
  * For the next logical character in the text, returns the character code
@@ -368,7 +365,7 @@ void display_calc_proportional_multiline_string_len_width( int &xw, int &yh, con
  */
 
 // #ifdef MULTI_THREAD
-int display_text_proportional_len_clip_rgb(KOORD_VAL x, KOORD_VAL y, const char* txt, control_alignment_t flags, const PIXVAL color, bool dirty, sint32 len  CLIP_NUM_DEF  CLIP_NUM_DEFAULT_ZERO);
+int display_text_proportional_len_clip_rgb(scr_coord_val x, scr_coord_val y, const char* txt, control_alignment_t flags, const PIXVAL color, bool dirty, sint32 len  CLIP_NUM_DEF  CLIP_NUM_DEFAULT_ZERO);
 /* macro are for compatibility */
 #define display_proportional_rgb(               x, y, txt, align, color, dirty)       display_text_proportional_len_clip_rgb( x, y, txt, align,           color, dirty, -1 )
 #define display_proportional_clip_rgb(          x, y, txt, align, color, dirty)       display_text_proportional_len_clip_rgb( x, y, txt, align | DT_CLIP, color, dirty, -1 )
@@ -379,30 +376,30 @@ int display_text_proportional_len_clip_rgb(KOORD_VAL x, KOORD_VAL y, const char*
  * If enough space is given, it just display the full string
  * @returns screen_width
  */
-KOORD_VAL display_proportional_ellipsis_rgb( scr_rect r, const char *text, int align, const PIXVAL color, const bool dirty, bool shadowed = false, PIXVAL shadow_color = 0 );
+scr_coord_val display_proportional_ellipsis_rgb( scr_rect r, const char *text, int align, const PIXVAL color, const bool dirty, bool shadowed = false, PIXVAL shadow_color = 0 );
 
-void display_ddd_proportional(KOORD_VAL xpos, KOORD_VAL ypos, KOORD_VAL width, KOORD_VAL hgt, FLAGGED_PIXVAL ddd_farbe, FLAGGED_PIXVAL text_farbe, const char *text, int dirty);
+void display_ddd_proportional(scr_coord_val xpos, scr_coord_val ypos, scr_coord_val width, scr_coord_val hgt, FLAGGED_PIXVAL ddd_farbe, FLAGGED_PIXVAL text_farbe, const char *text, int dirty);
 
-void display_ddd_proportional_clip(KOORD_VAL xpos, KOORD_VAL ypos, KOORD_VAL width, KOORD_VAL hgt, FLAGGED_PIXVAL ddd_farbe, FLAGGED_PIXVAL text_farbe, const char *text, int dirty  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
+void display_ddd_proportional_clip(scr_coord_val xpos, scr_coord_val ypos, scr_coord_val width, scr_coord_val hgt, FLAGGED_PIXVAL ddd_farbe, FLAGGED_PIXVAL text_farbe, const char *text, int dirty  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
 
 
-int display_multiline_text_rgb(KOORD_VAL x, KOORD_VAL y, const char *inbuf, PIXVAL color);
+int display_multiline_text_rgb(scr_coord_val x, scr_coord_val y, const char *inbuf, PIXVAL color);
 
 // line drawing primitives
-void display_direct_line_rgb(const KOORD_VAL x, const KOORD_VAL y, const KOORD_VAL xx, const KOORD_VAL yy, const PIXVAL color);
-void display_direct_line_dotted_rgb(const KOORD_VAL x, const KOORD_VAL y, const KOORD_VAL xx, const KOORD_VAL yy, const KOORD_VAL draw, const KOORD_VAL dontDraw, const PIXVAL color);
-void display_circle_rgb(KOORD_VAL x0, KOORD_VAL  y0, int radius, const PIXVAL color);
-void display_filled_circle_rgb(KOORD_VAL x0, KOORD_VAL  y0, int radius, const PIXVAL color);
-void display_right_triangle_rgb(KOORD_VAL x, KOORD_VAL y, uint8 height, const PIXVAL colval, const bool dirty);
-void draw_bezier_rgb(KOORD_VAL Ax, KOORD_VAL Ay, KOORD_VAL Bx, KOORD_VAL By, KOORD_VAL ADx, KOORD_VAL ADy, KOORD_VAL BDx, KOORD_VAL BDy, const PIXVAL colore, KOORD_VAL draw, KOORD_VAL dontDraw);
-int display_fluctuation_triangle_rgb(KOORD_VAL x, KOORD_VAL y, uint8 height, const bool dirty, sint64 value=0);
+void display_direct_line_rgb(const scr_coord_val x, const scr_coord_val y, const scr_coord_val xx, const scr_coord_val yy, const PIXVAL color);
+void display_direct_line_dotted_rgb(const scr_coord_val x, const scr_coord_val y, const scr_coord_val xx, const scr_coord_val yy, const scr_coord_val draw, const scr_coord_val dontDraw, const PIXVAL color);
+void display_circle_rgb(scr_coord_val x0, scr_coord_val  y0, int radius, const PIXVAL color);
+void display_filled_circle_rgb(scr_coord_val x0, scr_coord_val  y0, int radius, const PIXVAL color);
+void display_right_triangle_rgb(scr_coord_val x, scr_coord_val y, uint8 height, const PIXVAL colval, const bool dirty);
+void draw_bezier_rgb(scr_coord_val Ax, scr_coord_val Ay, scr_coord_val Bx, scr_coord_val By, scr_coord_val ADx, scr_coord_val ADy, scr_coord_val BDx, scr_coord_val BDy, const PIXVAL colore, scr_coord_val draw, scr_coord_val dontDraw);
+int display_fluctuation_triangle_rgb(scr_coord_val x, scr_coord_val y, uint8 height, const bool dirty, sint64 value=0);
 
-void display_right_triangle_rgb(KOORD_VAL x, KOORD_VAL y, KOORD_VAL height, const PIXVAL colval, const bool dirty);
+void display_right_triangle_rgb(scr_coord_val x, scr_coord_val y, scr_coord_val height, const PIXVAL colval, const bool dirty);
 
-void display_set_clip_wh(KOORD_VAL x, KOORD_VAL y, KOORD_VAL w, KOORD_VAL h  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO, bool fit = false);
+void display_set_clip_wh(scr_coord_val x, scr_coord_val y, scr_coord_val w, scr_coord_val h  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO, bool fit = false);
 clip_dimension display_get_clip_wh(CLIP_NUM_DEF0 CLIP_NUM_DEFAULT_ZERO);
 
-void display_push_clip_wh(KOORD_VAL x, KOORD_VAL y, KOORD_VAL w, KOORD_VAL h  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
+void display_push_clip_wh(scr_coord_val x, scr_coord_val y, scr_coord_val w, scr_coord_val h  CLIP_NUM_DEF CLIP_NUM_DEFAULT_ZERO);
 void display_swap_clip_wh(CLIP_NUM_DEF0);
 void display_pop_clip_wh(CLIP_NUM_DEF0);
 

--- a/display/simgraph0.cc
+++ b/display/simgraph0.cc
@@ -79,12 +79,12 @@ bool display_load_font(const char*, bool)
 	return true;
 }
 
-sint16 display_get_width()
+scr_coord_val display_get_width()
 {
 	return 0;
 }
 
-sint16 display_get_height()
+scr_coord_val display_get_height()
 {
 	return 0;
 }

--- a/display/simgraph0.cc
+++ b/display/simgraph0.cc
@@ -10,8 +10,8 @@
 #include "simgraph.h"
 
 
-KOORD_VAL tile_raster_width = 16; // zoomed
-KOORD_VAL base_tile_raster_width = 16; // original
+scr_coord_val tile_raster_width = 16; // zoomed
+scr_coord_val base_tile_raster_width = 16; // original
 
 
 PIXVAL color_idx_to_rgb(PIXVAL idx)
@@ -34,7 +34,7 @@ void env_t_rgb_to_system_colors()
 {
 }
 
-KOORD_VAL display_set_base_raster_width(KOORD_VAL)
+scr_coord_val display_set_base_raster_width(scr_coord_val)
 {
 	return 0;
 }
@@ -58,11 +58,11 @@ int zoom_factor_down()
 	return false;
 }
 
-void mark_rect_dirty_wc(KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL)
+void mark_rect_dirty_wc(scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val)
 {
 }
 
-void mark_rect_dirty_clip(KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL  CLIP_NUM_DEF_NOUSE)
+void mark_rect_dirty_clip(scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val  CLIP_NUM_DEF_NOUSE)
 {
 }
 
@@ -70,7 +70,7 @@ void mark_screen_dirty()
 {
 }
 
-void display_mark_img_dirty(image_id, KOORD_VAL, KOORD_VAL)
+void display_mark_img_dirty(image_id, scr_coord_val, scr_coord_val)
 {
 }
 
@@ -89,11 +89,11 @@ sint16 display_get_height()
 	return 0;
 }
 
-void display_set_height(KOORD_VAL)
+void display_set_height(scr_coord_val)
 {
 }
 
-void display_set_actual_width(KOORD_VAL)
+void display_set_actual_width(scr_coord_val)
 {
 }
 
@@ -114,7 +114,7 @@ void display_snapshot(int, int, int, int)
 {
 }
 
-void display_get_image_offset(image_id image, KOORD_VAL *xoff, KOORD_VAL *yoff, KOORD_VAL *xw, KOORD_VAL *yw)
+void display_get_image_offset(image_id image, scr_coord_val *xoff, scr_coord_val *yoff, scr_coord_val *xw, scr_coord_val *yw)
 {
 	if(  image < 2  ) {
 		// initialize offsets with dummy values
@@ -148,11 +148,11 @@ clip_dimension display_get_clip_wh(CLIP_NUM_DEF_NOUSE0)
 	return clip_rect;
 }
 
-void display_set_clip_wh(KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL  CLIP_NUM_DEF_NOUSE, bool)
+void display_set_clip_wh(scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val  CLIP_NUM_DEF_NOUSE, bool)
 {
 }
 
-void display_push_clip_wh(KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL  CLIP_NUM_DEF_NOUSE)
+void display_push_clip_wh(scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val  CLIP_NUM_DEF_NOUSE)
 {
 }
 
@@ -164,19 +164,19 @@ void display_pop_clip_wh(CLIP_NUM_DEF_NOUSE0)
 {
 }
 
-void display_scroll_band(const KOORD_VAL, const KOORD_VAL, const KOORD_VAL)
+void display_scroll_band(const scr_coord_val, const scr_coord_val, const scr_coord_val)
 {
 }
 
-void display_img_aux(const image_id, KOORD_VAL, KOORD_VAL, const signed char, const int, const int  CLIP_NUM_DEF_NOUSE)
+void display_img_aux(const image_id, scr_coord_val, scr_coord_val, const signed char, const int, const int  CLIP_NUM_DEF_NOUSE)
 {
 }
 
-void display_color_img(const image_id, KOORD_VAL, KOORD_VAL, const signed char, const int, const int  CLIP_NUM_DEF_NOUSE)
+void display_color_img(const image_id, scr_coord_val, scr_coord_val, const signed char, const int, const int  CLIP_NUM_DEF_NOUSE)
 {
 }
 
-void display_base_img(const image_id, KOORD_VAL, KOORD_VAL, const signed char, const int, const int  CLIP_NUM_DEF_NOUSE)
+void display_base_img(const image_id, scr_coord_val, scr_coord_val, const signed char, const int, const int  CLIP_NUM_DEF_NOUSE)
 {
 }
 
@@ -192,19 +192,19 @@ void display_img_stretch_blend( const stretch_map_t &, scr_rect, FLAGGED_PIXVAL)
 {
 }
 
-void display_rezoomed_img_blend(const image_id, KOORD_VAL, KOORD_VAL, const signed char, const FLAGGED_PIXVAL, const int, const int  CLIP_NUM_DEF_NOUSE)
+void display_rezoomed_img_blend(const image_id, scr_coord_val, scr_coord_val, const signed char, const FLAGGED_PIXVAL, const int, const int  CLIP_NUM_DEF_NOUSE)
 {
 }
 
-void display_rezoomed_img_alpha(const image_id, const image_id, const unsigned, KOORD_VAL, KOORD_VAL, const signed char, const FLAGGED_PIXVAL, const int, const int  CLIP_NUM_DEF_NOUSE)
+void display_rezoomed_img_alpha(const image_id, const image_id, const unsigned, scr_coord_val, scr_coord_val, const signed char, const FLAGGED_PIXVAL, const int, const int  CLIP_NUM_DEF_NOUSE)
 {
 }
 
-void display_base_img_blend(const image_id, KOORD_VAL, KOORD_VAL, const signed char, const FLAGGED_PIXVAL, const int, const int  CLIP_NUM_DEF_NOUSE)
+void display_base_img_blend(const image_id, scr_coord_val, scr_coord_val, const signed char, const FLAGGED_PIXVAL, const int, const int  CLIP_NUM_DEF_NOUSE)
 {
 }
 
-void display_base_img_alpha(const image_id, const image_id, const unsigned, KOORD_VAL, KOORD_VAL, const signed char, const FLAGGED_PIXVAL, const int, int  CLIP_NUM_DEF_NOUSE)
+void display_base_img_alpha(const image_id, const image_id, const unsigned, scr_coord_val, scr_coord_val, const signed char, const FLAGGED_PIXVAL, const int, int  CLIP_NUM_DEF_NOUSE)
 {
 }
 
@@ -221,52 +221,52 @@ PIXVAL display_blend_colors(PIXVAL, PIXVAL, int)
 	return 0;
 }
 
-void display_blend_wh_rgb(KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL, PIXVAL, int )
+void display_blend_wh_rgb(scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val, PIXVAL, int )
 {
 }
 
-void display_linear_gradient_wh_rgb(KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL, PIXVAL, int, int, bool)
+void display_linear_gradient_wh_rgb(scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val, PIXVAL, int, int, bool)
 {
 }
 
-void display_color_img_with_tooltip(const image_id, KOORD_VAL, KOORD_VAL, sint8, const int, const int, const char* CLIP_NUM_DEF_NOUSE)
+void display_color_img_with_tooltip(const image_id, scr_coord_val, scr_coord_val, sint8, const int, const int, const char* CLIP_NUM_DEF_NOUSE)
 {
 }
 
-void display_fillbox_wh_rgb(KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL, PIXVAL, bool )
+void display_fillbox_wh_rgb(scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val, PIXVAL, bool )
 {
 }
 
 
-void display_fillbox_wh_clip_rgb(KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL, PIXVAL, bool  CLIP_NUM_DEF_NOUSE)
+void display_fillbox_wh_clip_rgb(scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val, PIXVAL, bool  CLIP_NUM_DEF_NOUSE)
 {
 }
 
-void display_cylinderbar_wh_clip_rgb(KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL, PIXVAL, bool  CLIP_NUM_DEF_NOUSE)
+void display_cylinderbar_wh_clip_rgb(scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val, PIXVAL, bool  CLIP_NUM_DEF_NOUSE)
 {
 }
 
-void display_colorbox_with_tooltip(KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL, PIXVAL, bool, const char*)
+void display_colorbox_with_tooltip(scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val, PIXVAL, bool, const char*)
 {
 }
 
-void display_veh_form_wh_clip_rgb(KOORD_VAL, KOORD_VAL, KOORD_VAL, PIXVAL, bool, uint8, uint8, bool CLIP_NUM_DEF_NOUSE)
+void display_veh_form_wh_clip_rgb(scr_coord_val, scr_coord_val, scr_coord_val, PIXVAL, bool, uint8, uint8, bool CLIP_NUM_DEF_NOUSE)
 {
 }
 
-void display_vline_wh_rgb(KOORD_VAL, KOORD_VAL, KOORD_VAL, PIXVAL, bool)
+void display_vline_wh_rgb(scr_coord_val, scr_coord_val, scr_coord_val, PIXVAL, bool)
 {
 }
 
-void display_vline_wh_clip_rgb(KOORD_VAL, KOORD_VAL, KOORD_VAL, PIXVAL, bool  CLIP_NUM_DEF_NOUSE)
+void display_vline_wh_clip_rgb(scr_coord_val, scr_coord_val, scr_coord_val, PIXVAL, bool  CLIP_NUM_DEF_NOUSE)
 {
 }
 
-void display_array_wh(KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL, const PIXVAL *)
+void display_array_wh(scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val, const PIXVAL *)
 {
 }
 
-void display_filled_roundbox_clip(KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL, PIXVAL, bool)
+void display_filled_roundbox_clip(scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val, PIXVAL, bool)
 {
 }
 
@@ -283,12 +283,12 @@ sint32 get_prev_char(const char*, sint32 pos)
 	return pos - 1;
 }
 
-KOORD_VAL display_get_char_width(utf32)
+scr_coord_val display_get_char_width(utf32)
 {
 	return 0;
 }
 
-KOORD_VAL display_get_char_max_width(const char*, size_t)
+scr_coord_val display_get_char_max_width(const char*, size_t)
 {
 	return 0;
 }
@@ -325,40 +325,40 @@ void display_calc_proportional_multiline_string_len_width( int &xw, int &yh, con
 }
 
 
-int display_text_proportional_len_clip_rgb(KOORD_VAL, KOORD_VAL, const char*, control_alignment_t , const PIXVAL, bool, sint32  CLIP_NUM_DEF_NOUSE)
+int display_text_proportional_len_clip_rgb(scr_coord_val, scr_coord_val, const char*, control_alignment_t , const PIXVAL, bool, sint32  CLIP_NUM_DEF_NOUSE)
 {
 	return 0;
 }
 
-void display_outline_proportional_rgb(KOORD_VAL, KOORD_VAL, PIXVAL, PIXVAL, const char *, int, sint32)
+void display_outline_proportional_rgb(scr_coord_val, scr_coord_val, PIXVAL, PIXVAL, const char *, int, sint32)
 {
 }
 
-void display_shadow_proportional_rgb(KOORD_VAL, KOORD_VAL, PIXVAL, PIXVAL, const char *, int, sint32)
+void display_shadow_proportional_rgb(scr_coord_val, scr_coord_val, PIXVAL, PIXVAL, const char *, int, sint32)
 {
 }
 
-void display_heading_rgb(KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL, PIXVAL, PIXVAL, const char *, int, uint8)
+void display_heading_rgb(scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val, PIXVAL, PIXVAL, const char *, int, uint8)
 {
 }
 
-void display_ddd_box_rgb(KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL, PIXVAL, PIXVAL, bool)
+void display_ddd_box_rgb(scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val, PIXVAL, PIXVAL, bool)
 {
 }
 
-void display_ddd_box_clip_rgb(KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL, PIXVAL, PIXVAL)
+void display_ddd_box_clip_rgb(scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val, PIXVAL, PIXVAL)
 {
 }
 
-void display_ddd_proportional(KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL, FLAGGED_PIXVAL, FLAGGED_PIXVAL, const char *, int)
+void display_ddd_proportional(scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val, FLAGGED_PIXVAL, FLAGGED_PIXVAL, const char *, int)
 {
 }
 
-void display_ddd_proportional_clip(KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL, FLAGGED_PIXVAL, FLAGGED_PIXVAL, const char *, int  CLIP_NUM_DEF_NOUSE)
+void display_ddd_proportional_clip(scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val, FLAGGED_PIXVAL, FLAGGED_PIXVAL, const char *, int  CLIP_NUM_DEF_NOUSE)
 {
 }
 
-int display_multiline_text_rgb(KOORD_VAL, KOORD_VAL, const char *, PIXVAL)
+int display_multiline_text_rgb(scr_coord_val, scr_coord_val, const char *, PIXVAL)
 {
 	return 0;
 }
@@ -409,32 +409,32 @@ void display_snapshot()
 {
 }
 
-void display_direct_line_rgb(const KOORD_VAL, const KOORD_VAL, const KOORD_VAL, const KOORD_VAL, const PIXVAL)
+void display_direct_line_rgb(const scr_coord_val, const scr_coord_val, const scr_coord_val, const scr_coord_val, const PIXVAL)
 {
 }
 
-void display_direct_line_dotted_rgb(const KOORD_VAL, const KOORD_VAL, const KOORD_VAL, const KOORD_VAL, const KOORD_VAL, const KOORD_VAL, const PIXVAL)
+void display_direct_line_dotted_rgb(const scr_coord_val, const scr_coord_val, const scr_coord_val, const scr_coord_val, const scr_coord_val, const scr_coord_val, const PIXVAL)
 {
 }
 
-void display_circle_rgb( KOORD_VAL, KOORD_VAL, int, const PIXVAL )
+void display_circle_rgb( scr_coord_val, scr_coord_val, int, const PIXVAL )
 {
 }
 
-void display_filled_circle_rgb( KOORD_VAL, KOORD_VAL, int, const PIXVAL )
+void display_filled_circle_rgb( scr_coord_val, scr_coord_val, int, const PIXVAL )
 {
 }
 
-void display_right_triangle_rgb(KOORD_VAL, KOORD_VAL, uint8, const PIXVAL, const bool)
+void display_right_triangle_rgb(scr_coord_val, scr_coord_val, uint8, const PIXVAL, const bool)
 {
 }
 
-int display_fluctuation_triangle_rgb(KOORD_VAL, KOORD_VAL, uint8, const bool, sint64)
+int display_fluctuation_triangle_rgb(scr_coord_val, scr_coord_val, uint8, const bool, sint64)
 {
 	return 0;
 }
 
-void draw_bezier_rgb(KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL, KOORD_VAL, const PIXVAL, KOORD_VAL, KOORD_VAL)
+void draw_bezier_rgb(scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val, scr_coord_val, const PIXVAL, scr_coord_val, scr_coord_val)
 {
 }
 
@@ -450,7 +450,7 @@ void display_img_aligned( const image_id, scr_rect, int, int )
 {
 }
 
-KOORD_VAL display_proportional_ellipsis_rgb( scr_rect, const char *, int, PIXVAL, bool, bool, PIXVAL)
+scr_coord_val display_proportional_ellipsis_rgb( scr_rect, const char *, int, PIXVAL, bool, bool, PIXVAL)
 {
 	return 0;
 }

--- a/display/simgraph16.cc
+++ b/display/simgraph16.cc
@@ -78,8 +78,8 @@ int old_my = -1;
  * associated to some clipline
  */
 struct xrange {
-	int sx, sy;
-	KOORD_VAL y;
+	sint64 sx, sy;
+	scr_coord_val y;
 	bool non_convex_active;
 };
 
@@ -92,8 +92,9 @@ private:
 	// (not_convex) if y0>=y1 then clip along the path (x0,-inf)->(x0,y0)->(x1,y1)
 	// (not_convex) if y0<y1  then clip along the path (x0,y0)->(x1,y1)->(x1,+inf)
 	int x0, y0;
-	int dx, dy, sdy, sdx;
-	int inc;
+	int dx, dy;
+	sint64 sdy, sdx;
+	sint64 inc;
 	bool non_convex;
 
 public:
@@ -107,8 +108,8 @@ public:
 		if(  steps == 0  ) {
 			return;
 		}
-		sdx = (dx << 16) / steps;
-		sdy = (dy << 16) / steps;
+		sdx = ((sint64)dx << 16) / steps;
+		sdy = ((sint64)dy << 16) / steps;
 		// to stay right from the line
 		// left border: xmin <= x
 		// right border: x < xmax
@@ -117,7 +118,7 @@ public:
 				inc = 1 << 16;
 			}
 			else {
-				inc = (dx << 16) / dy -  (1 << 16);
+				inc = ((sint64)dx << 16) / dy -  (1 << 16);
 			}
 		}
 		else if(  dy < 0  ) {
@@ -136,7 +137,7 @@ public:
 	// -- initialize the clipping
 	//    has to be called before image will be drawn
 	//    return interval for x coordinate
-	inline void get_x_range(KOORD_VAL y, xrange &r, bool use_non_convex) const {
+	inline void get_x_range(scr_coord_val y, xrange &r, bool use_non_convex) const {
 		// do everything for the previous row
 		y--;
 		r.y = y;
@@ -147,11 +148,11 @@ public:
 		}
 		if(  dy != 0  ) {
 			// init Bresenham algorithm
-			const int t = ((y - y0) << 16) / sdy;
+			const sint64 t = (((sint64)y - y0) << 16) / sdy;
 			// sx >> 16 = x
 			// sy >> 16 = y
-			r.sx = t * sdx + inc + (x0 << 16);
-			r.sy = t * sdy + (y0 << 16);
+			r.sx = t * sdx + inc + ((sint64)x0 << 16);
+			r.sy = t * sdy + ((sint64)y0 << 16);
 		}
 	}
 
@@ -356,9 +357,9 @@ struct imd {
 
 static int bitdepth = 16;
 
-static KOORD_VAL disp_width  = 640;
-static KOORD_VAL disp_actual_width  = 640;
-static KOORD_VAL disp_height = 480;
+static scr_coord_val disp_width  = 640;
+static scr_coord_val disp_actual_width  = 640;
+static scr_coord_val disp_height = 480;
 
 
 /*
@@ -688,8 +689,8 @@ static const uint8 special_pal[SPECIAL_COLOR_COUNT*3] =
 /*
  * tile raster width
  */
-KOORD_VAL tile_raster_width = 16;      // zoomed
-KOORD_VAL base_tile_raster_width = 16; // original
+scr_coord_val tile_raster_width = 16;      // zoomed
+scr_coord_val base_tile_raster_width = 16; // original
 
 // variables for storing currently used image procedure set and tile raster width
 display_image_proc display_normal = NULL;
@@ -777,9 +778,9 @@ void env_t_rgb_to_system_colors()
 
 
 /* changes the raster width after loading */
-KOORD_VAL display_set_base_raster_width(KOORD_VAL new_raster)
+scr_coord_val display_set_base_raster_width(scr_coord_val new_raster)
 {
-	KOORD_VAL old = base_tile_raster_width;
+	scr_coord_val old = base_tile_raster_width;
 	base_tile_raster_width = new_raster;
 	tile_raster_width = (new_raster *  zoom_num[zoom_factor]) / zoom_den[zoom_factor];
 	return old;
@@ -789,26 +790,26 @@ KOORD_VAL display_set_base_raster_width(KOORD_VAL new_raster)
 // ----------------------------------- clipping routines ------------------------------------------
 
 
-sint16 display_get_width()
+scr_coord_val display_get_width()
 {
 	return disp_actual_width;
 }
 
 
 // only use, if you are really really sure!
-void display_set_actual_width(KOORD_VAL w)
+void display_set_actual_width(scr_coord_val w)
 {
 	disp_actual_width = w;
 }
 
 
-sint16 display_get_height()
+scr_coord_val display_get_height()
 {
 	return disp_height;
 }
 
 
-void display_set_height(KOORD_VAL const h)
+void display_set_height(scr_coord_val const h)
 {
 	disp_height = h;
 }
@@ -819,10 +820,10 @@ void display_set_height(KOORD_VAL const h)
  * If @p w is negative, it stays negative.
  * @returns difference between old and new value of @p x.
  */
-inline int clip_intv(KOORD_VAL &x, KOORD_VAL &w, const KOORD_VAL left, const KOORD_VAL right)
+inline int clip_intv(scr_coord_val &x, scr_coord_val &w, const scr_coord_val left, const scr_coord_val right)
 {
-	KOORD_VAL xx = min(x+w, right);
-	KOORD_VAL xoff = left - x;
+	scr_coord_val xx = min(x+w, right);
+	scr_coord_val xoff = left - x;
 	if (xoff > 0) { // equivalent to x < left
 		x = left;
 	}
@@ -834,14 +835,14 @@ inline int clip_intv(KOORD_VAL &x, KOORD_VAL &w, const KOORD_VAL left, const KOO
 }
 
 /// wrapper for clip_intv
-static int clip_wh(KOORD_VAL *x, KOORD_VAL *w, const KOORD_VAL left, const KOORD_VAL right)
+static int clip_wh(scr_coord_val *x, scr_coord_val *w, const scr_coord_val left, const scr_coord_val right)
 {
 	return clip_intv(*x, *w, left, right);
 }
 
 
 /// wrapper for clip_intv, @returns whether @p w is positive
-static bool clip_lr(KOORD_VAL *x, KOORD_VAL *w, const KOORD_VAL left, const KOORD_VAL right)
+static bool clip_lr(scr_coord_val *x, scr_coord_val *w, const scr_coord_val left, const scr_coord_val right)
 {
 	clip_intv(*x, *w, left, right);
 	return *w > 0;
@@ -866,7 +867,7 @@ clip_dimension display_get_clip_wh(CLIP_NUM_DEF0)
  *  clip.x < xp+w <= clip.xx
  * analogously for the y coordinate
  */
-void display_set_clip_wh(KOORD_VAL x, KOORD_VAL y, KOORD_VAL w, KOORD_VAL h  CLIP_NUM_DEF, bool fit)
+void display_set_clip_wh(scr_coord_val x, scr_coord_val y, scr_coord_val w, scr_coord_val h  CLIP_NUM_DEF, bool fit)
 {
 	if (!fit) {
 		clip_wh( &x, &w, 0, disp_width);
@@ -881,11 +882,11 @@ void display_set_clip_wh(KOORD_VAL x, KOORD_VAL y, KOORD_VAL w, KOORD_VAL h  CLI
 	CR.clip_rect.y = y;
 	CR.clip_rect.w = w;
 	CR.clip_rect.h = h;
-	CR.clip_rect.xx = x + w; // watch out, clips to KOORD_VAL max
-	CR.clip_rect.yy = y + h; // watch out, clips to KOORD_VAL max
+	CR.clip_rect.xx = x + w; // watch out, clips to scr_coord_val max
+	CR.clip_rect.yy = y + h; // watch out, clips to scr_coord_val max
 }
 
-void display_push_clip_wh(KOORD_VAL x, KOORD_VAL y, KOORD_VAL w, KOORD_VAL h  CLIP_NUM_DEF)
+void display_push_clip_wh(scr_coord_val x, scr_coord_val y, scr_coord_val w, scr_coord_val h  CLIP_NUM_DEF)
 {
 	assert(!CR.swap_active);
 	// save active clipping rectangle
@@ -998,7 +999,7 @@ static inline void mark_tile_dirty(const int x, const int y)
 /**
  * Mark tile as dirty, with _NO_ clipping
  */
-static void mark_rect_dirty_nc(KOORD_VAL x1, KOORD_VAL y1, KOORD_VAL x2, KOORD_VAL y2)
+static void mark_rect_dirty_nc(scr_coord_val x1, scr_coord_val y1, scr_coord_val x2, scr_coord_val y2)
 {
 	// floor to tile size
 	x1 >>= DIRTY_TILE_SHIFT;
@@ -1030,7 +1031,7 @@ static void mark_rect_dirty_nc(KOORD_VAL x1, KOORD_VAL y1, KOORD_VAL x2, KOORD_V
 /**
  * Mark tile as dirty, with clipping
  */
-void mark_rect_dirty_wc(KOORD_VAL x1, KOORD_VAL y1, KOORD_VAL x2, KOORD_VAL y2)
+void mark_rect_dirty_wc(scr_coord_val x1, scr_coord_val y1, scr_coord_val x2, scr_coord_val y2)
 {
 	// inside display?
 	if(  x2 >= 0  &&  y2 >= 0  &&  x1 < disp_width  &&  y1 < disp_height  ) {
@@ -1051,7 +1052,7 @@ void mark_rect_dirty_wc(KOORD_VAL x1, KOORD_VAL y1, KOORD_VAL x2, KOORD_VAL y2)
 }
 
 
-void mark_rect_dirty_clip(KOORD_VAL x1, KOORD_VAL y1, KOORD_VAL x2, KOORD_VAL y2  CLIP_NUM_DEF)
+void mark_rect_dirty_clip(scr_coord_val x1, scr_coord_val y1, scr_coord_val x2, scr_coord_val y2  CLIP_NUM_DEF)
 {
 	// inside clip_rect?
 	if(  x2 >= CR.clip_rect.x  &&  y2 >= CR.clip_rect.y  &&  x1 < CR.clip_rect.xx  &&  y1 < CR.clip_rect.yy  ) {
@@ -1085,7 +1086,7 @@ void mark_screen_dirty()
 /**
  * the area of this image need update
  */
-void display_mark_img_dirty(image_id image, KOORD_VAL xp, KOORD_VAL yp)
+void display_mark_img_dirty(image_id image, scr_coord_val xp, scr_coord_val yp)
 {
 	if(  image < anz_images  ) {
 		mark_rect_dirty_wc(
@@ -1220,14 +1221,14 @@ static void recode()
 
 
 // to switch between 15 bit and 16 bit recoding ...
-typedef void (*display_recode_img_src_target_proc)(KOORD_VAL h, PIXVAL *src, PIXVAL *target);
+typedef void (*display_recode_img_src_target_proc)(scr_coord_val h, PIXVAL *src, PIXVAL *target);
 static display_recode_img_src_target_proc recode_img_src_target = NULL;
 
 
 /**
  * Convert a certain image data to actual output data
  */
-static void recode_img_src_target_15(KOORD_VAL h, PIXVAL *src, PIXVAL *target)
+static void recode_img_src_target_15(scr_coord_val h, PIXVAL *src, PIXVAL *target)
 {
 	if(  h > 0  ) {
 		do {
@@ -1264,7 +1265,7 @@ static void recode_img_src_target_15(KOORD_VAL h, PIXVAL *src, PIXVAL *target)
 	}
 }
 
-static void recode_img_src_target_16(KOORD_VAL h, PIXVAL *src, PIXVAL *target)
+static void recode_img_src_target_16(scr_coord_val h, PIXVAL *src, PIXVAL *target)
 {
 	if(  h > 0  ) {
 		do {
@@ -2185,7 +2186,7 @@ void display_free_all_images_above( image_id above )
 
 
 // query offsets
-void display_get_image_offset(image_id image, KOORD_VAL *xoff, KOORD_VAL *yoff, KOORD_VAL *xw, KOORD_VAL *yw)
+void display_get_image_offset(image_id image, scr_coord_val *xoff, scr_coord_val *yoff, scr_coord_val *xw, scr_coord_val *yw)
 {
 	if(  image < anz_images  ) {
 		*xoff = images[image].x;
@@ -2338,7 +2339,7 @@ template<> void templated_pixcopy<colored>(PIXVAL *dest, const PIXVAL *src, cons
  * draws image with clipping along arbitrary lines
  */
 template<pixcopy_routines copyroutine>
-static void display_img_pc(KOORD_VAL h, const KOORD_VAL xp, const KOORD_VAL yp, const PIXVAL *sp  CLIP_NUM_DEF)
+static void display_img_pc(scr_coord_val h, const scr_coord_val xp, const scr_coord_val yp, const PIXVAL *sp  CLIP_NUM_DEF)
 {
 	if(  h > 0  ) {
 		PIXVAL *tp = textur + yp * disp_width;
@@ -2389,7 +2390,7 @@ static void display_img_pc(KOORD_VAL h, const KOORD_VAL xp, const KOORD_VAL yp, 
 /**
  * Draw image with horizontal clipping
  */
-static void display_img_wc(KOORD_VAL h, const KOORD_VAL xp, const KOORD_VAL yp, const PIXVAL *sp  CLIP_NUM_DEF)
+static void display_img_wc(scr_coord_val h, const scr_coord_val xp, const scr_coord_val yp, const PIXVAL *sp  CLIP_NUM_DEF)
 {
 	if(  h > 0  ) {
 		PIXVAL *tp = textur + yp * disp_width;
@@ -2434,7 +2435,7 @@ static void display_img_wc(KOORD_VAL h, const KOORD_VAL xp, const KOORD_VAL yp, 
 /**
  * Draw each image without clipping
  */
-static void display_img_nc(KOORD_VAL h, const KOORD_VAL xp, const KOORD_VAL yp, const PIXVAL *sp)
+static void display_img_nc(scr_coord_val h, const scr_coord_val xp, const scr_coord_val yp, const PIXVAL *sp)
 {
 	if (h > 0) {
 		PIXVAL *tp = textur + xp + yp * disp_width;
@@ -2541,7 +2542,7 @@ void display_img_aligned( const image_id n, scr_rect area, int align, const int 
 /**
  * Draw image with vertical clipping (quickly) and horizontal (slowly)
  */
-void display_img_aux(const image_id n, KOORD_VAL xp, KOORD_VAL yp, const sint8 player_nr_raw, const int /*daynight*/, const int dirty  CLIP_NUM_DEF)
+void display_img_aux(const image_id n, scr_coord_val xp, scr_coord_val yp, const sint8 player_nr_raw, const int /*daynight*/, const int dirty  CLIP_NUM_DEF)
 {
 	if(  n < anz_images  ) {
 		// only use player images if needed
@@ -2573,14 +2574,14 @@ void display_img_aux(const image_id n, KOORD_VAL xp, KOORD_VAL yp, const sint8 p
 		}
 		// now, since zooming may have change this image
 		yp += images[n].y;
-		KOORD_VAL h = images[n].h; // may change due to vertical clipping
+		scr_coord_val h = images[n].h; // may change due to vertical clipping
 
 		// in the next line the vertical clipping will be handled
 		// by that way the drawing routines must only take into account the horizontal clipping
 		// this should be much faster in most cases
 
 		// must the height be reduced?
-		KOORD_VAL reduce_h = yp + h - CR.clip_rect.yy;
+		scr_coord_val reduce_h = yp + h - CR.clip_rect.yy;
 		if(  reduce_h > 0  ) {
 			h -= reduce_h;
 		}
@@ -2590,7 +2591,7 @@ void display_img_aux(const image_id n, KOORD_VAL xp, KOORD_VAL yp, const sint8 p
 		}
 
 		// vertically lines to skip (only bottom is visible
-		KOORD_VAL skip_lines = CR.clip_rect.y - (int)yp;
+		scr_coord_val skip_lines = CR.clip_rect.y - (int)yp;
 		if(  skip_lines > 0  ) {
 			if(  skip_lines >= h  ) {
 				// not visible at all
@@ -2614,7 +2615,7 @@ void display_img_aux(const image_id n, KOORD_VAL xp, KOORD_VAL yp, const sint8 p
 		// new block for new variables
 		{
 			// needed now ...
-			const KOORD_VAL w = images[n].w;
+			const scr_coord_val w = images[n].w;
 			xp += images[n].x;
 
 			// clipping at poly lines?
@@ -2837,7 +2838,7 @@ void display_img_stretch_blend( const stretch_map_t &imag, scr_rect area, FLAGGE
  * assumes height is ok and valid data are calculated.
  * color replacement needs the original data => sp points to non-cached data
  */
-static void display_color_img_wc(const PIXVAL *sp, KOORD_VAL x, KOORD_VAL y, KOORD_VAL h  CLIP_NUM_DEF)
+static void display_color_img_wc(const PIXVAL *sp, scr_coord_val x, scr_coord_val y, scr_coord_val h  CLIP_NUM_DEF)
 {
 	PIXVAL *tp = textur + y * disp_width;
 
@@ -2875,7 +2876,7 @@ static void display_color_img_wc(const PIXVAL *sp, KOORD_VAL x, KOORD_VAL y, KOO
 /**
  * Draw Image, replaced player color
  */
-void display_color_img(const image_id n, KOORD_VAL xp, KOORD_VAL yp, sint8 player_nr_raw, const int daynight, const int dirty  CLIP_NUM_DEF)
+void display_color_img(const image_id n, scr_coord_val xp, scr_coord_val yp, sint8 player_nr_raw, const int daynight, const int dirty  CLIP_NUM_DEF)
 {
 	if(  n < anz_images  ) {
 		// do we have to use a player nr?
@@ -2896,10 +2897,10 @@ void display_color_img(const image_id n, KOORD_VAL xp, KOORD_VAL yp, sint8 playe
 		else {
 		// do player colour substitution but not daynight - can't use cached images. Do NOT call multithreaded.
 		// now test if visible and clipping needed
-			const KOORD_VAL x = images[n].x + xp;
-			      KOORD_VAL y = images[n].y + yp;
-			const KOORD_VAL w = images[n].w;
-			      KOORD_VAL h = images[n].h;
+			const scr_coord_val x = images[n].x + xp;
+			      scr_coord_val y = images[n].y + yp;
+			const scr_coord_val w = images[n].w;
+			      scr_coord_val h = images[n].h;
 			if(  h <= 0  ||  x >= CR.clip_rect.xx  ||  y >= CR.clip_rect.yy  ||  x + w <= CR.clip_rect.x  ||  y + h <= CR.clip_rect.y  ) {
 				// not visible => we are done
 				// happens quite often ...
@@ -2916,7 +2917,7 @@ void display_color_img(const image_id n, KOORD_VAL xp, KOORD_VAL yp, sint8 playe
 			const PIXVAL *sp = images[n].zoom_data != NULL ? images[n].zoom_data : images[n].base_data;
 
 			// clip top/bottom
-			KOORD_VAL yoff = clip_wh( &y, &h, CR.clip_rect.y, CR.clip_rect.yy );
+			scr_coord_val yoff = clip_wh( &y, &h, CR.clip_rect.y, CR.clip_rect.yy );
 			if(  h > 0  ) { // clipping may have reduced it
 				// clip top
 				while(  yoff  ) {
@@ -2942,7 +2943,7 @@ void display_color_img(const image_id n, KOORD_VAL xp, KOORD_VAL yp, sint8 playe
 	} // number ok
 }
 
-void display_color_img_with_tooltip(const image_id n, KOORD_VAL xp, KOORD_VAL yp, sint8 player_nr_raw, const int daynight, const int dirty, const char *text  CLIP_NUM_DEF_NOUSE)
+void display_color_img_with_tooltip(const image_id n, scr_coord_val xp, scr_coord_val yp, sint8 player_nr_raw, const int daynight, const int dirty, const char *text  CLIP_NUM_DEF_NOUSE)
 {
 	display_color_img(n, xp, yp, player_nr_raw, daynight, dirty);
 	if (text && n < anz_images && ( xp <= get_mouse_x() && yp <= get_mouse_y() && (xp+ images[n].w) > get_mouse_x() && (yp+ images[n].h) > get_mouse_y())) {
@@ -2953,7 +2954,7 @@ void display_color_img_with_tooltip(const image_id n, KOORD_VAL xp, KOORD_VAL yp
 /**
  * draw unscaled images, replaces base color
  */
-void display_base_img(const image_id n, KOORD_VAL xp, KOORD_VAL yp, const sint8 player_nr, const int daynight, const int dirty  CLIP_NUM_DEF)
+void display_base_img(const image_id n, scr_coord_val xp, scr_coord_val yp, const sint8 player_nr, const int daynight, const int dirty  CLIP_NUM_DEF)
 {
 	if(  base_tile_raster_width==tile_raster_width  ) {
 		// same size => use standard routine
@@ -2961,10 +2962,10 @@ void display_base_img(const image_id n, KOORD_VAL xp, KOORD_VAL yp, const sint8 
 	}
 	else if(  n < anz_images  ) {
 		// now test if visible and clipping needed
-		const KOORD_VAL x = images[n].base_x + xp;
-		      KOORD_VAL y = images[n].base_y + yp;
-		const KOORD_VAL w = images[n].base_w;
-		      KOORD_VAL h = images[n].base_h;
+		const scr_coord_val x = images[n].base_x + xp;
+		      scr_coord_val y = images[n].base_y + yp;
+		const scr_coord_val w = images[n].base_w;
+		      scr_coord_val h = images[n].base_h;
 
 		if(  h <= 0  ||  x >= CR.clip_rect.xx  ||  y >= CR.clip_rect.yy  ||  x + w <= CR.clip_rect.x  ||  y + h <= CR.clip_rect.y  ) {
 			// not visible => we are done
@@ -2989,7 +2990,7 @@ void display_base_img(const image_id n, KOORD_VAL xp, KOORD_VAL yp, const sint8 
 		const PIXVAL *sp = images[n].base_data;
 
 		// clip top/bottom
-		KOORD_VAL yoff = clip_wh( &y, &h, CR.clip_rect.y, CR.clip_rect.yy );
+		scr_coord_val yoff = clip_wh( &y, &h, CR.clip_rect.y, CR.clip_rect.yy );
 		if(  h > 0  ) { // clipping may have reduced it
 			// clip top
 			while(  yoff  ) {
@@ -3282,7 +3283,7 @@ static blend_proc outline[3];
 /**
  * Blends a rectangular region with a color
  */
-void display_blend_wh_rgb(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, PIXVAL colval, int percent_blend )
+void display_blend_wh_rgb(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, PIXVAL colval, int percent_blend )
 {
 	if(  clip_lr( &xp, &w, CR0.clip_rect.x, CR0.clip_rect.xx )  &&  clip_lr( &yp, &h, CR0.clip_rect.y, CR0.clip_rect.yy )  ) {
 		const PIXVAL alpha = (percent_blend*64)/100;
@@ -3298,7 +3299,7 @@ void display_blend_wh_rgb(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, 
 				// fast blending with 1/4 | 1/2 | 3/4 percentage
 				blend_proc blend = outline[ (alpha>>4) - 1 ];
 
-				for(  KOORD_VAL y=0;  y<h;  y++  ) {
+				for(  scr_coord_val y=0;  y<h;  y++  ) {
 					blend( textur + xp + (yp+y) * disp_width, NULL, colval, w );
 				}
 			}
@@ -3354,7 +3355,7 @@ void display_blend_wh_rgb(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, 
 	}
 }
 
-void display_linear_gradient_wh_rgb(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, PIXVAL colval, int percent_blend_start, int percent_blend_end, bool horizontal)
+void display_linear_gradient_wh_rgb(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, PIXVAL colval, int percent_blend_start, int percent_blend_end, bool horizontal)
 {
 	uint8 transparency = 0;
 	if (horizontal) {
@@ -3371,7 +3372,7 @@ void display_linear_gradient_wh_rgb(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOO
 	}
 }
 
-static void display_img_blend_wc(KOORD_VAL h, const KOORD_VAL xp, const KOORD_VAL yp, const PIXVAL *sp, int colour, blend_proc p  CLIP_NUM_DEF )
+static void display_img_blend_wc(scr_coord_val h, const scr_coord_val xp, const scr_coord_val yp, const PIXVAL *sp, int colour, blend_proc p  CLIP_NUM_DEF )
 {
 	if(  h > 0  ) {
 		PIXVAL *tp = textur + yp * disp_width;
@@ -3574,7 +3575,7 @@ static void pix_alpha_recode_16(PIXVAL *dest, const PIXVAL *src, const PIXVAL *a
 }
 
 
-static void display_img_alpha_wc(KOORD_VAL h, const KOORD_VAL xp, const KOORD_VAL yp, const PIXVAL *sp, const PIXVAL *alphamap, const uint8 alpha_flags, int colour, alpha_proc p  CLIP_NUM_DEF )
+static void display_img_alpha_wc(scr_coord_val h, const scr_coord_val xp, const scr_coord_val yp, const PIXVAL *sp, const PIXVAL *alphamap, const uint8 alpha_flags, int colour, alpha_proc p  CLIP_NUM_DEF )
 {
 	if(  h > 0  ) {
 		PIXVAL *tp = textur + yp * disp_width;
@@ -3616,7 +3617,7 @@ static void display_img_alpha_wc(KOORD_VAL h, const KOORD_VAL xp, const KOORD_VA
 /**
  * draws the transparent outline of an image
  */
-void display_rezoomed_img_blend(const image_id n, KOORD_VAL xp, KOORD_VAL yp, const signed char /*player_nr*/, const FLAGGED_PIXVAL color_index, const int /*daynight*/, const int dirty  CLIP_NUM_DEF)
+void display_rezoomed_img_blend(const image_id n, scr_coord_val xp, scr_coord_val yp, const signed char /*player_nr*/, const FLAGGED_PIXVAL color_index, const int /*daynight*/, const int dirty  CLIP_NUM_DEF)
 {
 	if(  n < anz_images  ) {
 		// need to go to nightmode and or rezoomed?
@@ -3632,14 +3633,14 @@ void display_rezoomed_img_blend(const image_id n, KOORD_VAL xp, KOORD_VAL yp, co
 		// now, since zooming may have change this image
 		xp += images[n].x;
 		yp += images[n].y;
-		KOORD_VAL h = images[n].h; // may change due to vertical clipping
+		scr_coord_val h = images[n].h; // may change due to vertical clipping
 
 		// in the next line the vertical clipping will be handled
 		// by that way the drawing routines must only take into account the horizontal clipping
 		// this should be much faster in most cases
 
 		// must the height be reduced?
-		KOORD_VAL reduce_h = yp + h - CR.clip_rect.yy;
+		scr_coord_val reduce_h = yp + h - CR.clip_rect.yy;
 		if(  reduce_h > 0  ) {
 			h -= reduce_h;
 		}
@@ -3647,7 +3648,7 @@ void display_rezoomed_img_blend(const image_id n, KOORD_VAL xp, KOORD_VAL yp, co
 		if(  h <= 0  ) return;
 
 		// vertically lines to skip (only bottom is visible)
-		KOORD_VAL skip_lines = CR.clip_rect.y - (int)yp;
+		scr_coord_val skip_lines = CR.clip_rect.y - (int)yp;
 		if(  skip_lines > 0  ) {
 			if(  skip_lines >= h  ) {
 				// not visible at all
@@ -3671,7 +3672,7 @@ void display_rezoomed_img_blend(const image_id n, KOORD_VAL xp, KOORD_VAL yp, co
 		// new block for new variables
 		{
 			// needed now ...
-			const KOORD_VAL w = images[n].w;
+			const scr_coord_val w = images[n].w;
 			// get the real color
 			const PIXVAL color = color_index & 0xFFFF;
 			// we use function pointer for the blend runs for the moment ...
@@ -3697,7 +3698,7 @@ void display_rezoomed_img_blend(const image_id n, KOORD_VAL xp, KOORD_VAL yp, co
 }
 
 
-void display_rezoomed_img_alpha(const image_id n, const image_id alpha_n, const unsigned alpha_flags, KOORD_VAL xp, KOORD_VAL yp, const signed char /*player_nr*/, const FLAGGED_PIXVAL color_index, const int /*daynight*/, const int dirty  CLIP_NUM_DEF)
+void display_rezoomed_img_alpha(const image_id n, const image_id alpha_n, const unsigned alpha_flags, scr_coord_val xp, scr_coord_val yp, const signed char /*player_nr*/, const FLAGGED_PIXVAL color_index, const int /*daynight*/, const int dirty  CLIP_NUM_DEF)
 {
 	if(  n < anz_images  &&  alpha_n < anz_images  ) {
 		// need to go to nightmode and or rezoomed?
@@ -3717,14 +3718,14 @@ void display_rezoomed_img_alpha(const image_id n, const image_id alpha_n, const 
 		// now, since zooming may have change this image
 		xp += images[n].x;
 		yp += images[n].y;
-		KOORD_VAL h = images[n].h; // may change due to vertical clipping
+		scr_coord_val h = images[n].h; // may change due to vertical clipping
 
 		// in the next line the vertical clipping will be handled
 		// by that way the drawing routines must only take into account the horizontal clipping
 		// this should be much faster in most cases
 
 		// must the height be reduced?
-		KOORD_VAL reduce_h = yp + h - CR.clip_rect.yy;
+		scr_coord_val reduce_h = yp + h - CR.clip_rect.yy;
 		if(  reduce_h > 0  ) {
 			h -= reduce_h;
 		}
@@ -3734,7 +3735,7 @@ void display_rezoomed_img_alpha(const image_id n, const image_id alpha_n, const 
 		}
 
 		// vertically lines to skip (only bottom is visible
-		KOORD_VAL skip_lines = CR.clip_rect.y - (int)yp;
+		scr_coord_val skip_lines = CR.clip_rect.y - (int)yp;
 		if(  skip_lines > 0  ) {
 			if(  skip_lines >= h  ) {
 				// not visible at all
@@ -3762,7 +3763,7 @@ void display_rezoomed_img_alpha(const image_id n, const image_id alpha_n, const 
 		// new block for new variables
 		{
 			// needed now ...
-			const KOORD_VAL w = images[n].w;
+			const scr_coord_val w = images[n].w;
 			// get the real color
 			const PIXVAL color = color_index & 0xFFFF;
 
@@ -3787,7 +3788,7 @@ void display_rezoomed_img_alpha(const image_id n, const image_id alpha_n, const 
 
 
 // For blending or outlining unzoomed image. Adapted from display_base_img() and display_unzoomed_img_blend()
-void display_base_img_blend(const image_id n, KOORD_VAL xp, KOORD_VAL yp, const signed char player_nr, const FLAGGED_PIXVAL color_index, const int daynight, const int dirty  CLIP_NUM_DEF)
+void display_base_img_blend(const image_id n, scr_coord_val xp, scr_coord_val yp, const signed char player_nr, const FLAGGED_PIXVAL color_index, const int daynight, const int dirty  CLIP_NUM_DEF)
 {
 	if(  base_tile_raster_width == tile_raster_width  ) {
 		// same size => use standard routine
@@ -3795,10 +3796,10 @@ void display_base_img_blend(const image_id n, KOORD_VAL xp, KOORD_VAL yp, const 
 	}
 	else if(  n < anz_images  ) {
 		// now test if visible and clipping needed
-		KOORD_VAL x = images[n].base_x + xp;
-		KOORD_VAL y = images[n].base_y + yp;
-		KOORD_VAL w = images[n].base_w;
-		KOORD_VAL h = images[n].base_h;
+		scr_coord_val x = images[n].base_x + xp;
+		scr_coord_val y = images[n].base_y + yp;
+		scr_coord_val w = images[n].base_w;
+		scr_coord_val h = images[n].base_h;
 		if(  h == 0  ||  x >= CR.clip_rect.xx  ||  y >= CR.clip_rect.yy  ||  x + w <= CR.clip_rect.x  ||  y + h <= CR.clip_rect.y  ) {
 			// not visible => we are done
 			// happens quite often ...
@@ -3808,13 +3809,13 @@ void display_base_img_blend(const image_id n, KOORD_VAL xp, KOORD_VAL yp, const 
 		PIXVAL *sp = images[n].base_data;
 
 		// must the height be reduced?
-		KOORD_VAL reduce_h = y + h - CR.clip_rect.yy;
+		scr_coord_val reduce_h = y + h - CR.clip_rect.yy;
 		if(  reduce_h > 0  ) {
 			h -= reduce_h;
 		}
 
 		// vertical lines to skip (only bottom is visible)
-		KOORD_VAL skip_lines = CR.clip_rect.y - (int)y;
+		scr_coord_val skip_lines = CR.clip_rect.y - (int)y;
 		if(  skip_lines > 0  ) {
 			h -= skip_lines;
 			y += skip_lines;
@@ -3866,7 +3867,7 @@ void display_base_img_blend(const image_id n, KOORD_VAL xp, KOORD_VAL yp, const 
 }
 
 
-void display_base_img_alpha(const image_id n, const image_id alpha_n, const unsigned alpha_flags, KOORD_VAL xp, KOORD_VAL yp, const signed char player_nr, const FLAGGED_PIXVAL color_index, const int daynight, const int dirty  CLIP_NUM_DEF)
+void display_base_img_alpha(const image_id n, const image_id alpha_n, const unsigned alpha_flags, scr_coord_val xp, scr_coord_val yp, const signed char player_nr, const FLAGGED_PIXVAL color_index, const int daynight, const int dirty  CLIP_NUM_DEF)
 {
 	if(  base_tile_raster_width == tile_raster_width  ) {
 		// same size => use standard routine
@@ -3874,10 +3875,10 @@ void display_base_img_alpha(const image_id n, const image_id alpha_n, const unsi
 	}
 	else if(  n < anz_images  ) {
 		// now test if visible and clipping needed
-		KOORD_VAL x = images[n].base_x + xp;
-		KOORD_VAL y = images[n].base_y + yp;
-		KOORD_VAL w = images[n].base_w;
-		KOORD_VAL h = images[n].base_h;
+		scr_coord_val x = images[n].base_x + xp;
+		scr_coord_val y = images[n].base_y + yp;
+		scr_coord_val w = images[n].base_w;
+		scr_coord_val h = images[n].base_h;
 		if(  h == 0  ||  x >= CR.clip_rect.xx  ||  y >= CR.clip_rect.yy  ||  x + w <= CR.clip_rect.x  ||  y + h <= CR.clip_rect.y  ) {
 			// not visible => we are done
 			// happens quite often ...
@@ -3888,13 +3889,13 @@ void display_base_img_alpha(const image_id n, const image_id alpha_n, const unsi
 		PIXVAL *alphamap = images[alpha_n].base_data;
 
 		// must the height be reduced?
-		KOORD_VAL reduce_h = y + h - CR.clip_rect.yy;
+		scr_coord_val reduce_h = y + h - CR.clip_rect.yy;
 		if(  reduce_h > 0  ) {
 			h -= reduce_h;
 		}
 
 		// vertical lines to skip (only bottom is visible)
-		KOORD_VAL skip_lines = CR.clip_rect.y - (int)y;
+		scr_coord_val skip_lines = CR.clip_rect.y - (int)y;
 		if(  skip_lines > 0  ) {
 			h -= skip_lines;
 			y += skip_lines;
@@ -3956,7 +3957,7 @@ void display_base_img_alpha(const image_id n, const image_id alpha_n, const unsi
 
 
 // scrolls horizontally, will ignore clipping etc.
-void display_scroll_band(KOORD_VAL start_y, KOORD_VAL x_offset, KOORD_VAL h)
+void display_scroll_band(scr_coord_val start_y, scr_coord_val x_offset, scr_coord_val h)
 {
 	start_y  = max(start_y,  0);
 	x_offset = min(x_offset, disp_width);
@@ -3974,9 +3975,9 @@ void display_scroll_band(KOORD_VAL start_y, KOORD_VAL x_offset, KOORD_VAL h)
  * Draw one Pixel
  */
 #ifdef DEBUG_FLUSH_BUFFER
-static void display_pixel(KOORD_VAL x, KOORD_VAL y, PIXVAL color, bool mark_dirty=true)
+static void display_pixel(scr_coord_val x, scr_coord_val y, PIXVAL color, bool mark_dirty=true)
 #else
-static void display_pixel(KOORD_VAL x, KOORD_VAL y, PIXVAL color)
+static void display_pixel(scr_coord_val x, scr_coord_val y, PIXVAL color)
 #endif
 {
 	if(  x >= CR0.clip_rect.x  &&  x < CR0.clip_rect.xx  &&  y >= CR0.clip_rect.y  &&  y < CR0.clip_rect.yy  ) {
@@ -3997,7 +3998,7 @@ static void display_pixel(KOORD_VAL x, KOORD_VAL y, PIXVAL color)
 /**
  * Draw filled rectangle
  */
-static void display_fb_internal(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, PIXVAL colval, bool dirty, KOORD_VAL cL, KOORD_VAL cR, KOORD_VAL cT, KOORD_VAL cB)
+static void display_fb_internal(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, PIXVAL colval, bool dirty, scr_coord_val cL, scr_coord_val cR, scr_coord_val cT, scr_coord_val cB)
 {
 	if (clip_lr(&xp, &w, cL, cR) && clip_lr(&yp, &h, cT, cB)) {
 		PIXVAL *p = textur + xp + yp * disp_width;
@@ -4031,7 +4032,7 @@ static void display_fb_internal(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_V
 		// low level c++
 		const uint32 colvald = (colval << 16) | colval;
 		do {
-			KOORD_VAL count = w;
+			scr_coord_val count = w;
 
 			// align to 4 bytes, should use uintptr_t but not available
 			if(  reinterpret_cast<size_t>(p) & 0x2  ) {
@@ -4064,25 +4065,25 @@ static void display_fb_internal(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_V
 }
 
 
-void display_fillbox_wh_rgb(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, PIXVAL color, bool dirty)
+void display_fillbox_wh_rgb(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, PIXVAL color, bool dirty)
 {
 	display_fb_internal(xp, yp, w, h, color, dirty, 0, disp_width, 0, disp_height);
 }
 
 
-void display_fillbox_wh_clip_rgb(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, PIXVAL color, bool dirty  CLIP_NUM_DEF)
+void display_fillbox_wh_clip_rgb(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, PIXVAL color, bool dirty  CLIP_NUM_DEF)
 {
 	display_fb_internal(xp, yp, w, h, color, dirty, CR.clip_rect.x, CR.clip_rect.xx, CR.clip_rect.y, CR.clip_rect.yy);
 }
 
-void display_filled_roundbox_clip(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, PIXVAL color, bool dirty)
+void display_filled_roundbox_clip(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, PIXVAL color, bool dirty)
 {
 	display_fillbox_wh_clip_rgb(xp, yp+1, w, h-2, color, dirty);
 	display_fillbox_wh_clip_rgb(xp+1, yp, w-2, 1, color, dirty);
 	display_fillbox_wh_clip_rgb(xp+1, yp + h-1, w-2, 1, color, dirty);
 }
 
-void display_cylinderbar_wh_clip_rgb(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, PIXVAL color, bool dirty  CLIP_NUM_DEF)
+void display_cylinderbar_wh_clip_rgb(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, PIXVAL color, bool dirty  CLIP_NUM_DEF)
 {
 	display_fb_internal( xp, yp, w, h, color, dirty, CR.clip_rect.x, CR.clip_rect.xx, CR.clip_rect.y, CR.clip_rect.yy );
 	for (uint8 i = 1; i < h/2; i++) {
@@ -4095,7 +4096,7 @@ void display_cylinderbar_wh_clip_rgb(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KO
 }
 
 
-void display_colorbox_with_tooltip(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, PIXVAL color, bool dirty, const char *text)
+void display_colorbox_with_tooltip(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, PIXVAL color, bool dirty, const char *text)
 {
 	display_ddd_box_clip_rgb(xp, yp, w, h, color_idx_to_rgb(MN_GREY0), color_idx_to_rgb(MN_GREY4));
 	//display_fb_internal(xp+1, yp+1, w-2, h-2, color, dirty, CR.clip_rect.x, CR.clip_rect.xx, CR.clip_rect.y, CR.clip_rect.yy);
@@ -4111,7 +4112,7 @@ void display_colorbox_with_tooltip(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOOR
 /**
  * Draw vertical line
  */
-static void display_vl_internal(const KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL h, const PIXVAL colval, int dirty, KOORD_VAL cL, KOORD_VAL cR, KOORD_VAL cT, KOORD_VAL cB)
+static void display_vl_internal(const scr_coord_val xp, scr_coord_val yp, scr_coord_val h, const PIXVAL colval, int dirty, scr_coord_val cL, scr_coord_val cR, scr_coord_val cT, scr_coord_val cB)
 {
 	if (xp >= cL && xp < cR && clip_lr(&yp, &h, cT, cB)) {
 		PIXVAL *p = textur + xp + yp * disp_width;
@@ -4126,13 +4127,13 @@ static void display_vl_internal(const KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL h, c
 }
 
 
-void display_vline_wh_rgb(const KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL h, const PIXVAL color, bool dirty)
+void display_vline_wh_rgb(const scr_coord_val xp, scr_coord_val yp, scr_coord_val h, const PIXVAL color, bool dirty)
 {
 	display_vl_internal(xp, yp, h, color, dirty, 0, disp_width, 0, disp_height);
 }
 
 
-void display_vline_wh_clip_rgb(const KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL h, const PIXVAL color, bool dirty  CLIP_NUM_DEF)
+void display_vline_wh_clip_rgb(const scr_coord_val xp, scr_coord_val yp, scr_coord_val h, const PIXVAL color, bool dirty  CLIP_NUM_DEF)
 {
 	display_vl_internal( xp, yp, h, color, dirty, CR.clip_rect.x, CR.clip_rect.xx, CR.clip_rect.y, CR.clip_rect.yy );
 }
@@ -4141,11 +4142,11 @@ void display_vline_wh_clip_rgb(const KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL h, co
 /**
  * Draw raw Pixel data
  */
-void display_array_wh(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, const PIXVAL *arr)
+void display_array_wh(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, const PIXVAL *arr)
 {
 	const int arr_w = w;
-	const KOORD_VAL xoff = clip_wh( &xp, &w, CR0.clip_rect.x, CR0.clip_rect.xx );
-	const KOORD_VAL yoff = clip_wh( &yp, &h, CR0.clip_rect.y, CR0.clip_rect.yy );
+	const scr_coord_val xoff = clip_wh( &xp, &w, CR0.clip_rect.x, CR0.clip_rect.xx );
+	const scr_coord_val yoff = clip_wh( &yp, &h, CR0.clip_rect.y, CR0.clip_rect.yy );
 	if(  w > 0  &&  h > 0  ) {
 		PIXVAL *p = textur + xp + yp * disp_width;
 		const PIXVAL *arr_src = arr;
@@ -4165,7 +4166,7 @@ void display_array_wh(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, cons
 	}
 }
 
-void display_veh_form_wh_clip_rgb(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, PIXVAL color, bool dirty, uint8 basic_constraint_flags, uint8 interactivity, bool is_rightside  CLIP_NUM_DEF_NOUSE)
+void display_veh_form_wh_clip_rgb(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, PIXVAL color, bool dirty, uint8 basic_constraint_flags, uint8 interactivity, bool is_rightside  CLIP_NUM_DEF_NOUSE)
 {
 	uint8 h = VEHICLE_BAR_HEIGHT;
 	uint8 width = (uint8)((w + 1) * 0.9);
@@ -4343,16 +4344,16 @@ sint32 get_prev_char(const char* text, sint32 pos)
 }
 
 
-KOORD_VAL display_get_char_width(utf32 c)
+scr_coord_val display_get_char_width(utf32 c)
 {
 	return default_font.get_glyph_advance(c);
 }
 
 
 /* returns the width of this character or the default (Nr 0) character size */
-KOORD_VAL display_get_char_max_width(const char* text, size_t len) {
+scr_coord_val display_get_char_max_width(const char* text, size_t len) {
 
-	KOORD_VAL max_len=0;
+	scr_coord_val max_len=0;
 
 	for(unsigned n=0; (len && n<len) || (len==0 && *text != '\0'); n++) {
 		max_len = max(max_len,display_get_char_width(*text++));
@@ -4551,9 +4552,9 @@ static unsigned char get_h_mask(const int xL, const int xR, const int cL, const 
  * len parameter added - use -1 for previous behaviour.
  * completely renovated for unicode and 10 bit width and variable height
  */
-int display_text_proportional_len_clip_rgb(KOORD_VAL x, KOORD_VAL y, const char* txt, control_alignment_t flags, const PIXVAL color, bool dirty, sint32 len  CLIP_NUM_DEF)
+int display_text_proportional_len_clip_rgb(scr_coord_val x, scr_coord_val y, const char* txt, control_alignment_t flags, const PIXVAL color, bool dirty, sint32 len  CLIP_NUM_DEF)
 {
-	KOORD_VAL cL, cR, cT, cB;
+	scr_coord_val cL, cR, cT, cB;
 
 	// TAKE CARE: Clipping area may be larger than actual screen size
 	if(  (flags & DT_CLIP)  ) {
@@ -4598,11 +4599,11 @@ int display_text_proportional_len_clip_rgb(KOORD_VAL x, KOORD_VAL y, const char*
 	}
 
 	// store the initial x (for dirty marking)
-	const KOORD_VAL x0 = x;
+	const scr_coord_val x0 = x;
 
-	KOORD_VAL y_offset = 0; // real y for display with clipping
-	KOORD_VAL glyph_height = fnt->get_linespace();
-	const KOORD_VAL yy = y + fnt->get_linespace();
+	scr_coord_val y_offset = 0; // real y for display with clipping
+	scr_coord_val glyph_height = fnt->get_linespace();
+	const scr_coord_val yy = y + fnt->get_linespace();
 
 	// calculate vertical y clipping parameters
 	if (y < cT) {
@@ -4693,7 +4694,7 @@ int display_text_proportional_len_clip_rgb(KOORD_VAL x, KOORD_VAL y, const char*
  * If enough space is given then it just displays the full string
  * @returns screen_width
  */
-KOORD_VAL display_proportional_ellipsis_rgb( scr_rect r, const char *text, int align, const PIXVAL color, const bool dirty, bool shadowed, PIXVAL shadow_color)
+scr_coord_val display_proportional_ellipsis_rgb( scr_rect r, const char *text, int align, const PIXVAL color, const bool dirty, bool shadowed, PIXVAL shadow_color)
 {
 	const scr_coord_val ellipsis_width = translator::get_lang()->ellipsis_width;
 	const scr_coord_val max_screen_width = r.w;
@@ -4728,7 +4729,7 @@ KOORD_VAL display_proportional_ellipsis_rgb( scr_rect r, const char *text, int a
 		}
 		// if it does not fit
 		if(  max_screen_width < (current_offset+pixel_width)  ) {
-			KOORD_VAL w = 0;
+			scr_coord_val w = 0;
 			// since we know the length already, we try to center the text with the remaining pixels of the last character
 			if(  align & ALIGN_CENTER_H  ) {
 				w = (max_screen_width-max_offset_before_ellipsis-ellipsis_width)/2;
@@ -4768,7 +4769,7 @@ KOORD_VAL display_proportional_ellipsis_rgb( scr_rect r, const char *text, int a
 /**
  * Draw shaded rectangle using direct color values
  */
-void display_ddd_box_rgb(KOORD_VAL x1, KOORD_VAL y1, KOORD_VAL w, KOORD_VAL h, PIXVAL tl_color, PIXVAL rd_color, bool dirty)
+void display_ddd_box_rgb(scr_coord_val x1, scr_coord_val y1, scr_coord_val w, scr_coord_val h, PIXVAL tl_color, PIXVAL rd_color, bool dirty)
 {
 	display_fillbox_wh_rgb(x1, y1,         w, 1, tl_color, dirty);
 	display_fillbox_wh_rgb(x1, y1 + h - 1, w, 1, rd_color, dirty);
@@ -4780,7 +4781,7 @@ void display_ddd_box_rgb(KOORD_VAL x1, KOORD_VAL y1, KOORD_VAL w, KOORD_VAL h, P
 }
 
 
-void display_outline_proportional_rgb(KOORD_VAL xpos, KOORD_VAL ypos, PIXVAL text_color, PIXVAL shadow_color, const char *text, int dirty, sint32 len)
+void display_outline_proportional_rgb(scr_coord_val xpos, scr_coord_val ypos, PIXVAL text_color, PIXVAL shadow_color, const char *text, int dirty, sint32 len)
 {
 	const int flags = ALIGN_LEFT | DT_CLIP;
 	display_text_proportional_len_clip_rgb(xpos - 1, ypos - 1 + (12 - LINESPACE) / 2, text, flags, shadow_color, dirty, len  CLIP_NUM_DEFAULT);
@@ -4789,7 +4790,7 @@ void display_outline_proportional_rgb(KOORD_VAL xpos, KOORD_VAL ypos, PIXVAL tex
 }
 
 
-void display_shadow_proportional_rgb(KOORD_VAL xpos, KOORD_VAL ypos, PIXVAL text_color, PIXVAL shadow_color, const char *text, int dirty, sint32 len)
+void display_shadow_proportional_rgb(scr_coord_val xpos, scr_coord_val ypos, PIXVAL text_color, PIXVAL shadow_color, const char *text, int dirty, sint32 len)
 {
 	const int flags = ALIGN_LEFT | DT_CLIP;
 	display_text_proportional_len_clip_rgb(xpos + 1, ypos + 1 + (12 - LINESPACE) / 2, text, flags, shadow_color, dirty, len  CLIP_NUM_DEFAULT);
@@ -4799,7 +4800,7 @@ void display_shadow_proportional_rgb(KOORD_VAL xpos, KOORD_VAL ypos, PIXVAL text
 
 // If want to set the background color in some styles, use it together with display_fillbox_wh_clip
 // style: 0=roundbox back ground, 1=left box + bottom line with shadow, 2=only left box
-void display_heading_rgb(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, PIXVAL text_color, PIXVAL frame_color, const char *text, int dirty, uint8 style)
+void display_heading_rgb(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, PIXVAL text_color, PIXVAL frame_color, const char *text, int dirty, uint8 style)
 {
 	if (h < LINESPACE) { h = LINESPACE; }
 	if (style > 3/* max styles */) { style = 0; }
@@ -4840,7 +4841,7 @@ void display_heading_rgb(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, P
 /**
  * Draw shaded rectangle using direct color values
  */
-void display_ddd_box_clip_rgb(KOORD_VAL x1, KOORD_VAL y1, KOORD_VAL w, KOORD_VAL h, PIXVAL tl_color, PIXVAL rd_color)
+void display_ddd_box_clip_rgb(scr_coord_val x1, scr_coord_val y1, scr_coord_val w, scr_coord_val h, PIXVAL tl_color, PIXVAL rd_color)
 {
 	display_fillbox_wh_clip_rgb(x1, y1,         w, 1, tl_color, true);
 	display_fillbox_wh_clip_rgb(x1, y1 + h - 1, w, 1, rd_color, true);
@@ -4853,7 +4854,7 @@ void display_ddd_box_clip_rgb(KOORD_VAL x1, KOORD_VAL y1, KOORD_VAL w, KOORD_VAL
 
 
 // if width equals zero, take default value
-void display_ddd_proportional(KOORD_VAL xpos, KOORD_VAL ypos, KOORD_VAL width, KOORD_VAL hgt, FLAGGED_PIXVAL ddd_color, FLAGGED_PIXVAL text_color, const char *text, int dirty)
+void display_ddd_proportional(scr_coord_val xpos, scr_coord_val ypos, scr_coord_val width, scr_coord_val hgt, FLAGGED_PIXVAL ddd_color, FLAGGED_PIXVAL text_color, const char *text, int dirty)
 {
 	const int halfheight = LINESPACE / 2 + 1;
 
@@ -4875,7 +4876,7 @@ void display_ddd_proportional(KOORD_VAL xpos, KOORD_VAL ypos, KOORD_VAL width, K
 /**
  * display text in 3d box with clipping
  */
-void display_ddd_proportional_clip(KOORD_VAL xpos, KOORD_VAL ypos, KOORD_VAL width, KOORD_VAL hgt, FLAGGED_PIXVAL ddd_color, FLAGGED_PIXVAL text_color, const char *text, int dirty  CLIP_NUM_DEF)
+void display_ddd_proportional_clip(scr_coord_val xpos, scr_coord_val ypos, scr_coord_val width, scr_coord_val hgt, FLAGGED_PIXVAL ddd_color, FLAGGED_PIXVAL text_color, const char *text, int dirty  CLIP_NUM_DEF)
 {
 	const int halfheight = LINESPACE / 2 + 1;
 
@@ -4897,7 +4898,7 @@ void display_ddd_proportional_clip(KOORD_VAL xpos, KOORD_VAL ypos, KOORD_VAL wid
 /**
  * Draw multiline text
  */
-int display_multiline_text_rgb(KOORD_VAL x, KOORD_VAL y, const char *buf, PIXVAL color)
+int display_multiline_text_rgb(scr_coord_val x, scr_coord_val y, const char *buf, PIXVAL color)
 {
 	int max_px_len = 0;
 	if (buf != NULL && *buf != '\0') {
@@ -4924,25 +4925,25 @@ int display_multiline_text_rgb(KOORD_VAL x, KOORD_VAL y, const char *buf, PIXVAL
 /**
  * draw line from x,y to xx,yy
  **/
-void display_direct_line_rgb(const KOORD_VAL x, const KOORD_VAL y, const KOORD_VAL xx, const KOORD_VAL yy, const PIXVAL colval)
+void display_direct_line_rgb(const scr_coord_val x, const scr_coord_val y, const scr_coord_val xx, const scr_coord_val yy, const PIXVAL colval)
 {
 	int i, steps;
-	int xp, yp;
-	int xs, ys;
+	sint64 xp, yp;
+	sint64 xs, ys;
 
-	const int dx = xx - x;
-	const int dy = yy - y;
+	const scr_coord_val dx = xx - x;
+	const scr_coord_val dy = yy - y;
 
 	steps = (abs(dx) > abs(dy) ? abs(dx) : abs(dy));
 	if (steps == 0) {
 		steps = 1;
 	}
 
-	xs = (dx << 16) / steps;
-	ys = (dy << 16) / steps;
+	xs = ((sint64)dx << 16) / steps;
+	ys = ((sint64)dy << 16) / steps;
 
-	xp = x << 16;
-	yp = y << 16;
+	xp = (sint64)x << 16;
+	yp = (sint64)y << 16;
 
 	for (i = 0; i <= steps; i++) {
 #ifdef DEBUG_FLUSH_BUFFER
@@ -4957,11 +4958,11 @@ void display_direct_line_rgb(const KOORD_VAL x, const KOORD_VAL y, const KOORD_V
 
 
 //taken from function display_direct_line() above, to draw a dotted line: draw=pixels drawn, dontDraw=pixels skipped
-void display_direct_line_dotted_rgb(const KOORD_VAL x, const KOORD_VAL y, const KOORD_VAL xx, const KOORD_VAL yy, const KOORD_VAL draw, const KOORD_VAL dontDraw, const PIXVAL colval)
+void display_direct_line_dotted_rgb(const scr_coord_val x, const scr_coord_val y, const scr_coord_val xx, const scr_coord_val yy, const scr_coord_val draw, const scr_coord_val dontDraw, const PIXVAL colval)
 {
 	int i, steps;
-	int xp, yp;
-	int xs, ys;
+	sint64 xp, yp;
+	sint64 xs, ys;
 	int counter=0;
 	bool mustDraw=true;
 
@@ -4973,11 +4974,11 @@ void display_direct_line_dotted_rgb(const KOORD_VAL x, const KOORD_VAL y, const 
 		steps = 1;
 	}
 
-	xs = (dx << 16) / steps;
-	ys = (dy << 16) / steps;
+	xs = ((sint64)dx << 16) / steps;
+	ys = ((sint64)dy << 16) / steps;
 
-	xp = x << 16;
-	yp = y << 16;
+	xp = (sint64)x << 16;
+	yp = (sint64)y << 16;
 
 	for(  i = 0;  i <= steps;  i++  ) {
 		counter ++;
@@ -5004,7 +5005,7 @@ void display_direct_line_dotted_rgb(const KOORD_VAL x, const KOORD_VAL y, const 
 
 
 // bresenham circle (from wikipedia ...)
-void display_circle_rgb( KOORD_VAL x0, KOORD_VAL  y0, int radius, const PIXVAL colval )
+void display_circle_rgb( scr_coord_val x0, scr_coord_val  y0, int radius, const PIXVAL colval )
 {
 	int f = 1 - radius;
 	int ddF_x = 1;
@@ -5044,7 +5045,7 @@ void display_circle_rgb( KOORD_VAL x0, KOORD_VAL  y0, int radius, const PIXVAL c
 
 
 // bresenham circle (from wikipedia ...)
-void display_filled_circle_rgb( KOORD_VAL x0, KOORD_VAL  y0, int radius, const PIXVAL colval )
+void display_filled_circle_rgb( scr_coord_val x0, scr_coord_val  y0, int radius, const PIXVAL colval )
 {
 	int f = 1 - radius;
 	int ddF_x = 1;
@@ -5082,7 +5083,7 @@ void display_filled_circle_rgb( KOORD_VAL x0, KOORD_VAL  y0, int radius, const P
 
 // Currently, only right-facing equilateral triangles are supported. Can be expanded if needed to accommodate another direction.
 // The horizontal size is sqrt(3) times the height. - Ranran
-void display_right_triangle_rgb(KOORD_VAL x, KOORD_VAL y, uint8 height, const PIXVAL colval, const bool dirty)
+void display_right_triangle_rgb(scr_coord_val x, scr_coord_val y, uint8 height, const PIXVAL colval, const bool dirty)
 {
 	double sqrt3 = sqrt(3);
 	for (uint16 x0 = 0; x0 <= (uint16)(0.99 + height * (sqrt3)); x0++)
@@ -5091,15 +5092,15 @@ void display_right_triangle_rgb(KOORD_VAL x, KOORD_VAL y, uint8 height, const PI
 	}
 }
 
-int display_fluctuation_triangle_rgb(KOORD_VAL x, KOORD_VAL y, uint8 height, const bool dirty, sint64 value)
+int display_fluctuation_triangle_rgb(scr_coord_val x, scr_coord_val y, uint8 height, const bool dirty, sint64 value)
 {
 	if (!value) { return 0; } // nothing to draw
 	PIXVAL col = value > 0 ? SYSCOL_UP_TRIANGLE : SYSCOL_DOWN_TRIANGLE;
 	uint8 width = height - height % 2;
 	for (uint i = 0; i < width; i++) {
 		uint8 h = height - 2 * abs(int(width / 2 - i));
-		KOORD_VAL y0 = value > 0 ? y + 2 + height - h : y+2;
-		KOORD_VAL y1 = value > 0 ? y0 - 1 : y + h +1;
+		scr_coord_val y0 = value > 0 ? y + 2 + height - h : y+2;
+		scr_coord_val y1 = value > 0 ? y0 - 1 : y + h +1;
 
 		if (h > 1) {
 			display_vline_wh_clip_rgb(x + i, y0, h - 1, col, dirty);
@@ -5123,9 +5124,9 @@ int display_fluctuation_triangle_rgb(KOORD_VAL x, KOORD_VAL y, uint8 height, con
  * @draw=for dotted lines, how many pixels to be drawn (leave 0 for solid line)
  * @dontDraw=for dotted lines, how many pixels to not be drawn (leave 0 for solid line)
  */
-void draw_bezier_rgb(KOORD_VAL Ax, KOORD_VAL Ay, KOORD_VAL Bx, KOORD_VAL By, KOORD_VAL ADx, KOORD_VAL ADy, KOORD_VAL BDx, KOORD_VAL BDy, const PIXVAL colore, KOORD_VAL draw, KOORD_VAL dontDraw)
+void draw_bezier_rgb(scr_coord_val Ax, scr_coord_val Ay, scr_coord_val Bx, scr_coord_val By, scr_coord_val ADx, scr_coord_val ADy, scr_coord_val BDx, scr_coord_val BDy, const PIXVAL colore, scr_coord_val draw, scr_coord_val dontDraw)
 {
-	KOORD_VAL Cx,Cy,Dx,Dy;
+	scr_coord_val Cx,Cy,Dx,Dy;
 	Cx = Ax + ADx;
 	Cy = Ay + ADy;
 	Dx = Bx + BDx;
@@ -5503,7 +5504,7 @@ void simgraph_resize(scr_size new_window_size)
 	}
 	// only resize, if internal values are different
 	if (disp_width != new_window_size.w || disp_height != new_window_size.h) {
-		KOORD_VAL new_pitch = dr_textur_resize(&textur, new_window_size.w, new_window_size.h);
+		scr_coord_val new_pitch = dr_textur_resize(&textur, new_window_size.w, new_window_size.h);
 		if(  new_pitch!=disp_width  ||  disp_height != new_window_size.h) {
 			disp_width = new_pitch;
 			disp_height = new_window_size.h;

--- a/display/simview.cc
+++ b/display/simview.cc
@@ -212,8 +212,8 @@ void main_view_t::display(bool force_dirty)
 		}
 
 		// set parameter for each thread
-		const KOORD_VAL wh_x = disp_width / env_t::num_threads;
-		KOORD_VAL lt_x = 0;
+		const scr_coord_val wh_x = disp_width / env_t::num_threads;
+		scr_coord_val lt_x = 0;
 		for(  int t = 0;  t < env_t::num_threads - 1;  t++  ) {
 			ka[t].show_routine = this;
 			ka[t].lt_cl = koord( lt_x, menu_height );
@@ -574,7 +574,7 @@ void main_view_t::display_region( koord lt, koord wh, sint16 y_min, sint16 y_max
 }
 
 
-void main_view_t::display_background( KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, bool dirty )
+void main_view_t::display_background( scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, bool dirty )
 {
 	if(  !(env_t::draw_earth_border  &&  env_t::draw_outside_tile)  ) {
 		display_fillbox_wh_rgb(xp, yp, w, h, env_t::background_color, dirty );

--- a/display/simview.h
+++ b/display/simview.h
@@ -76,7 +76,7 @@ public:
 	 * @param h Height of the rectangle to draw.
 	 * @param dirty Mark the specified area as dirty.
 	 */
-	void display_background( KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, bool dirty );
+	void display_background( scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, bool dirty );
 
 };
 

--- a/gui/components/gui_building.cc
+++ b/gui/components/gui_building.cc
@@ -26,7 +26,7 @@ void gui_building_t::init(const building_desc_t* d, int r)
 		return;
 	}
 
-	KOORD_VAL rw4 = get_base_tile_raster_width()/4;
+	scr_coord_val rw4 = get_base_tile_raster_width()/4;
 	for(int i=0; i< desc->get_x(layout); i++) {
 		for(int j=0; j < desc->get_y(layout); j++) {
 			image_id id = desc->get_tile(layout,i,j)->get_background(0,0,0);

--- a/gui/components/gui_convoy_assembler.h
+++ b/gui/components/gui_convoy_assembler.h
@@ -217,7 +217,7 @@ class gui_convoy_assembler_t :
 	cbuffer_t text_convoi_axle_load;
 	char txt_convoi_count_fluctuation[6];
 
-	KOORD_VAL second_column_x; // x position of the second text column
+	scr_coord_val second_column_x; // x position of the second text column
 
 	enum { va_append, va_insert, va_sell, va_upgrade };
 	uint8 veh_action;

--- a/gui/components/gui_speedbar.cc
+++ b/gui/components/gui_speedbar.cc
@@ -251,12 +251,12 @@ void gui_bandgraph_t::draw(scr_coord offset)
 	}
 	else{
 		sint32 temp = 0;
-		KOORD_VAL end = 0;
+		scr_coord_val end = 0;
 		FOR(slist_tpl<info_t>, const& i, values) {
 			if (*i.value>0) {
 				temp += (*i.value);
-				const KOORD_VAL from = size.w * temp / total + 0.5;
-				const KOORD_VAL width = from-end;
+				const scr_coord_val from = size.w * temp / total + 0.5;
+				const scr_coord_val width = from-end;
 				if (width) {
 					display_fillbox_wh_clip_rgb(offset.x + size.w - from, offset.y, width, size.h, i.color, true);
 				}

--- a/gui/components/gui_table.h
+++ b/gui/components/gui_table.h
@@ -18,7 +18,7 @@
 
 //typedef KOORD_VAL koord_x;
 //typedef KOORD_VAL koord_y;
-typedef KOORD_VAL coordinate_t;
+typedef scr_coord_val coordinate_t;
 typedef FLAGGED_PIXVAL color_t;
 
 

--- a/gui/components/gui_textarea.cc
+++ b/gui/components/gui_textarea.cc
@@ -101,7 +101,7 @@ void gui_textarea_t::draw(scr_coord offset)
 			int px_len;
 			if (  -LINESPACE <= draw_y  &&  draw_y <= display_get_height() + LINESPACE) {
 				// draw when in screen area
-				px_len = display_text_proportional_len_clip_rgb((KOORD_VAL)x, (KOORD_VAL)draw_y, buf, ALIGN_LEFT | DT_CLIP, SYSCOL_TEXT, true, len);
+				px_len = display_text_proportional_len_clip_rgb(x, draw_y, buf, ALIGN_LEFT | DT_CLIP, SYSCOL_TEXT, true, len);
 			}
 			else {
 				// track required length when out of screen area

--- a/gui/components/gui_textinput.cc
+++ b/gui/components/gui_textinput.cc
@@ -530,9 +530,9 @@ void gui_textinput_t::display_with_cursor(scr_coord offset, bool cursor_active, 
 
 	if(  text  ) {
 		// recalculate scroll offset
-		const KOORD_VAL text_width = proportional_string_width(text);
-		const KOORD_VAL view_width = size.w - 3;
-		const KOORD_VAL cursor_offset = cursor_active ? proportional_string_len_width(text, head_cursor_pos) : 0;
+		const int text_width = proportional_string_width(text);
+		const scr_coord_val view_width = size.w - 3;
+		const int cursor_offset = cursor_active ? proportional_string_len_width(text, head_cursor_pos) : 0;
 		if(  text_width<=view_width  ) {
 			// case : text is shorter than displayable width of the text input
 			//        -> the only case where left and right alignments differ

--- a/gui/convoi_detail_t.cc
+++ b/gui/convoi_detail_t.cc
@@ -1261,7 +1261,7 @@ void gui_convoy_payload_info_t::draw(scr_coord offset)
 }
 
 
-void gui_convoy_payload_info_t::display_loading_bar(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, PIXVAL color, uint16 loading, uint16 capacity, uint16 overcrowd_capacity)
+void gui_convoy_payload_info_t::display_loading_bar(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, PIXVAL color, uint16 loading, uint16 capacity, uint16 overcrowd_capacity)
 {
 	if (capacity > 0 || overcrowd_capacity > 0) {
 		// base
@@ -1549,7 +1549,7 @@ void gui_convoy_maintenance_info_t::draw(scr_coord offset)
 			extra_y += LINESPACE;
 
 			if (sint64 cost = welt->calc_adjusted_monthly_figure(v->get_desc()->get_maintenance())) {
-				KOORD_VAL len = display_proportional_clip_rgb(pos.x + extra_w + offset.x, pos.y + offset.y + total_height + extra_y, translator::translate("Maintenance"), ALIGN_LEFT, SYSCOL_TEXT, true);
+				int len = display_proportional_clip_rgb(pos.x + extra_w + offset.x, pos.y + offset.y + total_height + extra_y, translator::translate("Maintenance"), ALIGN_LEFT, SYSCOL_TEXT, true);
 				len += display_proportional_clip_rgb(pos.x + extra_w + offset.x + len, pos.y + offset.y + total_height + extra_y, ": ", ALIGN_LEFT, SYSCOL_TEXT, true);
 				money_to_string(number, cost / (100.0));
 				display_proportional_clip_rgb(pos.x + extra_w + offset.x + len, pos.y + offset.y + total_height + extra_y, number, ALIGN_LEFT, MONEY_MINUS, true);

--- a/gui/convoi_detail_t.h
+++ b/gui/convoi_detail_t.h
@@ -109,7 +109,7 @@ public:
 	void set_show_detail(bool yesno) { show_detail = yesno; } // Currently not in use
 
 	void draw(scr_coord offset);
-	void display_loading_bar(KOORD_VAL xp, KOORD_VAL yp, KOORD_VAL w, KOORD_VAL h, PIXVAL color, uint16 loading, uint16 capacity, uint16 overcrowd_capacity);
+	void display_loading_bar(scr_coord_val xp, scr_coord_val yp, scr_coord_val w, scr_coord_val h, PIXVAL color, uint16 loading, uint16 capacity, uint16 overcrowd_capacity);
 };
 
 // content of maintenance info tab

--- a/gui/gui_theme.cc
+++ b/gui/gui_theme.cc
@@ -88,20 +88,20 @@ scr_size gui_theme_t::gui_label_size;
 scr_size gui_theme_t::gui_edit_size;
 scr_size gui_theme_t::gui_gadget_size;
 scr_size gui_theme_t::gui_indicator_size;
-KOORD_VAL gui_theme_t::gui_waitingbar_width;
+scr_coord_val gui_theme_t::gui_waitingbar_width;
 
 scr_coord gui_theme_t::gui_focus_offset;
 scr_coord gui_theme_t::gui_button_text_offset_right;
 scr_coord gui_theme_t::gui_color_button_text_offset_right;
 
-KOORD_VAL gui_theme_t::gui_titlebar_height;
-KOORD_VAL gui_theme_t::gui_frame_left;
-KOORD_VAL gui_theme_t::gui_frame_top;
-KOORD_VAL gui_theme_t::gui_frame_right;
-KOORD_VAL gui_theme_t::gui_frame_bottom;
-KOORD_VAL gui_theme_t::gui_hspace;
-KOORD_VAL gui_theme_t::gui_vspace;
-KOORD_VAL gui_theme_t::gui_filelist_vspace;
+scr_coord_val gui_theme_t::gui_titlebar_height;
+scr_coord_val gui_theme_t::gui_frame_left;
+scr_coord_val gui_theme_t::gui_frame_top;
+scr_coord_val gui_theme_t::gui_frame_right;
+scr_coord_val gui_theme_t::gui_frame_bottom;
+scr_coord_val gui_theme_t::gui_hspace;
+scr_coord_val gui_theme_t::gui_vspace;
+scr_coord_val gui_theme_t::gui_filelist_vspace;
 
 /* those are the 3x3 images which are used for stretching
  * also 1x3 and 3x1 subsets are possible

--- a/gui/gui_theme.h
+++ b/gui/gui_theme.h
@@ -278,17 +278,17 @@ public:
 	static scr_coord gui_color_button_text_offset_right; // extra right offset for the text (in case of asymmetric or buttons with color on the right)
 	static scr_coord gui_button_text_offset_right;       // extra right offset for the text (in case of asymmetric or buttons with checkmark on the right)
 
-	static KOORD_VAL gui_titlebar_height;
-	static KOORD_VAL gui_frame_left;
-	static KOORD_VAL gui_frame_top;
-	static KOORD_VAL gui_frame_right;
-	static KOORD_VAL gui_frame_bottom;
-	static KOORD_VAL gui_hspace;
-	static KOORD_VAL gui_vspace;
-	static KOORD_VAL gui_waitingbar_width;
+	static scr_coord_val gui_titlebar_height;
+	static scr_coord_val gui_frame_left;
+	static scr_coord_val gui_frame_top;
+	static scr_coord_val gui_frame_right;
+	static scr_coord_val gui_frame_bottom;
+	static scr_coord_val gui_hspace;
+	static scr_coord_val gui_vspace;
+	static scr_coord_val gui_waitingbar_width;
 
 	// one special entries, since there are lot of lists with files/fonts/paks/... where zero spacing could fit more entires on the screen
-	static KOORD_VAL gui_filelist_vspace;
+	static scr_coord_val gui_filelist_vspace;
 	/// @}
 
 	// those are the 3x3 images which are used for stretching

--- a/gui/halt_detail.cc
+++ b/gui/halt_detail.cc
@@ -655,7 +655,7 @@ void halt_detail_pas_t::draw_class_table(scr_coord offset, const uint8 class_nam
 	if (good_category != goods_manager_t::mail && good_category != goods_manager_t::passengers) {
 		return; // this table is for pax and mail
 	}
-	KOORD_VAL y = offset.y;
+	scr_coord_val y = offset.y;
 
 	uint base_capacity = halt->get_capacity(good_category->get_catg_index()) ? max(halt->get_capacity(good_category->get_catg_index()), 10) : 10; // Note that capacity may have 0 even if pax_enabled
 	uint transferring_sum = 0;

--- a/gui/halt_list_stats.cc
+++ b/gui/halt_list_stats.cc
@@ -112,8 +112,8 @@ void gui_mini_halt_waiting_indicator_t::draw(scr_coord offset)
 		// [colorbox]
 		display_ddd_box_clip_rgb(pos.x+offset.x, pos.y+offset.y + i*(MINI_WAITING_BAR_HEIGHT+1), MINI_WAITING_BAR_HEIGHT, MINI_WAITING_BAR_HEIGHT, color_idx_to_rgb(MN_GREY0), color_idx_to_rgb(MN_GREY4));
 		if (served) {
-			const KOORD_VAL base_x = pos.x + offset.x;
-			const KOORD_VAL base_y = pos.y + offset.y + i * (MINI_WAITING_BAR_HEIGHT + 1);
+			const scr_coord_val base_x = pos.x + offset.x;
+			const scr_coord_val base_y = pos.y + offset.y + i * (MINI_WAITING_BAR_HEIGHT + 1);
 			const uint8 color_box_size = is_operating ? MINI_WAITING_BAR_HEIGHT : MINI_WAITING_BAR_HEIGHT-2;
 			display_fillbox_wh_clip_rgb(is_operating ? base_x : base_x+1, is_operating ? base_y : base_y+1,	color_box_size, color_box_size, goods_colval, false);
 		}

--- a/gui/map_frame.cc
+++ b/gui/map_frame.cc
@@ -276,7 +276,7 @@ map_frame_t::map_frame_t() :
 	viewed_player_c.new_component<gui_scrolled_list_t::const_text_scrollitem_t>(translator::translate("All"), SYSCOL_TEXT);
 	viewable_players[ 0 ] = -1;
 	for(  int np = 0, count = 1;  np < MAX_PLAYER_COUNT;  np++  ) {
-		if(  welt->get_player( np )  &&  welt->get_player( np )->get_finance()->has_convoi()) {
+		if(  welt->get_player( np )  /*&&  welt->get_player( np )->get_finance()->has_convoi()*/) { //player does not need any convoy, might be a pure infrastructure company
 			viewed_player_c.new_component<gui_scrolled_list_t::const_text_scrollitem_t>(welt->get_player( np )->get_name(), color_idx_to_rgb(welt->get_player( np )->get_player_color1()+env_t::gui_player_color_dark));
 			viewable_players[ count++ ] = np;
 		}

--- a/gui/minimap.cc
+++ b/gui/minimap.cc
@@ -26,7 +26,6 @@
 #include "../player/simplay.h"
 
 #include "../tpl/inthashtable_tpl.h"
-#include "../tpl/slist_tpl.h"
 
 #include <cmath>
 
@@ -811,18 +810,18 @@ void minimap_t::calc_map_pixel(const koord k)
 
 	bool any_suitable_stops = false;
 	uint16 min_tiles_to_halt = -1;
-	switch(mode&~MAP_MODE_FLAGS) {
+	switch(mode& ~MAP_MODE_FLAGS) {
 		// show passenger/mail coverage
 		// display coverage
 		case MAP_STATION_COVERAGE:
 			if(  plan->get_haltlist_count()>0 && gr->suche_obj(obj_t::gebaeude)) {
 				const nearby_halt_t *const halt_list = plan->get_haltlist();
-				bool show_only_freight_station = (freight_type_group_index_showed_on_map != nullptr && freight_type_group_index_showed_on_map != goods_manager_t::mail && freight_type_group_index_showed_on_map != goods_manager_t::passengers);
+				bool show_only_freight_station = (freight_type_group_index_showed_on_map != nullptr && freight_type_group_index_showed_on_map != goods_manager_t::none && freight_type_group_index_showed_on_map != goods_manager_t::mail && freight_type_group_index_showed_on_map != goods_manager_t::passengers);
 				for (int h = 0; h < plan->get_haltlist_count(); h++)
 				{
 					const halthandle_t halt = halt_list[h].halt;
 					// player filter
-					if(player_showed_on_map != -1 && (halt->get_owner() != world->get_public_player() && world->get_player(player_showed_on_map) != halt->get_owner()))
+					if(player_showed_on_map != -1 && (world->get_player(player_showed_on_map) != halt->get_owner()))
 					{
 						continue;
 					}
@@ -832,14 +831,7 @@ void minimap_t::calc_map_pixel(const koord k)
 						continue;
 					}
 
-					// station handling freight type filter
-					if (freight_type_group_index_showed_on_map == goods_manager_t::none && halt->get_ware_enabled())
-					{
-						// all freights but not pax or mail
-						;
-					}
-					else if(freight_type_group_index_showed_on_map != nullptr && !halt->gibt_ab(freight_type_group_index_showed_on_map))
-					{
+					if(!(freight_type_group_index_showed_on_map==nullptr || (freight_type_group_index_showed_on_map == goods_manager_t::none && halt->get_ware_enabled()) || halt->gibt_ab(freight_type_group_index_showed_on_map))){
 						continue;
 					}
 
@@ -2059,7 +2051,9 @@ bool minimap_t::is_matching_freight_catg(const minivec_tpl<uint8> &goods_catg_in
 		}
 		return false;
 	}
-	// NULL show all but obey modes
+/* This doesn't make sense anymore.
+ * Formerly it did.
+	// null show all but obey modes
 	if(  mode & MAP_STATION_COVERAGE  ) {
 		return goods_catg_index.is_contained(goods_manager_t::INDEX_PAS);
 	}
@@ -2072,6 +2066,7 @@ bool minimap_t::is_matching_freight_catg(const minivec_tpl<uint8> &goods_catg_in
 		}
 		return false;
 	}
+*/
 	// all true
 	return true;
 }

--- a/gui/minimap.cc
+++ b/gui/minimap.cc
@@ -566,10 +566,9 @@ bool minimap_t::change_zoom_factor(bool magnify)
 			zoomed = true;
 		}
 		else {
-			// Ensure that zoom*x < INT32_MAX, for any x < world->get_size_max();
-			// zoom*(world->get_size().x + world->get_size().y)) < INT32_MAX <=> zoom < INT32_MAX/(world->get_size().x + world->get_size().y));
-			// hint: will only happen at maximum zoom level if the map x+y > 134217727, so practically never.
-			int max_zoom_in = min(16, INT32_MAX/(world->get_size().x + world->get_size().y));
+			// check here for maximum zoom-out, otherwise there will be integer overflows
+			// with large maps as we calculate with sint16 coordinates ...
+			int max_zoom_in = min( ((1<<31) - 1) / (2*world->get_size_max()), 16);
 			if(  zoom_in < max_zoom_in  ) {
 				zoom_in++;
 				zoomed = true;

--- a/gui/minimap.cc
+++ b/gui/minimap.cc
@@ -52,11 +52,9 @@ static sint32 max_service = 1;
 
 static sint32 max_building_level = 0;
 
-minimap_t * minimap_t::single_instance = NULL;
+minimap_t * minimap_t::single_instance = nullptr;
 karte_ptr_t minimap_t::world;
-minimap_t::MAP_DISPLAY_MODE minimap_t::mode = MAP_TOWN;
-minimap_t::MAP_DISPLAY_MODE minimap_t::last_mode = MAP_TOWN;
-bool minimap_t::is_visible = false;
+
 
 #define MAX_MAP_TYPE_LAND 31
 #define MAX_MAP_TYPE_WATER 5
@@ -1282,20 +1280,8 @@ void minimap_t::calc_map()
 }
 
 
-minimap_t::minimap_t()
-{
-	map_data = NULL;
-	zoom_in = 1;
-	zoom_out = 1;
-	isometric = false;
-	show_contour = true;
-	show_network_load_factor = false;
+minimap_t::minimap_t(){
 	mode = MAP_TOWN;
-	selected_city = NULL;
-	cur_off = new_off = scr_coord(0,0);
-	cur_size = new_size = scr_size(0,0);
-	needs_redraw = true;
-	transport_type_showed_on_map = simline_t::line;
 }
 
 
@@ -1307,7 +1293,7 @@ minimap_t::~minimap_t()
 
 minimap_t *minimap_t::get_instance()
 {
-	if(single_instance == NULL) {
+	if(single_instance == nullptr) {
 		single_instance = new minimap_t();
 	}
 	return single_instance;
@@ -1316,17 +1302,20 @@ minimap_t *minimap_t::get_instance()
 
 void minimap_t::init()
 {
-	delete map_data;
-	map_data = NULL;
 	needs_redraw = true;
-	is_visible = false;
-	show_buildings = true;
+	//is_visible = false;
+	//show_buildings = true;
 
 	calc_map_size();
 	max_building_level = max_cargo = max_passed = 0;
 	max_tourist_ziele = max_waiting = max_origin = max_transfer = max_service = 1;
 	last_schedule_counter = world->get_schedule_counter()-1;
 	set_selected_cnv(convoihandle_t());
+}
+
+void minimap_t::finalize(){
+	delete map_data;
+	map_data = nullptr;
 }
 
 

--- a/gui/minimap.cc
+++ b/gui/minimap.cc
@@ -374,10 +374,10 @@ static void display_harbor( const scr_coord_val xx, const scr_coord_val yy, cons
 
 static void display_thick_line( scr_coord_val x1, scr_coord_val y1, scr_coord_val x2, scr_coord_val y2, PIXVAL col, bool dotting, short dot_full, short dot_empty, short thickness )
 {
-	double delta_x = abs( x1 - x2 );
-	double delta_y = abs( y1 - y2 );
+    scr_coord_val delta_x = abs( x1 - x2 );
+    scr_coord_val delta_y = abs( y1 - y2 );
 
-	if(  delta_x == 0.0  ||  delta_y/delta_x > 2.0  ) {
+	if(  delta_x == 0  ||  delta_y/delta_x > 2.0  ) {
 		// mostly vertical
 		x1 -= thickness/2;
 		x2 -= thickness/2;
@@ -417,8 +417,8 @@ static void display_thick_line( scr_coord_val x1, scr_coord_val y1, scr_coord_va
 				display_direct_line_rgb( x1+i+1, y1+i*y_multiplier, x2+i+1, y2+i*y_multiplier, col );
 			}
 			else {
-				display_direct_line_dotted_rgb ( x1 + i, y1 + i*y_multiplier, x2 + i, y2 + i*y_multiplier, dot_full, dot_empty, col );
-				display_direct_line_dotted_rgb ( x1 + i + 1, y1 + i*y_multiplier, x2 + i + 1, y2 + i*y_multiplier, dot_full, dot_empty, col );
+				display_direct_line_dotted_rgb( x1 + i, y1 + i*y_multiplier, x2 + i, y2 + i*y_multiplier, dot_full, dot_empty, col );
+				display_direct_line_dotted_rgb( x1 + i + 1, y1 + i*y_multiplier, x2 + i + 1, y2 + i*y_multiplier, dot_full, dot_empty, col );
 			}
 		}
 	}
@@ -567,9 +567,9 @@ bool minimap_t::change_zoom_factor(bool magnify)
 		}
 		else {
 			// Ensure that zoom*x < INT32_MAX, for any x < world->get_size_max();
-			// zoom*world->get_size_max() < INT32_MAX <=> zoom < INT32_MAX/world->get_size_max();
-			// hint: will only happen at maximum zoom level if the map is larger than
-			int max_zoom_in = min(16, INT32_MAX/world->get_size_max());
+			// zoom*(world->get_size().x + world->get_size().y)) < INT32_MAX <=> zoom < INT32_MAX/(world->get_size().x + world->get_size().y));
+			// hint: will only happen at maximum zoom level if the map x+y > 134217727, so practically never.
+			int max_zoom_in = min(16, INT32_MAX/(world->get_size().x + world->get_size().y));
 			if(  zoom_in < max_zoom_in  ) {
 				zoom_in++;
 				zoomed = true;
@@ -827,7 +827,7 @@ void minimap_t::calc_map_pixel(const koord k)
 		// show passenger/mail coverage
 		// display coverage
 		case MAP_STATION_COVERAGE:
-			if(  plan->get_haltlist_count()>0 && gr->get_typ() == grund_t::fundament) {
+			if(  plan->get_haltlist_count()>0 && gr->suche_obj(obj_t::gebaeude)) {
 				const nearby_halt_t *const halt_list = plan->get_haltlist();
 				bool show_only_freight_station = (freight_type_group_index_showed_on_map != NULL && freight_type_group_index_showed_on_map != goods_manager_t::mail && freight_type_group_index_showed_on_map != goods_manager_t::passengers);
 				for (int h = 0; h < plan->get_haltlist_count(); h++)
@@ -1229,9 +1229,7 @@ void minimap_t::calc_map()
 	}
 	else {
 		// always the whole map ...
-		if(isometric) {
-			map_data->init( color_idx_to_rgb(COL_BLACK) );
-		}
+        map_data->init( color_idx_to_rgb(COL_BLACK) );
 		koord k;
 		for(  k.y=0;  k.y < world->get_size().y;  k.y++  ) {
 			for(  k.x=0;  k.x < world->get_size().x;  k.x++  ) {

--- a/gui/minimap.h
+++ b/gui/minimap.h
@@ -35,7 +35,7 @@ class goods_desc_t;
 class minimap_t : public gui_component_t
 {
 public:
-	enum MAP_DISPLAY_MODE {
+	enum MAP_DISPLAY_MODE: unsigned int {
 		PLAIN                       = 0,
 		MAP_TOWN                    = 1u << 0u,
 		MAP_STATION_COVERAGE        = 1u << 1u,
@@ -205,7 +205,7 @@ public:
 
 	int player_showed_on_map{};
 	int transport_type_showed_on_map{simline_t::line};
-	const goods_desc_t *freight_type_group_index_showed_on_map{};
+	const goods_desc_t *freight_type_group_index_showed_on_map{nullptr};
 
 	/**
 	 * returns a color based on an amount (high amount/scale -> color shifts from green to red)

--- a/gui/minimap.h
+++ b/gui/minimap.h
@@ -37,50 +37,52 @@ class minimap_t : public gui_component_t
 public:
 	enum MAP_DISPLAY_MODE {
 		PLAIN                       = 0,
-		MAP_TOWN                    = 1 << 0,
-		MAP_STATION_COVERAGE        = 1 << 1,
-		MAP_CONVOYS                 = 1 << 2,
-		MAP_FREIGHT                 = 1 << 3,
-		MAP_STATUS                  = 1 << 4,
-		MAP_SERVICE                 = 1 << 5,
-		MAP_TRAFFIC                 = 1 << 6,
-		MAP_ORIGIN                  = 1 << 7,
-		MAP_TRANSFER                = 1 << 8,
-		MAP_WAITING                 = 1 << 9,
-		MAP_TRACKS                  = 1 << 10,
-		MAX_SPEEDLIMIT              = 1 << 11,
-		MAP_POWERLINES              = 1 << 12,
-		MAP_TOURIST                 = 1 << 13,
-		MAP_FACTORIES               = 1 << 14,
-		MAP_DEPOT                   = 1 << 15,
-		MAP_FOREST                  = 1 << 16,
-		MAP_CITYLIMIT               = 1 << 17,
-		MAP_PAX_DEST                = 1 << 18,
-		MAP_OWNER                   = 1 << 19,
-		MAP_LINES                   = 1 << 20,
-		MAP_LEVEL                   = 1 << 21,
-		MAP_WAITCHANGE              = 1 << 22,
-		MAP_CONDITION               = 1 << 23,
-		MAP_WEIGHTLIMIT             = 1 << 24,
-		MAP_ACCESSIBILITY_COMMUTING = 1 << 25,
-		MAP_ACCESSIBILITY_TRIP      = 1 << 26,
-		MAP_STAFF_FULFILLMENT       = 1 << 27,
-		MAP_MAIL_DELIVERY           = 1 << 28,
-		MAP_CONGESTION              = 1 << 29,
+		MAP_TOWN                    = 1u << 0u,
+		MAP_STATION_COVERAGE        = 1u << 1u,
+		MAP_CONVOYS                 = 1u <<2u,
+		MAP_FREIGHT                 = 1u <<3u,
+		MAP_STATUS                  = 1u <<4u,
+		MAP_SERVICE                 = 1u <<5u,
+		MAP_TRAFFIC                 = 1u <<6u,
+		MAP_ORIGIN                  = 1u <<7u,
+		MAP_TRANSFER                = 1u <<8u,
+		MAP_WAITING                 = 1u <<9u,
+		MAP_TRACKS                  = 1u <<10u,
+		MAX_SPEEDLIMIT              = 1u <<11u,
+		MAP_POWERLINES              = 1u <<12u,
+		MAP_TOURIST                 = 1u <<13u,
+		MAP_FACTORIES               = 1u <<14u,
+		MAP_DEPOT                   = 1u <<15u,
+		MAP_FOREST                  = 1u <<16u,
+		MAP_CITYLIMIT               = 1u <<17u,
+		MAP_PAX_DEST                = 1u <<18u,
+		MAP_OWNER                   = 1u <<19u,
+		MAP_LINES                   = 1u <<20u,
+		MAP_LEVEL                   = 1u <<21u,
+		MAP_WAITCHANGE              = 1u <<22u,
+		MAP_CONDITION               = 1u <<23u,
+		MAP_WEIGHTLIMIT             = 1u <<24u,
+		MAP_ACCESSIBILITY_COMMUTING = 1u <<25u,
+		MAP_ACCESSIBILITY_TRIP      = 1u <<26u,
+		MAP_STAFF_FULFILLMENT       = 1u <<27u,
+		MAP_MAIL_DELIVERY           = 1u <<28u,
+		MAP_CONGESTION              = 1u <<29u,
 
 		MAP_MODE_HALT_FLAGS = (MAP_STATUS|MAP_SERVICE|MAP_ORIGIN|MAP_TRANSFER|MAP_WAITING|MAP_WAITCHANGE),
 		MAP_MODE_FLAGS = (MAP_TOWN|MAP_CITYLIMIT|MAP_STATUS|MAP_SERVICE|MAP_WAITING|MAP_WAITCHANGE|MAP_TRANSFER|MAP_LINES|MAP_FACTORIES|MAP_ORIGIN|MAP_DEPOT|MAP_TOURIST|MAP_CONVOYS)
 	};
 
 private:
+	//This one really has to be static
+	static minimap_t *single_instance;
 	static karte_ptr_t world;
 
 	minimap_t();
 
-	static minimap_t *single_instance;
+
 
 	/// the terrain map
-	array2d_tpl<PIXVAL> *map_data;
+	array2d_tpl<PIXVAL> *map_data{nullptr};
 
 	/// nonstatic, if we have someday many maps ...
 	void set_map_color_clip( sint16 x, sint16 y, PIXVAL color );
@@ -131,25 +133,26 @@ private:
 
 	vector_tpl<line_segment_t> schedule_cache;
 	convoihandle_t current_cnv;
-	uint8 last_schedule_counter;
+	uint8 last_schedule_counter{};
 	vector_tpl<halthandle_t> stop_cache;
 
 	/// adds a schedule to cache
 	void add_to_schedule_cache( convoihandle_t cnv, bool with_waypoints );
 
 	/**
+	 * //TODO Why are the following two static?
 	 * 0: normal
 	 * everything else: special map
 	 */
-	static MAP_DISPLAY_MODE mode;
-	static MAP_DISPLAY_MODE last_mode;
+	MAP_DISPLAY_MODE mode{MAP_TOWN};
+	MAP_DISPLAY_MODE last_mode{MAP_TOWN};
 	static const uint8 severity_color[MAX_SEVERITY_COLORS];
 
 	koord screen_to_map_coord(const scr_coord&) const;
 
 	/// for passenger destination display
-	const stadt_t *selected_city;
-	uint32 pax_destinations_last_change;
+	const stadt_t *selected_city{nullptr};
+	uint32 pax_destinations_last_change{};
 
 	koord last_world_pos;
 
@@ -161,28 +164,28 @@ private:
 	 * These are size and offset of visible part of map.
 	 * We only show and compute this.
 	 */
-	scr_coord cur_off, new_off;
-	scr_size cur_size, new_size;
+	scr_coord cur_off{scr_coord(0,0)};
+	scr_coord new_off{scr_coord(0,0)};
+	scr_size cur_size{scr_size(0,0)};
+	scr_size new_size{scr_size(0,0)};
 
 	/// true, if full redraw is needed
-	bool needs_redraw;
+	bool needs_redraw{true};
 
 	const fabrik_t* get_factory_near(koord pos, bool large_area) const;
 
 	const fabrik_t* draw_factory_connections(PIXVAL colour, scr_coord pos) const;
 
+	//TODO why static?
 	static sint32 max_cargo;
 	static sint32 max_passed;
 
 	/// the zoom factors
-	sint16 zoom_out, zoom_in;
-
-	uint16 citycar_speed_average;
-
-	void set_citycar_speed_average();
+	sint16 zoom_out{1};
+	sint16 zoom_in{1};
 
 	/// if true, draw the map with 45 degree rotation
-	bool isometric;
+	bool isometric{false};
 
 	bool is_matching_freight_catg(const minivec_tpl<uint8> &goods_catg_index);
 
@@ -194,15 +197,15 @@ public:
 	void toggle_isometric() { isometric = !isometric; }
 	bool is_isometric() const { return isometric; }
 
-	static bool is_visible;
+	bool is_visible{false};
 
-	bool show_network_load_factor;
-	bool show_contour;
-	bool show_buildings;
+	bool show_network_load_factor{false};
+	bool show_contour{true};
+	bool show_buildings{true};
 
-	int player_showed_on_map;
-	int transport_type_showed_on_map;
-	const goods_desc_t *freight_type_group_index_showed_on_map;
+	int player_showed_on_map{};
+	int transport_type_showed_on_map{simline_t::line};
+	const goods_desc_t *freight_type_group_index_showed_on_map{};
 
 	/**
 	 * returns a color based on an amount (high amount/scale -> color shifts from green to red)
@@ -218,7 +221,7 @@ public:
 	/**
 	 * returns a color based on the current height
 	 */
-	static PIXVAL calc_height_color(const sint16 height, const sint16 groundwater);
+	static PIXVAL calc_height_color(sint16 height, sint16 groundwater);
 
 	/// needed for town passenger map
 	static PIXVAL calc_ground_color (const grund_t *gr, bool show_contour = true, bool show_buildings = true);
@@ -227,22 +230,24 @@ public:
 	static minimap_t *get_instance();
 
 	// HACK! since we cannot set cleanly the current offset/size, we use this helper function
-	void set_xy_offset_size( scr_coord off, scr_size size ) {
+	void set_xy_offset_size( scr_coord off, const scr_size& size ) {
 		new_off = off;
 		new_size = size;
 	}
 
 	/// update color with render mode (but few are ignored ... )
-	void calc_map_pixel(const koord k);
+	void calc_map_pixel(koord k);
 
 	void calc_map();
 
 	/// calculates the current size of the map (but do not change anything else)
 	void calc_map_size();
 
-	~minimap_t();
+	~minimap_t() override;
 
 	void init();
+
+	void finalize();
 
 	void set_display_mode(MAP_DISPLAY_MODE new_mode);
 
@@ -278,6 +283,7 @@ public:
 	scr_size get_min_size() const OVERRIDE;
 
 	scr_size get_max_size() const OVERRIDE;
+
 };
 
 #endif

--- a/gui/simwin.cc
+++ b/gui/simwin.cc
@@ -1740,11 +1740,11 @@ void win_display_flush(double konto)
 	char const *time = tick_to_string( wl->get_ticks(), true );
 
 	// statusbar background
-	KOORD_VAL const status_bar_height = win_get_statusbar_height();
-	KOORD_VAL const status_bar_y = disp_height - status_bar_height;
-	KOORD_VAL const status_bar_text_y = status_bar_y + (status_bar_height - LINESPACE) / 2;
-	KOORD_VAL const status_bar_icon_y = status_bar_y + (status_bar_height - 15) / 2;
-	display_set_clip_wh( 0, 0, disp_width, disp_height );
+	scr_coord_val const status_bar_height = win_get_statusbar_height();
+	scr_coord_val const status_bar_y = disp_height - status_bar_height;
+	scr_coord_val const status_bar_text_y = status_bar_y + (status_bar_height - LINESPACE) / 2;
+	scr_coord_val const status_bar_icon_y = status_bar_y + (status_bar_height - 15) / 2;
+	display_set_clip_wh(0, 0, disp_width, disp_height);
 	display_fillbox_wh_rgb(0, status_bar_y - 1, disp_width, 1, SYSCOL_STATUSBAR_DIVIDER, false);
 	display_fillbox_wh_rgb(0, status_bar_y, disp_width, status_bar_height, SYSCOL_STATUSBAR_BACKGROUND, false);
 

--- a/obj/simobj.cc
+++ b/obj/simobj.cc
@@ -337,7 +337,7 @@ void obj_t::mark_image_dirty(image_id image, sint16 yoff) const
 		display_mark_img_dirty( image, scr_pos.x + xpos, scr_pos.y + ypos + yoff);
 
 		// too close to border => set dirty to be sure (smoke, skyscrapers, birds, or the like)
-		KOORD_VAL xbild, ybild, wbild, hbild;
+		scr_coord_val xbild, ybild, wbild, hbild;
 		display_get_image_offset( image, &xbild, &ybild, &wbild, &hbild );
 		const sint16 distance_to_border = 3 - (yoff+get_yoff()+ybild)/(rasterweite/4);
 		if(  pos.x <= distance_to_border  ||  pos.y <= distance_to_border  ) {

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -4926,7 +4926,7 @@ void haltestelle_t::recalc_status()
 /**
  * Draws some nice colored bars giving some status information
  */
-void haltestelle_t::display_status(KOORD_VAL xpos, KOORD_VAL ypos)
+void haltestelle_t::display_status(sint16 xpos, sint16 ypos)
 {
 	// ignore freight that cannot reach to this station
 	sint16 count = 0;
@@ -4971,13 +4971,13 @@ void haltestelle_t::display_status(KOORD_VAL xpos, KOORD_VAL ypos)
 
 	if(  count != last_bar_count  ) {
 		// bars will shift x positions, mark entire station bar region dirty
-		KOORD_VAL max_bar_height = 0;
+		scr_coord_val max_bar_height = 0;
 		for(  sint16 i = 0;  i < last_bar_count;  i++  ) {
 			if(  last_bar_height[i] > max_bar_height  ) {
 				max_bar_height = last_bar_height[i];
 			}
 		}
-		const KOORD_VAL x = xpos - (last_bar_count * D_WAITINGBAR_WIDTH - get_tile_raster_width()) / 2;
+		const scr_coord_val x = xpos - (last_bar_count * D_WAITINGBAR_WIDTH - get_tile_raster_width()) / 2;
 		mark_rect_dirty_wc( x - 1 - D_WAITINGBAR_WIDTH, ypos - 11 - max_bar_height - 6, x + last_bar_count * D_WAITINGBAR_WIDTH + 12 - 2, ypos - 11 );
 
 		// reset bar heights for new count
@@ -4991,7 +4991,7 @@ void haltestelle_t::display_status(KOORD_VAL xpos, KOORD_VAL ypos)
 
 	ypos -= D_LABEL_HEIGHT/2 +D_WAITINGBAR_WIDTH;
 	xpos -= (count * D_WAITINGBAR_WIDTH - get_tile_raster_width()) / 2;
-	const KOORD_VAL x = xpos;
+	const int x = xpos;
 
 	sint16 bar_height_index = 0;
 	uint32 max_capacity;
@@ -5046,8 +5046,8 @@ void haltestelle_t::display_status(KOORD_VAL xpos, KOORD_VAL ypos)
 					display_fillbox_wh_clip_rgb(xpos + (D_WAITINGBAR_WIDTH / 2) - 2, ypos - v - 5, 4, 1, color_idx_to_rgb(COL_WHITE), false);
 				}
 
-				if (last_bar_height[bar_height_index] != (KOORD_VAL)v) {
-					if ((KOORD_VAL)v > last_bar_height[bar_height_index]) {
+				if (last_bar_height[bar_height_index] != (scr_coord_val)v) {
+					if ((scr_coord_val)v > last_bar_height[bar_height_index]) {
 						// bar will be longer, mark new height dirty
 						mark_rect_dirty_wc(xpos, ypos - v - 6, xpos + 4 - 1, ypos + 4 - 1);
 					}
@@ -5081,8 +5081,8 @@ void haltestelle_t::display_status(KOORD_VAL xpos, KOORD_VAL ypos)
 			display_fillbox_wh_clip_rgb(xpos + (D_WAITINGBAR_WIDTH / 2) - 2, ypos - v - 5, 4, 1, color_idx_to_rgb(COL_WHITE), false);
 		}
 
-		if (last_bar_height[bar_height_index] != (KOORD_VAL)v) {
-			if ((KOORD_VAL)v > last_bar_height[bar_height_index]) {
+		if (last_bar_height[bar_height_index] != (scr_coord_val)v) {
+			if ((scr_coord_val)v > last_bar_height[bar_height_index]) {
 				// bar will be longer, mark new height dirty
 				mark_rect_dirty_wc(xpos, ypos - v - 6, xpos + 4 - 1, ypos + 4 - 1);
 			}
@@ -5115,7 +5115,7 @@ void haltestelle_t::display_status(KOORD_VAL xpos, KOORD_VAL ypos)
 			}
 
 			// second, draw the bar
-			KOORD_VAL yoff = 0;
+			scr_coord_val yoff = 0;
 			max_capacity = get_capacity(2);
 			if (gibt_ab(goods_manager_t::get_info_catg_index(i))) {
 				uint32 v = min(total_ware, get_capacity(2));
@@ -5131,7 +5131,7 @@ void haltestelle_t::display_status(KOORD_VAL xpos, KOORD_VAL ypos)
 						continue;
 					}
 					if (total_ware) {
-						KOORD_VAL h = (v*get_ware_summe(wtyp2) + total_ware-1) / total_ware;
+						scr_coord_val h = (v*get_ware_summe(wtyp2) + total_ware-1) / total_ware;
 						h = min(h, v-yoff);
 
 						display_fillbox_wh_clip_rgb(xpos, ypos - v - 1 + yoff, 1, h, color_idx_to_rgb(COL_GREY4), false);
@@ -5147,8 +5147,8 @@ void haltestelle_t::display_status(KOORD_VAL xpos, KOORD_VAL ypos)
 					display_fillbox_wh_clip_rgb(xpos + (D_WAITINGBAR_WIDTH / 2) - 2, ypos - v - 5, 4, 1, color_idx_to_rgb(COL_WHITE), false);
 				}
 
-				if (last_bar_height[bar_height_index] != (KOORD_VAL)v) {
-					if ((KOORD_VAL)v > last_bar_height[bar_height_index]) {
+				if (last_bar_height[bar_height_index] != (scr_coord_val)v) {
+					if ((scr_coord_val)v > last_bar_height[bar_height_index]) {
 						// bar will be longer, mark new height dirty
 						mark_rect_dirty_wc(xpos, ypos - v - 6, xpos + 4 - 1, ypos + 4 - 1);
 					}

--- a/simhalt.h
+++ b/simhalt.h
@@ -146,7 +146,7 @@ private:
 
 	PIXVAL status_color, last_status_color;
 	sint16 last_bar_count;
-	vector_tpl<KOORD_VAL> last_bar_height; // caches the last height of the station bar for each good type drawn in display_status(). used for dirty tile management
+	vector_tpl<scr_coord_val> last_bar_height; // caches the last height of the station bar for each good type drawn in display_status(). used for dirty tile management
 	uint32 capacity[3]; // passenger, mail, goods
 	uint8 overcrowded[256/8]; ///< bit field for each goods type (max 256)
 
@@ -558,7 +558,7 @@ public:
 	/**
 	 * Draws some nice colored bars giving some status information
 	 */
-	void display_status(KOORD_VAL xpos, KOORD_VAL ypos);
+	void display_status(sint16 xpos, sint16 ypos);
 
 	/**
 	 * "Surrounding searches, achievable factories and builds the

--- a/simloadingscreen.cc
+++ b/simloadingscreen.cc
@@ -67,9 +67,9 @@ void loadingscreen_t::display()
 	const int half_width = width>>1;
 	const int quarter_width = width>>2;
 	const int half_height = display_get_height()>>1;
-	KOORD_VAL const bar_height = max(LINESPACE + 10, 20);
-	KOORD_VAL const bar_y = half_height - bar_height / 2 + 1;
-	KOORD_VAL const bar_text_y = half_height - LINESPACE / 2 + 1;
+    scr_coord_val const bar_height = max(LINESPACE + 10, 20);
+    scr_coord_val const bar_y = half_height - bar_height / 2 + 1;
+    scr_coord_val const bar_text_y = half_height - LINESPACE / 2 + 1;
 
 	const int bar_len = max_progress>0 ? (int) ( ((double)progress*(double)half_width)/(double)max_progress ) : 0;
 

--- a/simworld.cc
+++ b/simworld.cc
@@ -2756,14 +2756,14 @@ void karte_t::enlarge_map(settings_t const* sets, sint8 const* const h_field)
 
 	intr_disable();
 
-	bool minimap_was_visible = minimap_t::is_visible;
+	bool minimap_was_visible = minimap_t::get_instance()->is_visible;
 
 	uint32 max_display_progress;
 
 	// If this is not called by karte_t::init
 	if(  old_x != 0  ) {
 		mute_sound(true);
-		minimap_t::is_visible = false;
+		minimap_t::get_instance()->is_visible = false;
 
 		if(is_display_init()) {
 			display_show_pointer(false);
@@ -3074,8 +3074,8 @@ void karte_t::enlarge_map(settings_t const* sets, sint8 const* const h_field)
 		}
 		mute_sound(false);
 
-		minimap_t::is_visible = minimap_was_visible;
 		minimap_t::get_instance()->init();
+		minimap_t::get_instance()->is_visible = minimap_was_visible;
 		minimap_t::get_instance()->calc_map();
 		minimap_t::get_instance()->set_display_mode( minimap_t::get_instance()->get_display_mode() );
 
@@ -4643,7 +4643,7 @@ DBG_MESSAGE( "karte_t::rotate90()", "called" );
 	factory_builder_t::new_world();
 
 	// update minimap
-	if(minimap_t::is_visible) {
+	if(minimap_t::get_instance()->is_visible) {
 		minimap_t::get_instance()->set_display_mode( minimap_t::get_instance()->get_display_mode() );
 	}
 

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -1648,7 +1648,7 @@ void vehicle_t::leave_tile()
 {
 	vehicle_base_t::leave_tile();
 #ifndef DEBUG_ROUTES
-	if(last  &&  minimap_t::is_visible) {
+	if(last  &&  minimap_t::get_instance()->is_visible) {
 			minimap_t::get_instance()->calc_map_pixel(get_pos().get_2d());
 	}
 #endif
@@ -1661,7 +1661,7 @@ void vehicle_t::enter_tile(grund_t* gr)
 {
 	vehicle_base_t::enter_tile(gr);
 
-	if(leading  &&  minimap_t::is_visible  ) {
+	if(leading  &&  minimap_t::get_instance()->is_visible  ) {
 		minimap_t::get_instance()->calc_map_pixel( get_pos().get_2d() );
 	}
 }


### PR DESCRIPTION
This PR includes the following changes:
Fix: Do not show stop coverage on farm fields
Fix: Prevent overflows caused by some minimap layers on huge maps
Fix: The "Stop coverage" layer did not work properly with the "All freight Types" filter
Change: Companies without convoys (pure infrastructure companies) can now be selected in minimaps company filter.
Code cleanup of minimap.cc and minimap.h