### PR TITLE
FIX: cities_awaiting_private_car_check saves fixed city position

### DIFF
--- a/simworld.cc
+++ b/simworld.cc
@@ -8933,7 +8933,7 @@ DBG_MESSAGE("karte_t::save(loadsave_t *file)", "motd filename %s", env_t::server
 
 		for (auto city : cities_awaiting_private_car_route_check)
 		{
-			koord location = city->get_center();
+			koord location = city->get_pos();
 			location.rdwr(file);
 		}
 


### PR DESCRIPTION
Previously, cities_awaiting_private_car_route_check saved using cities center position, which in rare cases would move outside of the city when loading.