### PR TITLE
Added private car routing improvements

### DIFF
--- a/simcity.cc
+++ b/simcity.cc
@@ -6014,6 +6014,28 @@ int private_car_destination_finder_t::get_cost(const grund_t* gr, sint32 max_spe
 	sint32 speed = min(max_speed, max_tile_speed);
 
 #ifndef FORBID_CONGESTION_EFFECTS
+
+#ifndef FORBID_CONGESTION_ASSUMPTIONS
+	//cities tend to be congested despite way congestion percentage
+	if(city!=NULL){
+		speed -= speed / 2;
+	}
+
+	//crossings very slow
+	if(w->is_crossing()){
+		speed -= speed / 2;
+	}
+
+	//one way roads tend to be faster
+	if(ribi_t::is_single(w->get_ribi_maske())){
+		speed += speed / 2;
+	}
+
+	if(ribi_t::is_threeway(w->get_ribi_unmasked())){
+		speed -= speed / 2;
+	}
+#endif
+
 	const uint32 congestion_percentage = w->get_congestion_percentage();
 	if (congestion_percentage)
 	{

--- a/simcity.cc
+++ b/simcity.cc
@@ -6027,8 +6027,8 @@ int private_car_destination_finder_t::get_cost(const grund_t* gr, sint32 max_spe
 	}
 
 	//one way roads tend to be faster
-	if(ribi_t::is_single(w->get_ribi_maske())){
-		speed += speed / 2;
+	if(ribi_t::is_twoway(w->get_ribi_maske())){
+		speed -= speed / 4;
 	}
 
 	if(ribi_t::is_threeway(w->get_ribi_unmasked())){


### PR DESCRIPTION
Private cars prefer one-ways roads, and avoid cities, crossings, and intersections.
This would hypothetically reduce private car driving calculations by steering private cars away from situations where more calculations are needed, however there would be a slight increase in private car routing calculations, which do not need to be done in real-time.  The side effects of this are reduced in-city congestion, as well as encouraging the placement of "ring-roads" or "beltways" around cities.