### PR TITLE
Low Level performance optimizations for ribi_t

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,23 @@ SDL2_CONFIG      ?= pkg-config sdl2
 FREETYPE_CONFIG  ?= pkg-config freetype2
 #FREETYPE_CONFIG ?= freetype-config
 
+ifneq ($(LTO),)
+  CFLAGS += -flto
+  LDFLAGS += -flto
+endif
+
+ifeq ($(shell getconf LONG_BIT),64)
+  CFLAGS += -DHAS_64_BIT_SYSTEM
+endif
+
+ifneq ($(TUNE_NATIVE),)
+	CFLAGS += -march=native -mtune=native
+	LDFLAGS += -march=native -mtune=native
+  ifneq ($(GCC_POPCOUNT),)
+    CFLAGS += -DUSE_GCC_POPCOUNT	
+  endif
+endif
+
 ifneq ($(OPTIMISE),)
   CFLAGS += -O3
   ifeq ($(findstring $(OSTYPE), amiga),)

--- a/config.default.in
+++ b/config.default.in
@@ -31,6 +31,9 @@ MSG_LEVEL = 3
 OPTIMISE = 1 # Add umpteen optimisation flags
 #PROFILE = 1  # Enable profiling
 #PROFILE = 2  # Enable profiling with optimisation flags, can be used with `OPTIMISE = 1'
+#LTO = 1 # enable link time optimizations
+#TUNE_NATIVE = 1 # enable tuning for this machine (makes binary not portable)
+#GCC_POPCOUNT = 1 # use gcc builtin popcount to speed up on modern machines (makes binary not portable) 
 
 
 WITH_REVISION = @svn@ # adds the revision from svn; required for networkgames

--- a/config.template
+++ b/config.template
@@ -33,6 +33,9 @@
 #OPTIMISE = 1 # Add umpteen optimisation flags
 #PROFILE = 1  # Enable profiling
 #PROFILE = 2  # Enable profiling with optimisation flags, can be used with `OPTIMISE = 1'
+#LTO = 1 # enable link time optimizations
+#TUNE_NATIVE = 1 # enable tuning for this machine (makes binary not portable)
+#GCC_POPCOUNT = 1 # use gcc builtin popcount to speed up on modern machines (makes binary not portable) 
 
 #AV_FOUNDATION = 1  # Use AVFoundation instead of QTKit. If you are using macOS 10.12 or later, this must be enabled.
 

