### PR TITLE
Yellow light

### DIFF
--- a/gui/trafficlight_info.cc
+++ b/gui/trafficlight_info.cc
@@ -14,7 +14,7 @@ trafficlight_info_t::trafficlight_info_t(roadsign_t* s) :
 	obj_infowin_t(s),
 	roadsign(s)
 {
-	add_table(3,0);
+	add_table(4,0);
 	ns.set_limits( 1, 255 );
 	ns.set_value( s->get_ticks_ns() );
 	ns.wrap_mode( false );
@@ -26,6 +26,12 @@ trafficlight_info_t::trafficlight_info_t(roadsign_t* s) :
 	ow.wrap_mode( false );
 	ow.add_listener( this );
 	add_component( &ow );
+
+	ow.set_limits( 1, 255 );
+	ow.set_value( s->get_ticks_yellow() );
+	ow.wrap_mode( false );
+	ow.add_listener( this );
+	add_component( &yellow );
 
 	offset.set_limits( 0, 255 );
 	offset.set_value( s->get_ticks_offset() );
@@ -70,6 +76,11 @@ bool trafficlight_info_t::action_triggered( gui_action_creator_t *comp, value_t 
 		tool_t::simple_tool[TOOL_CHANGE_TRAFFIC_LIGHT]->set_default_param( param );
 		welt->set_tool( tool_t::simple_tool[TOOL_CHANGE_TRAFFIC_LIGHT], welt->get_active_player() );
 	}
+ 	else if(comp == &yellow) {
+		sprintf( param, "%s,3,%i", roadsign->get_pos().get_str(), (int)v.i );
+		tool_t::simple_tool[TOOL_CHANGE_TRAFFIC_LIGHT]->set_default_param( param );
+		welt->set_tool( tool_t::simple_tool[TOOL_CHANGE_TRAFFIC_LIGHT], welt->get_active_player() );
+	}
 	return true;
 }
 
@@ -80,4 +91,5 @@ void trafficlight_info_t::update_data()
 	ns.set_value( roadsign->get_ticks_ns() );
 	ow.set_value( roadsign->get_ticks_ow() );
 	offset.set_value( roadsign->get_ticks_offset() );
+	yellow.set_value( roadsign->get_ticks_yellow() );
 }

