### PR TITLE
Company takeover fixes

### DIFF
--- a/player/finance.h
+++ b/player/finance.h
@@ -540,6 +540,8 @@ public:
 		return veh_month[TT_ALL][0][ATV_NON_FINANCIAL_ASSETS] + account_balance;
 	}
 
+	sint64 get_financial_assets() const {return veh_month[TT_ALL][0][ATV_NON_FINANCIAL_ASSETS];}
+
 	sint64 get_scenario_completed() const { return com_month[0][ATC_SCENARIO_COMPLETED]; }
 
 	void set_scenario_completed(sint64 percent) { com_year[0][ATC_SCENARIO_COMPLETED] = com_month[0][ATC_SCENARIO_COMPLETED] = percent; }

--- a/player/simplay.cc
+++ b/player/simplay.cc
@@ -345,7 +345,7 @@ void player_t::step()
 {
 	/*
 	NOTE: This would need updating to the new FOR iterators to work now.
-	// die haltestellen mEsen die Fahrpläne rgelmaessig pruefen
+	// die haltestellen mï¿½Esen die Fahrplï¿½ne rgelmaessig pruefen
 	uint8 i = (uint8)(welt->get_steps()+player_nr);
 	//slist_iterator_tpl <nearby_halt_t> iter( halt_list );
 	//while(iter.next()) {
@@ -1250,18 +1250,14 @@ sint64 player_t::calc_takeover_cost() const
 {
 	sint64 cost = 0;
 	const bool do_not_adopt_liabilities = check_solvency() == player_t::in_liquidation;
-	if (!do_not_adopt_liabilities)
-	{
-		if (finance->get_account_balance() < 0)
-		{
-			cost -= finance->get_account_balance();
-		}
-
-		// TODO: Add any liability for longer term loans here whenever longer term loans come to be implemented.
+	if (!do_not_adopt_liabilities || finance->get_account_balance() > 0) {
+		cost -= finance->get_account_balance();
 	}
+	// TODO: Add any liability for longer term loans here whenever longer term loans come to be implemented.
+
 
 	// TODO: Consider a more sophisticated system here; but where can we get the data for this?
-	cost -= finance->get_netwealth();
+	cost += finance->get_financial_assets();
 	return cost;
 }
 
@@ -1283,8 +1279,8 @@ const char* player_t::can_take_over(player_t* target_player)
 void player_t::take_over(player_t* target_player)
 {
 	// Pay for the takeover
-	finance->book_account(target_player->calc_takeover_cost());
-
+	finance->book_account(-target_player->calc_takeover_cost());
+/*
 	if (check_solvency() != player_t::in_liquidation)
 	{
 		// Take the player's account balance, whether negative or not.
@@ -1292,7 +1288,7 @@ void player_t::take_over(player_t* target_player)
 
 		// TODO: Add any liability for longer term loans here whenever longer term loans come to be implemented.
 	}
-
+*/
 	// Transfer maintenance costs
 	for (uint32 i = 0; i < transport_type::TT_MAX; i++)
 	{

--- a/player/simplay.cc
+++ b/player/simplay.cc
@@ -1249,9 +1249,17 @@ void player_t::set_selected_signalbox(signalbox_t* sb)
 sint64 player_t::calc_takeover_cost() const
 {
 	sint64 cost = 0;
-	cost += welt->get_settings().get_starting_money(welt->get_last_year());
-	const bool do_not_adopt_liabilities = check_solvency() == player_t::in_liquidation;
-	if (!do_not_adopt_liabilities || finance->get_account_balance() > 0) {
+
+	const bool adopt_liabilities = check_solvency() != player_t::in_liquidation;
+	if(adopt_liabilities){
+		// Refund the free starting capital on company takeover.
+		// This represents a situation in which the starting capital is a non-interest-bearing available to each company only exactly once.
+		// Do not add this cost when the company is in liquidation as discussed in the forums, although this re-enables a free-money-generator exploit.
+		// TODO: Reconsider this whenever a more sophisticated loan system is implemented.
+		cost += welt->get_settings().get_starting_money(welt->get_last_year());
+	}
+
+	if (adopt_liabilities || finance->get_account_balance() > 0) {
 		cost -= finance->get_account_balance();
 	}
 	// TODO: Add any liability for longer term loans here whenever longer term loans come to be implemented.

--- a/player/simplay.cc
+++ b/player/simplay.cc
@@ -1249,6 +1249,7 @@ void player_t::set_selected_signalbox(signalbox_t* sb)
 sint64 player_t::calc_takeover_cost() const
 {
 	sint64 cost = 0;
+	cost += welt->get_settings().get_starting_money(welt->get_last_year());
 	const bool do_not_adopt_liabilities = check_solvency() == player_t::in_liquidation;
 	if (!do_not_adopt_liabilities || finance->get_account_balance() > 0) {
 		cost -= finance->get_account_balance();


### PR DESCRIPTION
The takeover cost calculation seems to be broken.
The first commit fixes those calculations.
The new behavior is the following:
- Takeover costs are calculated as "assets - account_balance" if the company is not in liquidation
- Takeover costs ammount in just the assets if the company is in liquidation

The second commit adds an additional cost to takeovers ammounting in the start capital of the current year to prevent the takeover exploit.