### PR TITLE
Private car routing improvements

### DIFF
--- a/simcity.cc
+++ b/simcity.cc
@@ -6014,6 +6014,28 @@ int private_car_destination_finder_t::get_cost(const grund_t* gr, sint32 max_spe
 	sint32 speed = min(max_speed, max_tile_speed);
 
 #ifndef FORBID_CONGESTION_EFFECTS
+
+#ifndef FORBID_CONGESTION_ASSUMPTIONS
+	//cities tend to be congested despite way congestion percentage
+	if(city!=NULL){
+		speed -= speed / 2;
+	}
+
+	//crossings very slow
+	if(w->is_crossing()){
+		speed -= speed / 2;
+	}
+
+	//one way roads tend to be faster
+	if(ribi_t::is_single(w->get_ribi_maske())){
+		speed += speed / 2;
+	}
+
+	if(ribi_t::is_threeway(w->get_ribi_unmasked())){
+		speed -= speed / 2;
+	}
+#endif
+
 	const uint32 congestion_percentage = w->get_congestion_percentage();
 	if (congestion_percentage)
 	{

--- a/simcity.cc
+++ b/simcity.cc
@@ -5914,10 +5914,6 @@ private_car_destination_finder_t::private_car_destination_finder_t(karte_t* w, r
 	welt = w;
 	master = m;
 	origin_city = o;
-	last_tile_speed = 0;
-	last_tile_cost_diagonal = 0;
-	last_tile_cost_straight = 0;
-	last_city = NULL;
 	meters_per_tile_x100 = welt->get_settings().get_meters_per_tile() * 100; // For 100ths of a minute
 }
 
@@ -5991,55 +5987,15 @@ int private_car_destination_finder_t::get_cost(const grund_t* gr, sint32 max_spe
 	}
 
 	const sint32 max_tile_speed = w->get_max_speed(); // This returns speed in km/h.
-	const planquadrat_t* plan = welt->access_nocheck(gr->get_pos().get_2d());
-	const stadt_t* city = plan->get_city();
 	const bool is_diagonal = w->is_diagonal();
-
-	if(city == last_city && max_tile_speed == last_tile_speed)
-	{
-		// Need not redo the whole calculation if nothing has changed.
-		if(is_diagonal && last_tile_cost_diagonal > 0)
-		{
-			return last_tile_cost_diagonal;
-		}
-		else if(last_tile_cost_straight > 0)
-		{
-			return last_tile_cost_straight;
-		}
-	}
-
-	last_city = city;
-	last_tile_speed = max_tile_speed;
 
 	sint32 speed = min(max_speed, max_tile_speed);
 
 #ifndef FORBID_CONGESTION_EFFECTS
-
-#ifndef FORBID_CONGESTION_ASSUMPTIONS
-	//cities tend to be congested despite way congestion percentage
-	if(city!=NULL){
-		speed -= speed / 2;
-	}
-
-	//crossings very slow
-	if(w->is_crossing()){
-		speed -= speed / 2;
-	}
-
-	//one way roads tend to be faster
-	if(ribi_t::is_twoway(w->get_ribi_maske())){
-		speed -= speed / 4;
-	}
-
-	if(ribi_t::is_threeway(w->get_ribi_unmasked())){
-		speed -= speed / 2;
-	}
-#endif
-
-	const uint32 congestion_percentage = w->get_congestion_percentage();
+	const sint32 congestion_percentage = w->get_congestion_percentage();
 	if (congestion_percentage)
 	{
-		speed -= (speed * congestion_percentage) / 200;
+		speed = speed * 100 / (100 + congestion_percentage);
 		speed = max(4, speed);
 	}
 #endif
@@ -6069,14 +6025,6 @@ int private_car_destination_finder_t::get_cost(const grund_t* gr, sint32 max_spe
 
 	const int cost = mpt / ((speed * 167) / 10);
 
-	if(is_diagonal)
-	{
-		last_tile_cost_diagonal = cost;
-	}
-	else
-	{
-		last_tile_cost_straight = cost;
-	}
 	return cost;
 }
 

--- a/simcity.cc
+++ b/simcity.cc
@@ -6027,8 +6027,8 @@ int private_car_destination_finder_t::get_cost(const grund_t* gr, sint32 max_spe
 	}
 
 	//one way roads tend to be faster
-	if(ribi_t::is_single(w->get_ribi_maske())){
-		speed += speed / 2;
+	if(ribi_t::is_twoway(w->get_ribi_maske())){
+		speed -= speed / 4;
 	}
 
 	if(ribi_t::is_threeway(w->get_ribi_unmasked())){

--- a/simcity.h
+++ b/simcity.h
@@ -90,10 +90,6 @@ private:
 	karte_t* welt;
 	road_vehicle_t *master;
 	stadt_t* origin_city;
-	const stadt_t* last_city;
-	uint32 last_tile_speed;
-	int last_tile_cost_diagonal;
-	int last_tile_cost_straight;
 	uint16 meters_per_tile_x100;
 
 public:


### PR DESCRIPTION
private_car_destination_finder: made speed calculation more linear to recorded congestion information and removed erroneous caching of cost.