--- a/dataobj/ribi.cc
+++ b/dataobj/ribi.cc
@@ -340,7 +340,7 @@ bool ribi_t::is_perpendicular(ribi x, ribi y)
 {
 	// for straight direction x use doppelr lookup table
 	if(is_straight(x)) {
-		return (doppelr[x] | doppelr[y]) == all;
+		return (doubles(x) | doubles(y)) == all;
 	}
 	// now diagonals (more tricky)
 	if(x!=y) {

--- a/dataobj/ribi.h
+++ b/dataobj/ribi.h
@@ -232,13 +232,13 @@ public:
 
 	/// Convert single/straight direction into their doubled form (n, ns -> ns), map all others to zero
 #ifdef HAS_64_BIT_SYSTEM
-	static ribi doubles(ribi x) {return (0x00000A0A00550A50lu>>(x*4))&0xf; }
+	static ribi doubles(ribi x) {return (INT64_C(0x00000A0A00550A50)>>(x*4))&0xf; }
 #else
 	static ribi doubles(ribi x) { return doppelr[x]; }
 #endif
 	/// Backward direction for single (or straight) ribi's, bitwise-NOT for all others
 #ifdef HAS_64_BIT_SYSTEM
-	static ribi backward(ribi x) {return (0x01234A628951C84Flu>>(x*4))&0xF; }
+	static ribi backward(ribi x) {return (INT64_C(0x01234A628951C84F)>>(x*4))&0xF; }
 #else
 	static ribi backward(ribi x) { return backwards[x]; }
 #endif
@@ -261,7 +261,7 @@ public:
 
 	/// Convert ribi to dir
 #ifdef HAS_64_BIT_SYSTEM
-	static dir get_dir(ribi x) {return (0x0002007103006540>>(x*4))&0x7; }
+	static dir get_dir(ribi x) {return (INT64_C(0x0002007103006540)>>(x*4))&0x7; }
 #else
 	static dir get_dir(ribi x) { return dirs[x]; }
 #endif

--- a/dataobj/ribi.h
+++ b/dataobj/ribi.h
@@ -200,25 +200,48 @@ private:
 	static const ribi doppelr[16];
 	/// Lookup table to convert ribi to dir.
 	static const dir  dirs[16];
+
+#ifdef USE_GCC_POPCOUNT
+	static uint8 get_numways(ribi x) { return (__builtin_popcount(x));}
+#endif
+
 public:
 	/// Table containing the four compass directions
 	static const ribi nesw[4];
 	/// Convert building layout to ribi (four rotations), use doppelt in case of two rotations
 	static const ribi layout_to_ribi[4]; // building layout to ribi (for four rotations, for two use doppelt()!
 
-	static bool is_twoway(ribi x) { return (flags[x]&twoway)!=0; }
-	static bool is_threeway(ribi x) { return (flags[x]&threeway)!=0; }
-	static bool is_perpendicular(ribi x, ribi y);
-	static bool is_single(ribi x) { return (flags[x] & single) != 0; }
-	static bool is_bend(ribi x) { return (flags[x] & bend) != 0; }
-	static bool is_straight(ribi x) { return (flags[x] & (straight_ns | straight_ew)) != 0; }
-	static bool is_straight_ns(ribi x) { return (flags[x] & straight_ns) != 0; }
-	static bool is_straight_ew(ribi x) { return (flags[x] & straight_ew) != 0; }
+#ifdef USE_GCC_POPCOUNT
+    static bool is_twoway(ribi x) { return get_numways(x)==2; }
+    static bool is_threeway(ribi x) { return get_numways(x)>2; }
+#else
+    static bool is_twoway(ribi x) { return (0x1668>>x)&1; }
+    static bool is_threeway(ribi x) { return (0xE880>>x)&1; }
+#endif
+
+    static bool is_perpendicular(ribi x, ribi y);
+#ifdef USE_GCC_POPCOUNT
+    static bool is_single(ribi x) { return get_numways(x)==1; }
+#else
+    static bool is_single(ribi x) { return (0x0116>>x)&1; }
+#endif
+    static bool is_bend(ribi x) { return (0x1248>>x)&1; }
+    static bool is_straight(ribi x) { return (0x0536>>x)&1; }
+    static bool is_straight_ns(ribi x) { return (x | northsouth) == northsouth; }
+    static bool is_straight_ew(ribi x) { return (x | eastwest) == eastwest; }
 
 	/// Convert single/straight direction into their doubled form (n, ns -> ns), map all others to zero
-	static ribi doubles(ribi x) { return doppelr[x]; }
-	/// Backward direction for single ribi's, bitwise-NOT for all others
+#ifdef HAS_64_BIT_SYSTEM
+	static ribi doubles(ribi x) {return (0x00000A0A00550A50lu>>(x*4))&0xf; }
+#else
+	static ribi doubles(ribi x) { return is_straight_ns(x) ? northsouth : (is_straight_ew(x) ? eastwest : none); }
+#endif
+	/// Backward direction for single (or straight) ribi's, bitwise-NOT for all others
+#ifdef HAS_64_BIT_SYSTEM
+	static ribi backward(ribi x) {return (0x01234A628951C84Flu>>(x*4))&0xF; }
+#else
 	static ribi backward(ribi x) { return backwards[x]; }
+#endif
 
 	/**
 	 * Same as backward, but for single directions only.
@@ -237,7 +260,11 @@ public:
 	static ribi rotate45l(ribi x) { return (is_single(x) ? x|rotate90l(x) : x&rotate90l(x)); } // 45 to the left
 
 	/// Convert ribi to dir
+#ifdef HAS_64_BIT_SYSTEM
+	static dir get_dir(ribi x) {return (0x0002007103006540>>(x*4))&0x7; }
+#else
 	static dir get_dir(ribi x) { return dirs[x]; }
+#endif
 };
 
 /**

--- a/dataobj/ribi.h
+++ b/dataobj/ribi.h
@@ -212,29 +212,29 @@ public:
 	static const ribi layout_to_ribi[4]; // building layout to ribi (for four rotations, for two use doppelt()!
 
 #ifdef USE_GCC_POPCOUNT
-    static bool is_twoway(ribi x) { return get_numways(x)==2; }
-    static bool is_threeway(ribi x) { return get_numways(x)>2; }
+	static bool is_twoway(ribi x) { return get_numways(x)==2; }
+	static bool is_threeway(ribi x) { return get_numways(x)>2; }
 #else
-    static bool is_twoway(ribi x) { return (0x1668>>x)&1; }
-    static bool is_threeway(ribi x) { return (0xE880>>x)&1; }
+	static bool is_twoway(ribi x) { return (0x1668>>x)&1; }
+	static bool is_threeway(ribi x) { return (0xE880>>x)&1; }
 #endif
 
-    static bool is_perpendicular(ribi x, ribi y);
+	static bool is_perpendicular(ribi x, ribi y);
 #ifdef USE_GCC_POPCOUNT
-    static bool is_single(ribi x) { return get_numways(x)==1; }
+	static bool is_single(ribi x) { return get_numways(x)==1; }
 #else
-    static bool is_single(ribi x) { return (0x0116>>x)&1; }
+	static bool is_single(ribi x) { return (0x0116>>x)&1; }
 #endif
-    static bool is_bend(ribi x) { return (0x1248>>x)&1; }
-    static bool is_straight(ribi x) { return (0x0536>>x)&1; }
-    static bool is_straight_ns(ribi x) { return (x | northsouth) == northsouth; }
-    static bool is_straight_ew(ribi x) { return (x | eastwest) == eastwest; }
+	static bool is_bend(ribi x) { return (0x1248>>x)&1; }
+	static bool is_straight(ribi x) { return (0x0536>>x)&1; }
+	static bool is_straight_ns(ribi x) { return (0x0032>>x)&1; }
+	static bool is_straight_ew(ribi x) { return (0x0504>>x)&1; }
 
 	/// Convert single/straight direction into their doubled form (n, ns -> ns), map all others to zero
 #ifdef HAS_64_BIT_SYSTEM
 	static ribi doubles(ribi x) {return (0x00000A0A00550A50lu>>(x*4))&0xf; }
 #else
-	static ribi doubles(ribi x) { return is_straight_ns(x) ? northsouth : (is_straight_ew(x) ? eastwest : none); }
+	static ribi doubles(ribi x) { return doppelr[x]; }
 #endif
 	/// Backward direction for single (or straight) ribi's, bitwise-NOT for all others
 #ifdef HAS_64_BIT_SYSTEM


### PR DESCRIPTION
Modified `ribi` to avoid Look-Up-Tables to hypothetically increase performance.
Also adjusted Makefile to reflect conditional compilation of some such optimizations.
Additionally, enabled Link Time Optimizations (LTO).

As each column of the `ribi_t::flags` Look-Up Table is 16 bits, such columns are flattened into the `ribi_t` functions using such flags.  After compilation, this replaces the _address calculation_, _load_, _and_ with a _Load Immediate_, _shift_, _and_ on the x86 and x86_64.  Likewise, for 64 bit machines, the `ribi_t::backwards`, `ribi_t::doppelr`, and `ribi_t::dirs` have their LUTs flattened to 64 bit longs, resulting in a _shift_, _Load Immediate_, _shift_, _and_.  `is_straight_{ns,ew}` functions have been simplified to an _or_, _compare_.  Additionally, when compiling for a local machine, the user would have the option of use the `__builtin_popcount()` function which would, on architectures that support it, reduce `is_single()`, `is_twoway()`, and `is_threeway()` to _popcount_, _compare_.

An LTO option is also added to the Makefile.

Edit: Formatting