--- a/gui/trafficlight_info.cc
+++ b/gui/trafficlight_info.cc
@@ -14,31 +14,42 @@ trafficlight_info_t::trafficlight_info_t(roadsign_t* s) :
 	obj_infowin_t(s),
 	roadsign(s)
 {
-	add_table(4,0);
-	ns.set_limits( 1, 255 );
-	ns.set_value( s->get_ticks_ns() );
-	ns.wrap_mode( false );
-	ns.add_listener( this );
-	add_component( &ns );
+	add_table(3,1);
+	{
+	  ns.set_limits( 1, 255 );
+	  ns.set_value( s->get_ticks_ns() );
+	  ns.wrap_mode( false );
+	  ns.add_listener( this );
+	  add_component( &ns );
+	  
+	  ow.set_limits( 1, 255 );
+	  ow.set_value( s->get_ticks_ow() );
+	  ow.wrap_mode( false );
+	  ow.add_listener( this );
+	  add_component( &ow );
+	  
+	  offset.set_limits( 0, 255 );
+	  offset.set_value( s->get_ticks_offset() );
+	  offset.wrap_mode( false );
+	  offset.add_listener( this );
+	  add_component( &offset );
+	}
+	end_table();
 
-	ow.set_limits( 1, 255 );
-	ow.set_value( s->get_ticks_ow() );
-	ow.wrap_mode( false );
-	ow.add_listener( this );
-	add_component( &ow );
-
-	ow.set_limits( 1, 255 );
-	ow.set_value( s->get_ticks_yellow() );
-	ow.wrap_mode( false );
-	ow.add_listener( this );
-	add_component( &yellow );
-
-	offset.set_limits( 0, 255 );
-	offset.set_value( s->get_ticks_offset() );
-	offset.wrap_mode( false );
-	offset.add_listener( this );
-	add_component( &offset );
-
+	add_table(2,1);
+	{
+	  yellow_ns.set_limits( 1, 255 );
+	  yellow_ns.set_value( s->get_ticks_yellow_ns() );
+	  yellow_ns.wrap_mode( false );
+	  yellow_ns.add_listener( this );
+	  add_component( &yellow_ns );
+	  
+	  yellow_ow.set_limits( 1, 255 );
+	  yellow_ow.set_value( s->get_ticks_yellow_ow() );
+	  yellow_ow.wrap_mode( false );
+	  yellow_ow.add_listener( this );
+	  add_component( &yellow_ow );
+	}
 	end_table();
 
 	// show author below the settings
@@ -76,7 +87,12 @@ bool trafficlight_info_t::action_triggered( gui_action_creator_t *comp, value_t 
 		tool_t::simple_tool[TOOL_CHANGE_TRAFFIC_LIGHT]->set_default_param( param );
 		welt->set_tool( tool_t::simple_tool[TOOL_CHANGE_TRAFFIC_LIGHT], welt->get_active_player() );
 	}
- 	else if(comp == &yellow) {
+ 	else if(comp == &yellow_ns) {
+		sprintf( param, "%s,4,%i", roadsign->get_pos().get_str(), (int)v.i );
+		tool_t::simple_tool[TOOL_CHANGE_TRAFFIC_LIGHT]->set_default_param( param );
+		welt->set_tool( tool_t::simple_tool[TOOL_CHANGE_TRAFFIC_LIGHT], welt->get_active_player() );
+	}
+ 	else if(comp == &yellow_ow) {
 		sprintf( param, "%s,3,%i", roadsign->get_pos().get_str(), (int)v.i );
 		tool_t::simple_tool[TOOL_CHANGE_TRAFFIC_LIGHT]->set_default_param( param );
 		welt->set_tool( tool_t::simple_tool[TOOL_CHANGE_TRAFFIC_LIGHT], welt->get_active_player() );
@@ -91,5 +107,6 @@ void trafficlight_info_t::update_data()
 	ns.set_value( roadsign->get_ticks_ns() );
 	ow.set_value( roadsign->get_ticks_ow() );
 	offset.set_value( roadsign->get_ticks_offset() );
-	yellow.set_value( roadsign->get_ticks_yellow() );
+	yellow_ns.set_value( roadsign->get_ticks_yellow_ns() );
+	yellow_ow.set_value( roadsign->get_ticks_yellow_ow() );
 }

--- a/gui/trafficlight_info.h
+++ b/gui/trafficlight_info.h
@@ -21,7 +21,7 @@ class trafficlight_info_t : public obj_infowin_t, public action_listener_t
 {
 private:
 	roadsign_t* roadsign;
-	gui_numberinput_t ns, ow, offset;
+  gui_numberinput_t ns, ow, offset, yellow;
 
 public:
 	trafficlight_info_t(roadsign_t* s);

--- a/gui/trafficlight_info.h
+++ b/gui/trafficlight_info.h
@@ -21,7 +21,7 @@ class trafficlight_info_t : public obj_infowin_t, public action_listener_t
 {
 private:
 	roadsign_t* roadsign;
-  gui_numberinput_t ns, ow, offset, yellow;
+        gui_numberinput_t ns, ow, offset, yellow_ns, yellow_ow;
 
 public:
 	trafficlight_info_t(roadsign_t* s);

--- a/obj/roadsign.cc
+++ b/obj/roadsign.cc
@@ -639,11 +639,11 @@ sync_result roadsign_t::sync_step(uint32 /*delta_t*/)
 
 		uint8 new_state=0;
 		//traffic light transition: e-w dir -> yellow e-w -> n-s dir -> yellow n-s -> ...
-		if( ticks <= ticks_ow ){
+		if( ticks < ticks_ow ){
 		  new_state=0;
-		}else if( ticks <= ticks_ow+ticks_yellow_ow ){
+		}else if( ticks < ticks_ow+ticks_yellow_ow ){
 		  new_state=2;
-		}else if( ticks <= ticks_ow+ticks_yellow_ow+ticks_ns ){
+		}else if( ticks < ticks_ow+ticks_yellow_ow+ticks_ns ){
 		  new_state=1;
 		}else{
 		  new_state=3;

--- a/obj/roadsign.h
+++ b/obj/roadsign.h
@@ -39,7 +39,7 @@ protected:
 	bool preview:1;
 	uint8 ticks_ns;
 	uint8 ticks_ow;
-	uint8 ticks_yellow;
+        uint8 ticks_yellow_ns, ticks_yellow_ow;
 	uint8 ticks_offset;
 
 	sint8 after_yoffset, after_xoffset;
@@ -135,24 +135,32 @@ public:
 	void set_ticks_ns(uint8 ns) {
 		ticks_ns = ns;
 		// To prevent overflow in ticks_offset when rotating
-		if (ticks_ow > 256-ticks_ns - ticks_yellow*2 ) {
-			ticks_ow = 256-ticks_ns-ticks_yellow*2;
+		if (ticks_ow > 256-ticks_ns - ticks_yellow_ns - ticks_yellow_ow ) {
+			ticks_ow = 256-ticks_ns-ticks_yellow_ns-ticks_yellow_ow;
 		}
 	}
 	uint8 get_ticks_ow() const { return ticks_ow; }
 	void set_ticks_ow(uint8 ow) {
 		ticks_ow = ow;
 		// To prevent overflow in ticks_offset when rotating
-		if (ticks_ns > 256-ticks_ow - ticks_yellow*2 ) {
-			ticks_ns = 256-ticks_ow-ticks_yellow*2;
+		if (ticks_ns > 256-ticks_ow - ticks_yellow_ns-ticks_yellow_ow ) {
+			ticks_ns = 256-ticks_ow-ticks_yellow_ns-ticks_yellow_ow;
 		}
 	}
-	uint8 get_ticks_yellow() const { return ticks_yellow; }
-	void set_ticks_yellow(uint8 yellow) {
-		ticks_yellow = yellow;
+	uint8 get_ticks_yellow_ns() const { return ticks_yellow_ns; }
+	void set_ticks_yellow_ns(uint8 yellow) {
+		ticks_yellow_ns = yellow;
 		// To prevent overflow in ticks_offset when rotating
-		if (ticks_yellow*2 > 256-ticks_ns - ticks_ow) {
-		  ticks_yellow = (256-ticks_ns-ticks_ow)/2;
+		if (ticks_yellow_ns > 256-ticks_ns - ticks_ow - ticks_yellow_ow) {
+		  ticks_yellow_ns = 256-ticks_ns-ticks_ow-ticks_yellow_ow;
+		}
+	}
+	uint8 get_ticks_yellow_ow() const { return ticks_yellow_ow; }
+	void set_ticks_yellow_ow(uint8 yellow) {
+		ticks_yellow_ow = yellow;
+		// To prevent overflow in ticks_offset when rotating
+		if (ticks_yellow_ow > 256-ticks_ns - ticks_ow - ticks_yellow_ns) {
+		  ticks_yellow_ow = 256-ticks_ns-ticks_ow-ticks_yellow_ns;
 		}
 	}
 	uint8 get_ticks_offset() const { return ticks_offset; }

--- a/obj/roadsign.h
+++ b/obj/roadsign.h
@@ -39,6 +39,7 @@ protected:
 	bool preview:1;
 	uint8 ticks_ns;
 	uint8 ticks_ow;
+	uint8 ticks_yellow;
 	uint8 ticks_offset;
 
 	sint8 after_yoffset, after_xoffset;
@@ -134,16 +135,24 @@ public:
 	void set_ticks_ns(uint8 ns) {
 		ticks_ns = ns;
 		// To prevent overflow in ticks_offset when rotating
-		if (ticks_ow > 256-ticks_ns) {
-			ticks_ow = 256-ticks_ns;
+		if (ticks_ow > 256-ticks_ns - ticks_yellow*2 ) {
+			ticks_ow = 256-ticks_ns-ticks_yellow*2;
 		}
 	}
 	uint8 get_ticks_ow() const { return ticks_ow; }
 	void set_ticks_ow(uint8 ow) {
 		ticks_ow = ow;
 		// To prevent overflow in ticks_offset when rotating
-		if (ticks_ns > 256-ticks_ow) {
-			ticks_ns = 256-ticks_ow;
+		if (ticks_ns > 256-ticks_ow - ticks_yellow*2 ) {
+			ticks_ns = 256-ticks_ow-ticks_yellow*2;
+		}
+	}
+	uint8 get_ticks_yellow() const { return ticks_yellow; }
+	void set_ticks_yellow(uint8 yellow) {
+		ticks_yellow = yellow;
+		// To prevent overflow in ticks_offset when rotating
+		if (ticks_yellow*2 > 256-ticks_ns - ticks_ow) {
+		  ticks_yellow = (256-ticks_ns-ticks_ow)/2;
 		}
 	}
 	uint8 get_ticks_offset() const { return ticks_offset; }

--- a/simtool.cc
+++ b/simtool.cc
@@ -9579,8 +9579,11 @@ bool tool_change_traffic_light_t::init( player_t *player )
 				else if(  ns == 2  ) {
 					rs->set_ticks_offset( (uint8)ticks );
 				}
+				else if(  ns == 4  ) {
+					rs->set_ticks_yellow_ns( (uint8)ticks );
+				}
 				else if(  ns == 3  ) {
-					rs->set_ticks_yellow( (uint8)ticks );
+					rs->set_ticks_yellow_ow( (uint8)ticks );
 				}
 				// update the window
 				if(  rs->get_desc()->is_traffic_light()  ) {

--- a/simtool.cc
+++ b/simtool.cc
@@ -9579,6 +9579,9 @@ bool tool_change_traffic_light_t::init( player_t *player )
 				else if(  ns == 2  ) {
 					rs->set_ticks_offset( (uint8)ticks );
 				}
+				else if(  ns == 3  ) {
+					rs->set_ticks_yellow( (uint8)ticks );
+				}
 				// update the window
 				if(  rs->get_desc()->is_traffic_light()  ) {
 					trafficlight_info_t* trafficlight_win = (trafficlight_info_t*)win_get_magic((ptrdiff_t)rs);

--- a/simversion.h
+++ b/simversion.h
@@ -34,8 +34,8 @@ extern "C" FILE * __cdecl __iob_func(void) { return _iob; }
 #define SIM_SERVER_MINOR    7
 
 #define EX_VERSION_MAJOR	14
-#define EX_VERSION_MINOR	14
-#define EX_SAVE_MINOR		39
+#define EX_VERSION_MINOR	15
+#define EX_SAVE_MINOR		40
 
 // Do not forget to increment the save game versions in settings_stats.cc when changing this
 

--- a/vehicle/simroadtraffic.cc
+++ b/vehicle/simroadtraffic.cc
@@ -674,7 +674,7 @@ bool private_car_t::can_enter_tile(grund_t *gr)
 
 	if(player != NULL && player->get_player_nr() != 1 && !player->allows_access_to(1))
 	{
-		// Private cas should have the same restrictions as to the roads on which to travel
+		// Private cars should have the same restrictions as to the roads on which to travel
 		// as players' vehicles.
 		time_to_life = 0;
 		return false;


### PR DESCRIPTION
This patch introduces yellow light that enables to prevent the car from entering the intersection while transitioning phases.
The default duration of phases is as follows:
N-S direction (16s)→ N-S yellow (2s) → E-W direction (16s) → E-W yellow (2s) → ...
and now the yellow light image can be used when the images are listed in image[17]-[31]. If those are not defined, green light images are used instead of yellow light.
