### PR TITLE
Auto factory rotation capability

### DIFF
--- a/bauer/fabrikbauer.cc
+++ b/bauer/fabrikbauer.cc
@@ -689,7 +689,40 @@ int factory_builder_t::build_link(koord3d* parent, const factory_desc_t* info, s
 			k1 = factory_site_searcher_t(welt, factory_desc_t::City).find_place(city->get_pos(), size.y, size.x, cl, regions_allowed);
 		}
 
-		rotate = simrand( info->get_building()->get_all_layouts(), " factory_builder_t::build_link" );
+
+                int streetdir = 0;
+                if (size.x == 1 && size.y == 1) {
+                  static int const neighbours_to_senw[] = { 0x0c, 0x08, 0x09, 0x01, 0x03, 0x02, 0x06, 0x04 };
+                  for ( int i = 1;  i < 8;  i+=2  ) {
+                    grund_t *gr2 = welt->lookup_kartenboden(k + koord::neighbours[i]);
+                    if ( gr2  &&  gr2->get_weg_hang() == gr2->get_grund_hang()  &&  gr2->get_weg(road_wt) != NULL  ) {
+                      // update directions - note this is SENW, conversion from neighbours to SENW is
+                      // neighbours SENW   Bits in building_layout
+                      // 3          0      0x01
+                      // 5          1      0x02
+                      // 7          2      0x04
+                      // 1          3      0x08
+                      streetdir |= neighbours_to_senw[i];
+                    }
+                  }
+                  if (streetdir == 0) { // No adjacent streets; check diagonally
+                    for(  int i = 0;  i < 8;  i+=2  ) {
+                      grund_t *gr2 = welt->lookup_kartenboden(k + koord::neighbours[i]);
+                      if(  gr2  &&  gr2->get_weg_hang() == gr2->get_grund_hang()  &&  gr2->get_weg(road_wt) != NULL  ) {
+                        streetdir |= neighbours_to_senw[i];
+                      }
+                    }
+                  }
+                }
+
+                if (streetdir == 0) { // No adjacent streets; choose random rotation
+                  rotate = simrand( info->get_building()->get_all_layouts(), " factory_builder_t::build_link" );
+                } else {
+                  // Copied from simtool.cc, this converts senw to desired rotations.
+                  static int const building_layout[] = { 0, 0, 1, 4, 2, 0, 5, 1, 3, 7, 1, 0, 6, 3, 2, 0 };
+                  rotate = building_layout[streetdir];
+                }
+
 		if (k1 == koord::invalid) {
 			if (size.x != size.y) {
 				rotate &= 2; // rotation must be even number
@@ -699,6 +732,7 @@ int factory_builder_t::build_link(koord3d* parent, const factory_desc_t* info, s
 			k = k1;
 			rotate |= 1; // rotation must be odd number
 		}
+
 		if (!info->get_building()->can_rotate()) {
 			rotate = 0;
 		}

--- a/gui/factory_edit.cc
+++ b/gui/factory_edit.cc
@@ -378,16 +378,17 @@ void factory_edit_frame_t::change_item_info(sint32 entry)
 			// reset combobox
 			cb_rotation.clear_elements();
 			cb_rotation.new_component<gui_rotation_item_t>(gui_rotation_item_t::random);
+			cb_rotation.new_component<gui_rotation_item_t>(gui_rotation_item_t::automatic);
 			for(uint8 i = 0; i<desc->get_all_layouts(); i++) {
 				cb_rotation.new_component<gui_rotation_item_t>(i);
 			}
 
 			// orientation (255=random)
 			if(desc->get_all_layouts()>1) {
-				cb_rotation.set_selection(0);
+				cb_rotation.set_selection(1);
 			}
 			else {
-				cb_rotation.set_selection(1);
+				cb_rotation.set_selection(2);
 			}
 
 			// now for the tool
@@ -396,12 +397,12 @@ void factory_edit_frame_t::change_item_info(sint32 entry)
 
 		const building_desc_t *desc = fac_desc->get_building();
 		uint8 rotation = get_rotation();
-		uint8 rot = (rotation==255) ? 0 : rotation;
+		uint8 rot = (rotation >= 254) ? 0 : rotation;
 		building_image.init(desc, rot);
 
 		// the tools will be always updated, even though the data up there might be still current
 		param_str.clear();
-		param_str.printf("%i%c%i,%s", bt_climates.pressed, rotation==255 ? '#' : '0'+rotation, production, fac_desc->get_name() );
+		param_str.printf("%i%c%i,%s", bt_climates.pressed, rotation>253 ? (rotation==254 ? 'A' : '#') : '0'+rotation, production, fac_desc->get_name() );
 		if(bt_land_chain.pressed) {
 			land_chain_tool.set_default_param(param_str);
 			welt->set_tool( &land_chain_tool, player );

--- a/simtool.cc
+++ b/simtool.cc
@@ -7126,12 +7126,23 @@ bool tool_build_land_chain_t::init( player_t * )
  * the parameter string is a follow:
  * 1#34,oelfeld
  * first letter: ignore climates
- * second letter: rotation (0,1,2,3,#=random)
+ * second letter: rotation (0,1,2,3,#=random,A=auto)
  * next number is production value
  * finally industry name
  */
+
+/* This is practically the same as tool_build_factory_t::work(...)
+ * other than this calling factory_builder_t::build_link() [which
+ * returns an integer count] and that calling
+ * factory_builder_t::build_factory() which returns a fabrik_t*.
+ * These two routines (methods) should probably be merged, although I
+ * am yet unsure how to combine the parts of the two classes
+ * together. — WL
+ */
 const char *tool_build_land_chain_t::work( player_t *player, koord3d pos )
 {
+	koord k(pos.get_2d());
+
 	const grund_t* gr = welt->lookup_kartenboden(pos.get_2d());
 	if(gr==NULL) {
 		return "";
@@ -7157,7 +7168,25 @@ const char *tool_build_land_chain_t::work( player_t *player, koord3d pos )
 	if(fab==NULL) {
 		return "";
 	}
-	int rotation = (default_param  &&  default_param[1]!='#') ? (default_param[1]-'0') % fab->get_building()->get_all_layouts() : simrand(fab->get_building()->get_all_layouts()-1, "const char *tool_build_land_chain_t::work");
+	int rotation;
+	if(  !default_param || default_param[1]=='#'  ) {
+		rotation = simrand(fab->get_building()->get_all_layouts(), "const char *tool_build_land_chain_t::work");
+	}
+	else if(  default_param[1]=='A'  ) {
+		int streetdir = 0;
+                // Convert 'neighbors' indices to SENW bits
+                static int const neighbours_to_senw[] = { 0x0c, 0x08, 0x09, 0x01, 0x03, 0x02, 0x06, 0x04 };
+		for(  int i = 1;  i < 8;  i+=2  ) {
+			grund_t *gr2 = welt->lookup_kartenboden(k + koord::neighbours[i]);
+			if(  gr2  &&  gr2->get_weg_hang() == gr2->get_grund_hang()  &&  gr2->get_weg(road_wt) != NULL  ) {
+				streetdir |= neighbours_to_senw[i];
+			}
+		}
+		rotation = building_layout[streetdir];
+        }
+	else {
+		rotation = (default_param[1]-'0') % fab->get_building()->get_all_layouts();
+	}
 	koord size = fab->get_building()->get_size(rotation);
 
 	// process ignore climates switch
@@ -7310,6 +7339,8 @@ bool tool_build_factory_t::init( player_t * )
 /* builds an industry next to the cursor (default_param see above) */
 const char *tool_build_factory_t::work( player_t *player, koord3d pos )
 {
+	koord k(pos.get_2d());
+
 	const grund_t* gr = welt->lookup_kartenboden(pos.get_2d());
 	if(gr==NULL) {
 		return "";
@@ -7329,7 +7360,34 @@ const char *tool_build_factory_t::work( player_t *player, koord3d pos )
 	if(fab==NULL) {
 		return "";
 	}
-	int rotation = (default_param  &&  default_param[1]!='#') ? (default_param[1]-'0') % fab->get_building()->get_all_layouts() : simrand(fab->get_building()->get_all_layouts(), "const char *tool_build_factory_t::work");
+	int rotation;
+	if(  !default_param || default_param[1]=='#'  ) {
+		rotation = simrand(fab->get_building()->get_all_layouts(), "const char *tool_build_factory_t::work");
+	}
+	else if(  default_param[1]=='A'  ) {
+		int streetdir = 0;
+                // Convert 'neighbors' indices to SENW bits
+		static int const neighbours_to_senw[] = { 0x0c, 0x08, 0x09, 0x01, 0x03, 0x02, 0x06, 0x04 };
+		for(  int i = 1;  i < 8;  i+=2  ) {
+			grund_t *gr2 = welt->lookup_kartenboden(k + koord::neighbours[i]);
+			if(  gr2  &&  gr2->get_weg_hang() == gr2->get_grund_hang()  &&  gr2->get_weg(road_wt) != NULL  ) {
+				streetdir |= neighbours_to_senw[i];
+			}
+		}
+                if (streetdir == 0) { // No adjacent streets; check diagonally
+                  for(  int i = 0;  i < 8;  i+=2  ) {
+                    grund_t *gr2 = welt->lookup_kartenboden(k + koord::neighbours[i]);
+                    if(  gr2  &&  gr2->get_weg_hang() == gr2->get_grund_hang()  &&  gr2->get_weg(road_wt) != NULL  ) {
+                      streetdir |= neighbours_to_senw[i];
+                    }
+                  }
+                }
+		rotation = building_layout[streetdir];
+        }
+	else {
+		rotation = (default_param[1]-'0') % fab->get_building()->get_all_layouts();
+	}
+
 	koord size = fab->get_building()->get_size(rotation);
 
 	// process ignore climates switch


### PR DESCRIPTION
Add Auto rotation in factory creation dialog, and always auto-rotate factories created during world creation. Results in much-nicer looking cities.