### PR TITLE
Simuconf display setting refinements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,7 @@ add_executable(simutrans-extended
 	gui/overtaking_mode.cc
 	gui/pakselector.cc
 	gui/password_frame.cc
+	gui/pedestrian_info.cc
 	gui/player_frame_t.cc
 	gui/privatesign_info.cc
 	gui/replace_frame.cc

--- a/Makefile
+++ b/Makefile
@@ -483,6 +483,7 @@ SOURCES += gui/tool_selector
 SOURCES += gui/trafficlight_info.cc
 SOURCES += gui/vehiclelist_frame.cc
 SOURCES += gui/obj_info.cc
+SOURCES += gui/pedestrian_info.cc
 SOURCES += gui/vehicle_class_manager.cc
 SOURCES += gui/way_info.cc
 SOURCES += gui/welt.cc

--- a/Simutrans-Extended.vcxproj
+++ b/Simutrans-Extended.vcxproj
@@ -2005,6 +2005,7 @@
     <ClCompile Include="gui\onewaysign_info.cc" />
     <ClCompile Include="gui\overtaking_mode.cc" />
     <ClCompile Include="gui\obj_info.cc" />
+    <ClCompile Include="gui\pedestrian_info.cc" />
     <ClCompile Include="gui\privatesign_info.cc" />
     <ClCompile Include="gui\scenario_info.cc" />
     <ClCompile Include="gui\server_frame.cc" />
@@ -2576,6 +2577,7 @@
     <ClInclude Include="gui\onewaysign_info.h" />
     <ClInclude Include="gui\overtaking_mode.h" />
     <ClInclude Include="gui\obj_info.h" />
+    <ClInclude Include="gui\pedestrian_info.h" />
     <ClInclude Include="gui\privatesign_info.h" />
     <ClInclude Include="gui\scenario_info.h" />
     <ClInclude Include="gui\server_frame.h" />

--- a/dataobj/environment.cc
+++ b/dataobj/environment.cc
@@ -120,7 +120,7 @@ sint32 env_t::message_flags[4];
 uint32 env_t::water_animation;
 uint32 env_t::ground_object_probability;
 uint32 env_t::moving_object_probability;
-bool env_t::road_user_info;
+uint8 env_t::road_user_info;
 bool env_t::tree_info;
 bool env_t::ground_info;
 bool env_t::townhall_info;
@@ -240,7 +240,7 @@ void env_t::init()
 
 	follow_convoi_underground = 2;  // slice through map
 
-	road_user_info = false;
+	road_user_info = 0;
 	tree_info = true;
 	ground_info = false;
 	townhall_info = false;
@@ -409,7 +409,14 @@ void env_t::rdwr(loadsave_t *file)
 	}
 	file->rdwr_short( max_acceleration );
 
-	file->rdwr_bool( road_user_info );
+	if ( file->is_loading() && file->is_version_ex_less(14,45) ) {
+		bool temp_show_road_user_info;
+		file->rdwr_bool( temp_show_road_user_info );
+		road_user_info = temp_show_road_user_info ? 1 : 0;
+	}
+	else {
+		file->rdwr_byte( road_user_info );
+	}
 	file->rdwr_bool( tree_info );
 	file->rdwr_bool( ground_info );
 	file->rdwr_bool( townhall_info );

--- a/dataobj/environment.cc
+++ b/dataobj/environment.cc
@@ -240,7 +240,7 @@ void env_t::init()
 
 	follow_convoi_underground = 2;  // slice through map
 
-	road_user_info = 0;
+	road_user_info = 1;
 	tree_info = true;
 	ground_info = false;
 	townhall_info = false;
@@ -261,7 +261,7 @@ void env_t::init()
 	savegame_ex_version_str = EXTENDED_VER_NR;
 	savegame_ex_revision_str = EXTENDED_REVISION_NR;
 
-	show_month = DATE_FMT_US;
+	show_month = DATE_FMT_INTERNAL_MINUTE;
 
 	intercity_road_length = 512;
 

--- a/dataobj/environment.h
+++ b/dataobj/environment.h
@@ -166,7 +166,7 @@ public:
 	static bool numpad_always_moves_map;
 
 	/// open info windows for pedestrian and private cars
-	static bool road_user_info;
+	static uint8 road_user_info;
 
 	/// open info windows for trees
 	static bool tree_info;

--- a/dataobj/settings.cc
+++ b/dataobj/settings.cc
@@ -1997,7 +1997,7 @@ void settings_t::parse_simuconf( tabfile_t& simuconf, sint16& disp_width, sint16
 
 	env_t::straight_way_without_control = contents.get_int( "straight_way_without_control", env_t::straight_way_without_control ) != 0;
 
-	env_t::road_user_info = contents.get_int( "pedes_and_car_info", env_t::road_user_info ) != 0;
+	env_t::road_user_info = contents.get_int( "pedes_and_car_info", env_t::road_user_info );
 	env_t::tree_info      = contents.get_int( "tree_info",          env_t::tree_info      ) != 0;
 	env_t::ground_info    = contents.get_int( "ground_info",        env_t::ground_info    ) != 0;
 	env_t::townhall_info  = contents.get_int( "townhall_info",      env_t::townhall_info  ) != 0;

--- a/dataobj/settings.cc
+++ b/dataobj/settings.cc
@@ -1997,15 +1997,15 @@ void settings_t::parse_simuconf( tabfile_t& simuconf, sint16& disp_width, sint16
 
 	env_t::straight_way_without_control = contents.get_int( "straight_way_without_control", env_t::straight_way_without_control ) != 0;
 
-	// try to read pedes_info and car_info. If neither is found, try to fallback to pedes_and_car_info. If not found, do not override the existing value.
-	int car_info = contents.get_int("car_info", -1);
-	int pedes_info = contents.get_int("pedes_info", -1);
-	if(car_info != -1 || pedes_info != -1){
-		if(car_info != -1) set_bits_to<uint8>(env_t::road_user_info, 0b1, car_info!=0);
-		if(pedes_info != -1) set_bits_to<uint8>(env_t::road_user_info, 0b10, (pedes_info!=0) << 1);
+	// try to read pedestrian_info and privatecar_info. If neither is found, try to fallback to pedes_and_car_info. If not found, do not override the existing value.
+	int privatecar_info = contents.get_int("privatecar_info", -1);
+	int pedestrian_info = contents.get_int("pedestrian_info", -1);
+	if(privatecar_info != -1 || pedestrian_info != -1){
+		if(privatecar_info != -1) set_bits_to<uint8>(env_t::road_user_info, 0b1, privatecar_info!=0);
+		if(pedestrian_info != -1) set_bits_to<uint8>(env_t::road_user_info, 0b10, (pedestrian_info!=0) << 1);
 	}
 	else {
-		//re-defines semantics of pedes_and_car_info=1 to car_info=1, pedes_info=0, previously was car_info=1, pedes_info=1
+		//re-defines semantics of pedes_and_car_info=1 to privatecar_info=1, pedestrian_info=0, previously was privatecar_info=1, pedestrian_info=1
 		env_t::road_user_info = (contents.get_int( "pedes_and_car_info", env_t::road_user_info )!=0);
 	}
 	env_t::tree_info      = contents.get_int( "tree_info",          env_t::tree_info      ) != 0;

--- a/dataobj/settings.cc
+++ b/dataobj/settings.cc
@@ -1997,7 +1997,17 @@ void settings_t::parse_simuconf( tabfile_t& simuconf, sint16& disp_width, sint16
 
 	env_t::straight_way_without_control = contents.get_int( "straight_way_without_control", env_t::straight_way_without_control ) != 0;
 
-	env_t::road_user_info = contents.get_int( "pedes_and_car_info", env_t::road_user_info );
+	// try to read pedes_info and car_info. If neither is found, try to fallback to pedes_and_car_info. If not found, do not override the existing value.
+	int car_info = contents.get_int("car_info", -1);
+	int pedes_info = contents.get_int("pedes_info", -1);
+	if(car_info != -1 || pedes_info != -1){
+		if(car_info != -1) env_t::road_user_info = (env_t::road_user_info & ~1) | (car_info!=0);
+		if(pedes_info != -1) env_t::road_user_info = (env_t::road_user_info & ~2) | ((pedes_info!=0) << 1);
+	}
+	else {
+		//re-defines semantics of pedes_and_car_info=1 to car_info=1, pedes_info=0, previously was car_info=1, pedes_info=1
+		env_t::road_user_info = (contents.get_int( "pedes_and_car_info", env_t::road_user_info )!=0);
+	}
 	env_t::tree_info      = contents.get_int( "tree_info",          env_t::tree_info      ) != 0;
 	env_t::ground_info    = contents.get_int( "ground_info",        env_t::ground_info    ) != 0;
 	env_t::townhall_info  = contents.get_int( "townhall_info",      env_t::townhall_info  ) != 0;

--- a/dataobj/settings.cc
+++ b/dataobj/settings.cc
@@ -2001,8 +2001,8 @@ void settings_t::parse_simuconf( tabfile_t& simuconf, sint16& disp_width, sint16
 	int car_info = contents.get_int("car_info", -1);
 	int pedes_info = contents.get_int("pedes_info", -1);
 	if(car_info != -1 || pedes_info != -1){
-		if(car_info != -1) env_t::road_user_info = (env_t::road_user_info & ~1) | (car_info!=0);
-		if(pedes_info != -1) env_t::road_user_info = (env_t::road_user_info & ~2) | ((pedes_info!=0) << 1);
+		if(car_info != -1) set_bits_to<uint8>(env_t::road_user_info, 0b1, car_info!=0);
+		if(pedes_info != -1) set_bits_to<uint8>(env_t::road_user_info, 0b10, (pedes_info!=0) << 1);
 	}
 	else {
 		//re-defines semantics of pedes_and_car_info=1 to car_info=1, pedes_info=0, previously was car_info=1, pedes_info=1
@@ -2036,7 +2036,21 @@ void settings_t::parse_simuconf( tabfile_t& simuconf, sint16& disp_width, sint16
 	env_t::draw_outside_tile = contents.get_int( "draw_outside_tile", env_t::draw_outside_tile ) != 0;
 
 	// display stuff
-	env_t::show_names = contents.get_int( "show_names", env_t::show_names );
+	int show_station_names = contents.get_int( "show_station_names", -1);
+	int show_station_statistics = contents.get_int( "show_station_statistics", -1 );
+	int station_label_style = contents.get_int( "station_label_style", -1 );
+	if(show_station_names != -1 || show_station_statistics != -1 || station_label_style != -1){
+		if(show_station_names != -1) set_bits_to<int>(env_t::show_names,0b1, show_station_names!=0);
+		if(show_station_statistics != -1) set_bits_to(env_t::show_names,0b10, (show_station_statistics !=0) << 1);
+		if(station_label_style) set_bits_to(env_t::show_names,0b1100, station_label_style << 2);
+	}
+	else{
+		env_t::show_names = contents.get_int( "show_names", env_t::show_names );
+	}
+
+
+
+
 	env_t::show_depot_names = contents.get_int( "show_depot_names", env_t::show_depot_names );
 	env_t::show_month = contents.get_int( "show_month", env_t::show_month );
 	env_t::max_acceleration = contents.get_int( "fast_forward", env_t::max_acceleration );

--- a/dataobj/settings.cc
+++ b/dataobj/settings.cc
@@ -1983,11 +1983,12 @@ void settings_t::parse_simuconf( tabfile_t& simuconf, sint16& disp_width, sint16
 #endif
 
 	//check for fontname, must be a valid name!
-	const char *fname = contents.get_string( "fontname", env_t::fontname.c_str() );
-	if( FILE *f = fopen( fname, "r" ) ) {
+	std::string fname = trim( contents.get_string( "fontname", env_t::fontname.c_str() ) );
+	if( FILE* f = fopen( fname.c_str(), "r" ) ) {
 		fclose( f );
 		env_t::fontname = fname;
 	}
+	env_t::fontsize  = contents.get_int( "fontsize", env_t::fontsize );
 
 
 	env_t::water_animation = contents.get_int( "water_animation_ms", env_t::water_animation );

--- a/gui/display_settings.cc
+++ b/gui/display_settings.cc
@@ -323,8 +323,8 @@ map_settings_t::map_settings_t()
 		inp_underground_level.add_listener(this);
 		add_component(&inp_underground_level);
 
-		// Toggle simple drawing for debugging
 #ifdef DEBUG
+		// Toggle simple drawing for debugging
 		new_component<gui_margin_t>(LINESPACE/2);
 		buttons[IDBTN_SIMPLE_DRAWING].init(button_t::square_state, "Simple drawing");
 		add_component(buttons + IDBTN_SIMPLE_DRAWING, 2);
@@ -414,6 +414,21 @@ map_settings_t::map_settings_t()
 		cursor_hide_range.add_listener(this);
 		add_component(&cursor_hide_range);
 	}
+
+	// Set date format
+	new_component<gui_label_t>( "Date format" );
+	time_setting.set_focusable( false );
+	uint8 old_show_month = env_t::show_month;
+	sint32 current_tick = world()->get_ticks();
+	for( env_t::show_month = 0; env_t::show_month<10; env_t::show_month++ ) {
+		tstrncpy( time_str[env_t::show_month], tick_to_string( current_tick ), 64 );
+		time_setting.new_component<gui_scrolled_list_t::const_text_scrollitem_t>( time_str[env_t::show_month], SYSCOL_TEXT );
+	}
+	env_t::show_month = old_show_month;
+	time_setting.set_selection( old_show_month );
+	add_component( &time_setting );
+	time_setting.add_listener( this );
+
 	end_table();
 }
 
@@ -424,11 +439,11 @@ bool map_settings_t::action_triggered( gui_action_creator_t *comp, value_t v )
 		env_t::daynight_level = (sint8)v.i;
 	}
 	// Scroll speed edit
-	if( &scrollspeed == comp ) {
+	else if( &scrollspeed == comp ) {
 		env_t::scroll_multi = (sint16)(buttons[ IDBTN_SCROLL_INVERSE ].pressed ? -v.i : v.i);
 	}
 	// underground slice edit
-	if( comp == &inp_underground_level ) {
+	else if( comp == &inp_underground_level ) {
 		if( grund_t::underground_mode == grund_t::ugm_level ) {
 			grund_t::underground_level = inp_underground_level.get_value();
 
@@ -436,6 +451,11 @@ bool map_settings_t::action_triggered( gui_action_creator_t *comp, value_t v )
 			world()->update_underground();
 		}
 	}
+	else if( comp == &time_setting ) {
+		env_t::show_month = v.i;
+		return true;
+	}
+
 	// Smart hide objects edit
 	if( &cursor_hide_range == comp ) {
 		env_t::cursor_hide_range = cursor_hide_range.get_value();

--- a/gui/display_settings.cc
+++ b/gui/display_settings.cc
@@ -55,6 +55,8 @@ enum {
 	IDBTN_CLASSES_WAITING_BAR,
 	IDBTN_SHOW_DEPOT_NAME,
 	IDBTN_SHOW_FACTORY_STORAGE,
+	IDBTN_SHOW_PRIVATECAR_INFO,
+	IDBTN_SHOW_PEDESTRIAN_INFO,
 	COLORS_MAX_BUTTONS,
 };
 
@@ -729,6 +731,18 @@ traffic_settings_t::traffic_settings_t()
 	traffic_density.add_listener(this);
 	add_component(&traffic_density);
 
+	// Show private car info
+	buttons[IDBTN_SHOW_PRIVATECAR_INFO].init(button_t::square_state, "Show the private car information window");
+	buttons[IDBTN_SHOW_PRIVATECAR_INFO].set_tooltip("can open a dedicated window by clicking on a private car.");
+	buttons[IDBTN_SHOW_PRIVATECAR_INFO].pressed = env_t::road_user_info & 1;
+	add_component(buttons + IDBTN_SHOW_PRIVATECAR_INFO, 2);
+
+	// Show pedestrian info
+	buttons[IDBTN_SHOW_PEDESTRIAN_INFO].init(button_t::square_state, "Show the pedestrian information window");
+	buttons[IDBTN_SHOW_PEDESTRIAN_INFO].set_tooltip("can open a dedicated window by clicking on a pedestrian.");
+	buttons[IDBTN_SHOW_PEDESTRIAN_INFO].pressed = env_t::road_user_info & 2;
+	add_component(buttons + IDBTN_SHOW_PEDESTRIAN_INFO, 2);
+
 	// Convoy follow mode
 	new_component<gui_label_t>("Convoi following mode")->set_tooltip(translator::translate("Select the behavior of the camera when the following convoy enters the tunnel."));
 
@@ -857,6 +871,14 @@ bool color_gui_t::action_triggered( gui_action_creator_t *comp, value_t )
 		if( !env_t::networkmode || welt->get_active_player_nr() == 1 ) {
 			welt->set_tool( tool_t::simple_tool[ TOOL_TOOGLE_PEDESTRIANS & 0xFFF ], welt->get_active_player() );
 		}
+		break;
+	case IDBTN_SHOW_PRIVATECAR_INFO:
+		env_t::road_user_info = env_t::road_user_info ^ 1;
+		buttons[IDBTN_SHOW_PRIVATECAR_INFO].pressed = env_t::road_user_info&1;
+		break;
+	case IDBTN_SHOW_PEDESTRIAN_INFO:
+		env_t::road_user_info = env_t::road_user_info ^ 2;
+		buttons[IDBTN_SHOW_PEDESTRIAN_INFO].pressed = env_t::road_user_info&2;
 		break;
 	case IDBTN_HIDE_TREES:
 		env_t::hide_trees = !env_t::hide_trees;

--- a/gui/display_settings.cc
+++ b/gui/display_settings.cc
@@ -377,6 +377,25 @@ map_settings_t::map_settings_t()
 		add_component(&scrollspeed);
 	}
 	end_table();
+
+	// Set date format
+	new_component<gui_label_t>("Date format");
+	add_table(2,0);
+	{
+		new_component<gui_margin_t>(LINESPACE/2);
+		time_setting.set_focusable( false );
+		uint8 old_show_month = env_t::show_month;
+		sint32 current_tick = world()->get_ticks();
+		for( env_t::show_month = 0; env_t::show_month<10; env_t::show_month++ ) {
+			tstrncpy( time_str[env_t::show_month], tick_to_string( current_tick, true ), 64 );
+			time_setting.new_component<gui_scrolled_list_t::const_text_scrollitem_t>( time_str[env_t::show_month], SYSCOL_TEXT );
+		}
+		env_t::show_month = old_show_month;
+		time_setting.set_selection( old_show_month );
+		add_component( &time_setting );
+		time_setting.add_listener( this );
+	}
+	end_table();
 	new_component<gui_divider_t>();
 
 	new_component<gui_label_t>("transparencies");
@@ -414,21 +433,6 @@ map_settings_t::map_settings_t()
 		cursor_hide_range.add_listener(this);
 		add_component(&cursor_hide_range);
 	}
-
-	// Set date format
-	new_component<gui_label_t>( "Date format" );
-	time_setting.set_focusable( false );
-	uint8 old_show_month = env_t::show_month;
-	sint32 current_tick = world()->get_ticks();
-	for( env_t::show_month = 0; env_t::show_month<10; env_t::show_month++ ) {
-		tstrncpy( time_str[env_t::show_month], tick_to_string( current_tick ), 64 );
-		time_setting.new_component<gui_scrolled_list_t::const_text_scrollitem_t>( time_str[env_t::show_month], SYSCOL_TEXT );
-	}
-	env_t::show_month = old_show_month;
-	time_setting.set_selection( old_show_month );
-	add_component( &time_setting );
-	time_setting.add_listener( this );
-
 	end_table();
 }
 

--- a/gui/display_settings.h
+++ b/gui/display_settings.h
@@ -44,21 +44,22 @@ public:
 	button_t reselect_closes_tool;
 
 	gui_settings_t();
-	virtual void draw( scr_coord offset ) OVERRIDE;
+	void draw( scr_coord offset ) OVERRIDE;
 };
 
 class map_settings_t : public gui_aligned_container_t, public action_listener_t
 {
 private:
+	char time_str[8][64];
 	gui_numberinput_t cursor_hide_range;
-	gui_combobox_t hide_buildings;
+	gui_combobox_t time_setting, hide_buildings;
 public:
 	gui_numberinput_t
 		inp_underground_level,
 		brightness,
 		scrollspeed;
 	map_settings_t();
-	virtual bool action_triggered( gui_action_creator_t *comp, value_t v ) OVERRIDE;
+	bool action_triggered( gui_action_creator_t *comp, value_t v ) OVERRIDE;
 	void draw(scr_coord offset) OVERRIDE;
 };
 
@@ -69,7 +70,7 @@ private:
 	button_t bt_convoy_id_plate[2];
 public:
 	label_settings_t();
-	virtual bool action_triggered(gui_action_creator_t *comp, value_t v);
+	bool action_triggered(gui_action_creator_t *comp, value_t v) OVERRIDE;
 	void draw(scr_coord offset) OVERRIDE;
 };
 

--- a/gui/display_settings.h
+++ b/gui/display_settings.h
@@ -50,7 +50,7 @@ public:
 class map_settings_t : public gui_aligned_container_t, public action_listener_t
 {
 private:
-	char time_str[8][64];
+	char time_str[10][64];
 	gui_numberinput_t cursor_hide_range;
 	gui_combobox_t time_setting, hide_buildings;
 public:

--- a/gui/pedestrian_info.cc
+++ b/gui/pedestrian_info.cc
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the Simutrans-Extended project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#include "pedestrian_info.h"
+#include "components/gui_label.h"
+
+#include "../simworld.h"
+#include "../display/simgraph.h"
+#include "../display/viewport.h"
+#include "../descriptor/pedestrian_desc.h"
+
+
+pedestrian_info_t::pedestrian_info_t(const pedestrian_t* obj) :
+	base_infowin_t(translator::translate(obj->get_name()), NULL),
+	view(obj, scr_size(max(64, get_base_tile_raster_width()), max(56, (get_base_tile_raster_width() * 7) / 8)))
+{
+	remove_all();
+	add_component(&view);
+	if (char const* const maker = obj->get_desc()->get_copyright()) {
+		add_table(2, 2)->set_spacing(scr_size(0, 0)); {
+			new_component_span<gui_label_t>("Constructed by", 2);
+			new_component<gui_margin_t>(LINESPACE);
+			new_component<gui_label_t>(maker);
+		} end_table();
+	}
+	reset_min_windowsize();
+	set_windowsize(get_min_windowsize());
+}
+
+void pedestrian_info_t::draw(scr_coord pos, scr_size size)
+{
+	base_infowin_t::draw(pos, size);
+	pos += scr_size(D_V_SPACE + D_MARGIN_LEFT + 2, D_TITLEBAR_HEIGHT + D_MARGIN_TOP + 2);
+	display_proportional_clip_rgb(pos.x, pos.y, view.get_obj()->get_pos().get_2d().get_fullstr(), ALIGN_LEFT, color_idx_to_rgb(COL_WHITE), true);
+}
+
+

--- a/gui/pedestrian_info.h
+++ b/gui/pedestrian_info.h
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the Simutrans-Extended project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#ifndef GUI_PEDESTRIAN_INFO_H
+#define GUI_PEDESTRIAN_INFO_H
+
+
+//#include "../obj/simobj.h"
+#include "base_info.h"
+#include "components/gui_obj_view_t.h"
+#include "../vehicle/pedestrian.h"
+
+/**
+ * An adapter class to display info windows for things (objects)
+ */
+class pedestrian_info_t : public base_infowin_t
+{
+	obj_view_t view;
+public:
+	pedestrian_info_t(const pedestrian_t* obj);
+
+	bool has_sticky() const OVERRIDE { return false; }
+
+	void draw(scr_coord pos, scr_size size) OVERRIDE;
+};
+
+
+#endif

--- a/gui/settings_stats.cc
+++ b/gui/settings_stats.cc
@@ -570,18 +570,15 @@ void settings_general_stats_t::init(settings_t const* const sets)
 	INIT_NUM( "fast_forward", env_t::max_acceleration, 1, 1000, gui_numberinput_t::AUTOLINEAR, false );
 	SEPERATOR
 	INIT_BOOL( "numbered_stations", sets->get_numbered_stations() );
-	INIT_NUM( "show_names", env_t::show_names, 0, 7, gui_numberinput_t::AUTOLINEAR, true );
 	SEPERATOR
 	INIT_NUM( "bits_per_month", sets->get_bits_per_month(), 16, 48, gui_numberinput_t::AUTOLINEAR, false );
 	INIT_NUM( "use_timeline", sets->get_use_timeline(), 0, 3, gui_numberinput_t::AUTOLINEAR, false );
 	INIT_NUM_NEW( "starting_year", sets->get_starting_year(), 0, 2999, gui_numberinput_t::AUTOLINEAR, false );
 	INIT_NUM_NEW( "starting_month", sets->get_starting_month(), 0, 11, gui_numberinput_t::AUTOLINEAR, false );
-	INIT_NUM( "show_month", env_t::show_month, 0, 9, gui_numberinput_t::AUTOLINEAR, true );
 	SEPERATOR
 	INIT_NUM( "random_grounds_probability", env_t::ground_object_probability, 0, 0x7FFFFFFFul, gui_numberinput_t::POWER2, false );
 	INIT_NUM( "random_wildlife_probability", env_t::moving_object_probability, 0, 0x7FFFFFFFul, gui_numberinput_t::POWER2, false );
 	SEPERATOR
-	INIT_NUM(  "pedes_and_car_info", env_t::road_user_info, 0, 3, gui_numberinput_t::AUTOLINEAR, false);
 	INIT_BOOL( "tree_info", env_t::tree_info );
 	INIT_BOOL( "ground_info", env_t::ground_info );
 	INIT_BOOL( "townhall_info", env_t::townhall_info );
@@ -663,18 +660,15 @@ void settings_general_stats_t::read(settings_t* const sets)
 	READ_NUM_VALUE( env_t::max_acceleration );
 
 	READ_BOOL_VALUE( sets->numbered_stations );
-	READ_NUM_VALUE( env_t::show_names );
 
 	READ_NUM_VALUE( sets->bits_per_month );
 	READ_NUM_VALUE( sets->use_timeline );
 	READ_NUM_VALUE_NEW( sets->starting_year );
 	READ_NUM_VALUE_NEW( sets->starting_month );
-	READ_NUM_VALUE( env_t::show_month );
 
 	READ_NUM_VALUE( env_t::ground_object_probability );
 	READ_NUM_VALUE( env_t::moving_object_probability );
 
-	READ_NUM_VALUE( env_t::road_user_info );
 	READ_BOOL_VALUE( env_t::tree_info );
 	READ_BOOL_VALUE( env_t::ground_info );
 	READ_BOOL_VALUE( env_t::townhall_info );
@@ -707,7 +701,6 @@ void settings_display_stats_t::init(settings_t const* const)
 	INIT_NUM( "simple_drawing_tile_size",env_t::simple_drawing_default, 2, 256, gui_numberinput_t::POWER2, false );
 	INIT_BOOL( "simple_drawing_fast_forward",env_t::simple_drawing_fast_forward );
 	INIT_NUM( "water_animation_ms", env_t::water_animation, 0, 1000, 25, false );
-	INIT_NUM( "follow_convoi_underground", env_t::follow_convoi_underground, 0, 2, 1, true );
 	SEPERATOR
 	INIT_BOOL( "window_buttons_right", env_t::window_buttons_right );
 	INIT_BOOL( "window_frame_active", env_t::window_frame_active );
@@ -723,7 +716,6 @@ void settings_display_stats_t::init(settings_t const* const)
 	INIT_NUM( "tooltip_duration", env_t::tooltip_duration, 0, 30000, gui_numberinput_t::AUTOLINEAR, 0 );
 	SEPERATOR
 	INIT_NUM( "cursor_overlay_color", env_t::cursor_overlay_color_rgb, 0, 16777215, gui_numberinput_t::AUTOLINEAR, 0 );
-	INIT_BOOL( "left_to_right_graphs", env_t::left_to_right_graphs );
 	SEPERATOR
 	INIT_BOOL( "player_finance_display_account", env_t::player_finance_display_account );
 
@@ -739,7 +731,6 @@ void settings_display_stats_t::read(settings_t* const)
 	READ_NUM_VALUE( env_t::simple_drawing_default );
 	READ_BOOL_VALUE( env_t::simple_drawing_fast_forward );
 	READ_NUM_VALUE( env_t::water_animation );
-	READ_NUM_VALUE( env_t::follow_convoi_underground );
 
 	READ_BOOL_VALUE( env_t::window_buttons_right );
 	READ_BOOL_VALUE( env_t::window_frame_active );
@@ -755,7 +746,6 @@ void settings_display_stats_t::read(settings_t* const)
 	READ_NUM_VALUE( env_t::tooltip_duration );
 
 	READ_NUM_VALUE( env_t::cursor_overlay_color_rgb );
-	READ_BOOL_VALUE( env_t::left_to_right_graphs );
 
 	READ_BOOL_VALUE( env_t::player_finance_display_account );
 }

--- a/gui/settings_stats.cc
+++ b/gui/settings_stats.cc
@@ -125,7 +125,9 @@ static const char *revision_ex[] =
 	"40",
 	"41",
 	"42",
-	"43"
+	"43",
+	"44",
+	"45"
 };
 
 
@@ -579,7 +581,7 @@ void settings_general_stats_t::init(settings_t const* const sets)
 	INIT_NUM( "random_grounds_probability", env_t::ground_object_probability, 0, 0x7FFFFFFFul, gui_numberinput_t::POWER2, false );
 	INIT_NUM( "random_wildlife_probability", env_t::moving_object_probability, 0, 0x7FFFFFFFul, gui_numberinput_t::POWER2, false );
 	SEPERATOR
-	INIT_BOOL( "pedes_and_car_info", env_t::road_user_info );
+	INIT_NUM(  "pedes_and_car_info", env_t::road_user_info, 0, 3, gui_numberinput_t::AUTOLINEAR, false);
 	INIT_BOOL( "tree_info", env_t::tree_info );
 	INIT_BOOL( "ground_info", env_t::ground_info );
 	INIT_BOOL( "townhall_info", env_t::townhall_info );
@@ -672,7 +674,7 @@ void settings_general_stats_t::read(settings_t* const sets)
 	READ_NUM_VALUE( env_t::ground_object_probability );
 	READ_NUM_VALUE( env_t::moving_object_probability );
 
-	READ_BOOL_VALUE( env_t::road_user_info );
+	READ_NUM_VALUE( env_t::road_user_info );
 	READ_BOOL_VALUE( env_t::tree_info );
 	READ_BOOL_VALUE( env_t::ground_info );
 	READ_BOOL_VALUE( env_t::townhall_info );

--- a/gui/way_info.h
+++ b/gui/way_info.h
@@ -7,7 +7,7 @@
 #define GUI_WAY_INFO_H
 
 
-#include "base_info.h"
+#include "gui_frame.h"
 #include "../boden/grund.h"
 #include "components/gui_image.h"
 #include "components/gui_label.h"

--- a/simintr.cc
+++ b/simintr.cc
@@ -20,7 +20,6 @@
 
 #include "boden/wasser.h"
 
-static karte_t *welt_modell = NULL;
 static main_view_t *welt_ansicht = NULL;
 
 
@@ -78,10 +77,10 @@ void intr_refresh_display(bool dirty)
 	dr_prepare_flush();
 	welt_ansicht->display( dirty );
 	if(  env_t::player_finance_display_account  ) {
-		win_display_flush( (double)welt_modell->get_active_player()->get_finance()->get_account_balance()/100.0 );
+		win_display_flush( (double)world()->get_active_player()->get_finance()->get_account_balance()/100.0 );
 	}
 	else {
-		win_display_flush( (double)welt_modell->get_active_player()->get_finance()->get_netwealth()/100.0 );
+		win_display_flush( (double)world()->get_active_player()->get_finance()->get_netwealth()/100.0 );
 	}
 	// with a switch statement more types could be supported ...
 	dr_flush();
@@ -99,27 +98,26 @@ void interrupt_check(const char* caller_info)
 	}
 
 	static uint32 last_ms = 0;
-	if(  !welt_modell->is_fast_forward()  ||  welt_modell->get_ticks() != last_ms  ) {
+	if(  !world()->is_fast_forward()  ||  world()->get_ticks() != last_ms  ) {
 		const uint32 now = dr_time();
 		if((now-last_time)*FRAME_TIME_MULTI < frame_time) {
 			return;
 		}
 
-		const sint32 diff = (( (sint32)now - (sint32)last_time)*welt_modell->get_time_multiplier())/16;
+		const sint32 diff = (( (sint32)now - (sint32)last_time)*world()->get_time_multiplier())/16;
 		if(  diff>0  ) {
 			enabled = false;
 			last_time = now;
-			welt_modell->sync_step( diff, !welt_modell->is_fast_forward(), true );
+			world()->sync_step( diff, !world()->is_fast_forward(), true );
 			enabled = true;
 		}
 	}
-	last_ms = welt_modell->get_ticks();
+	last_ms = world()->get_ticks();
 }
 
 
 void intr_set(karte_t *welt, main_view_t *view)
 {
-	welt_modell = welt;
 	welt_ansicht = view;
 	last_time = dr_time();
 	enabled = true;
@@ -149,17 +147,16 @@ char const *tick_to_string( sint64 ticks, bool show_full )
 
 	time[0] = 0;
 
-	// World model might not be initalized if this is called while reading saved windows.
-	if (welt_modell == NULL) {
+	if (world()== NULL) {
 		return time;
 	}
 
-	sint32 month = welt_modell->get_last_month();
-	sint32 year = welt_modell->get_last_year();
+	sint32 month = world()->get_last_month();
+	sint32 year = world()->get_last_year();
 
 	// calculate right month first
-	const uint32 ticks_this_month = ticks % welt_modell->ticks_per_world_month;
-	month += ticks_this_month / welt_modell->ticks_per_world_month;
+	const uint32 ticks_this_month = ticks % world()->ticks_per_world_month;
+	month += ticks_this_month / world()->ticks_per_world_month;
 	while(  month>11  ) {
 		month -= 12;
 		year ++;
@@ -172,8 +169,8 @@ char const *tick_to_string( sint64 ticks, bool show_full )
 	uint32 tage, hours, minuten;
 	char ticks_as_clock[32], month_as_clock[32];
 	if (env_t::show_month > env_t::DATE_FMT_MONTH && env_t::show_month < env_t::DATE_FMT_INTERNAL_MINUTE) {
-		tage = (((sint64)ticks_this_month*tage_per_month[month]) >> welt_modell->ticks_per_world_month_shift) + 1;
-		hours = (((sint64)ticks_this_month*tage_per_month[month]) >> (welt_modell->ticks_per_world_month_shift-16));
+		tage = (((sint64)ticks_this_month*tage_per_month[month]) >> world()->ticks_per_world_month_shift) + 1;
+		hours = (((sint64)ticks_this_month*tage_per_month[month]) >> (world()->ticks_per_world_month_shift-16));
 		minuten = (((hours*3) % 8192)*60)/8192;
 		hours = ((hours*3) / 8192)%24;
 	}
@@ -184,15 +181,15 @@ char const *tick_to_string( sint64 ticks, bool show_full )
 	}
 	else {
 		tage = 0;
-		hours = (ticks_this_month * 24) >> welt_modell->ticks_per_world_month_shift;
-		minuten = ((ticks_this_month * 24 * 60) >> welt_modell->ticks_per_world_month_shift)%60;
+		hours = (ticks_this_month * 24) >> world()->ticks_per_world_month_shift;
+		minuten = ((ticks_this_month * 24 * 60) >> world()->ticks_per_world_month_shift)%60;
 	}
 
 	if(  show_full  ||  env_t::show_month == env_t::DATE_FMT_SEASON  ) {
 
 		//DBG_MESSAGE("env_t::show_month","%d",env_t::show_month);
 		// since seasons 0 is always summer for backward compatibility
-		char const* const date = translator::get_date(year, month, tage, translator::translate(seasons[welt_modell->get_season()]));
+		char const* const date = translator::get_date(year, month, tage, translator::translate(seasons[world()->get_season()]));
 		switch(env_t::show_month) {
 			case env_t::DATE_FMT_US:
 			case env_t::DATE_FMT_US_NO_SEASON: {
@@ -223,8 +220,8 @@ char const *tick_to_string( sint64 ticks, bool show_full )
 		}
 
 		// suppress as much as possible, assuming this is an relative offset to the current month
-		sint32 num_days = ( ticks * (env_t::show_month==env_t::DATE_FMT_MONTH? 3 : tage_per_month[month]) ) >> welt_modell->ticks_per_world_month_shift;
-		num_days -= ( (welt_modell->get_ticks() % welt_modell->ticks_per_world_month) * (env_t::show_month==env_t::DATE_FMT_MONTH? 3 : tage_per_month[month]) ) >> welt_modell->ticks_per_world_month_shift;
+		sint32 num_days = ( ticks * (env_t::show_month==env_t::DATE_FMT_MONTH? 3 : tage_per_month[month]) ) >> world()->ticks_per_world_month_shift;
+		num_days -= ( (world()->get_ticks() % world()->ticks_per_world_month) * (env_t::show_month==env_t::DATE_FMT_MONTH? 3 : tage_per_month[month]) ) >> world()->ticks_per_world_month_shift;
 		char days[64];
 		static struct lang_info_t
 		{
@@ -265,7 +262,7 @@ char const *tick_to_string( sint64 ticks, bool show_full )
 		}
 
 		// maybe round minutes
-		//int switchtick = welt_modell->ticks_per_world_month_shift;
+		//int switchtick = world()->ticks_per_world_month_shift;
 		//if(  env_t::show_month == env_t::DATE_FMT_MONTH  ) {
 		//	// since a month is then just three days instead of about 30 ...
 		//	switchtick += 3;

--- a/simline.cc
+++ b/simline.cc
@@ -19,6 +19,9 @@
 #include "simconvoi.h"
 #include "convoihandle_t.h"
 #include "simlinemgmt.h"
+#include "gui/simwin.h"
+#include "gui/gui_frame.h"
+
 
 line_cost_t convoi_to_line_catgory_[convoi_t::MAX_CONVOI_COST] =
 {
@@ -144,6 +147,32 @@ waytype_t simline_t::linetype_to_waytype(const linetype lt)
 {
 	static const waytype_t wt2lt[MAX_LINE_TYPE] = { invalid_wt, road_wt, track_wt, water_wt, air_wt, monorail_wt, tram_wt, maglev_wt, narrowgauge_wt };
 	return wt2lt[lt];
+}
+
+
+void simline_t::set_schedule(schedule_t* schedule)
+{
+	if (this->schedule)
+	{
+		haltestelle_t::refresh_routing(schedule, goods_catg_index, NULL, NULL, player);
+		unregister_stops();
+		delete this->schedule;
+	}
+	this->schedule = schedule;
+	financial_history[0][LINE_DEPARTURES_SCHEDULED] = calc_departures_scheduled();
+}
+
+
+void simline_t::set_name(const char *new_name)
+{
+	name = new_name;
+
+	/// Update window title if window is open
+	gui_frame_t *line_info = win_get_magic((ptrdiff_t)self.get_rep());
+
+	if (line_info) {
+		line_info->set_name(name);
+	}
 }
 
 
@@ -617,18 +646,6 @@ void simline_t::renew_stops()
 	{
 		financial_history[0][LINE_DEPARTURES_SCHEDULED] = calc_departures_scheduled();
 	}
-}
-
-void simline_t::set_schedule(schedule_t* schedule)
-{
-	if (this->schedule)
-	{
-		haltestelle_t::refresh_routing(schedule, goods_catg_index, NULL, NULL, player);
-		unregister_stops();
-		delete this->schedule;
-	}
-	this->schedule = schedule;
-	financial_history[0][LINE_DEPARTURES_SCHEDULED] = calc_departures_scheduled();
 }
 
 

--- a/simline.h
+++ b/simline.h
@@ -186,7 +186,7 @@ public:
 	 * get name of line
 	 */
 	char const* get_name() const { return name; }
-	void set_name(const char *str) { name = str; }
+	void set_name(const char *str);
 
 	/*
 	 * load or save the line

--- a/simtypes.h
+++ b/simtypes.h
@@ -213,6 +213,10 @@ static inline int max(const int a, const int b)
 }
 #endif
 
+template<typename T> static inline void set_bits_to(T& bits, const T mask, const T values){
+	bits = (bits & ~mask) | values;
+}
+
 // @author: jamespetts, April 2011
 template<class T> static T set_scale_generic(T value, uint16 scale_factor) { return (value * (T)scale_factor) / (T)1000; }
 

--- a/simutrans/config/simuconf.tab
+++ b/simutrans/config/simuconf.tab
@@ -417,11 +417,86 @@ auto_connect_industries_and_attractions_by_road = 4
 #  
 #industry_density_proportion_override = 0
 
-################################# Display settings ################################
+################################# Display settings  ################################
+# Use with care
+# Settings made here will override player preferences set via the Display settings UI
+# For that reason it is not recommended for pakset authors to override these.
+# Do not set those in simuconf unless you know exactly what you are doing!
+
+### GUI settings ###
+# show graphs old style (right to left) or rather left to right (default)
+#left_to_right_graphs  = 1
 
 # You can use a system font. BUT you must specify the whole path to it!
 # This can be only set in the user defined simuconf.tab
 #fontname=C:\Windows\fonts\arial.ttf
+
+# Position of the main menu bar (0=top, 1=left, 2=bottom, 3=right)
+#menubar_position = 0
+
+# 1=selecting a tool again will close it (0=will be topped/reinit)
+#reselect_closes_tool = 1
+
+
+### Map view ###
+# If set to 1 (default) the numpad will always move the map.
+# if set to 0, it will always produce numbers
+#numpad_always_moves_map = 1
+
+# Should month be shown in date?
+# (0=no, 1=yes, 2>=show day in japan format=2, us format=3, german=4, japanese no season=5, us no season=6, german no season = 7, hours/minutes scale = 8, japan hours/minutes scale = 9)
+# This is most useful, if you use longer months than the default length (see below)
+# The hours/minutes scale shows the time in hours/minutes as used for determining journey times and other short times. It is the recommended setting. 
+#show_month = 8
+
+
+### Tooltips/overlays ###
+#Station name, statistics and style of the label:
+# The following three atributes replace the show_names atribute.
+# Show station names?
+# (1=on, 0=off)
+#show_station_names = 1
+
+# Show station status bars?
+# (1=on, 0=off)
+#show_station_statistics = 1
+
+# The visual style of the station name label:
+#   0 = black name in color box
+#   1 = name in player color with outline
+#   2 = box in player color left of name in yellow outline
+#station_label_style = 1
+
+# Show the name of depot above own depots
+#show_depot_names = 0
+
+# show a tooltip on convois at several conditions
+# 0 no messages
+# 1 (default) only no_route and stuck
+# loading and waiting at signals too
+#show_vehicle_states = 1
+
+
+### Vehicle display settings ###
+# Show info windows for private cars?
+# (1=on, 0=off)
+#car_info = 1
+
+# Show info windows for pedestrians?
+# (1=on, 0=off)
+#pedes_info = 0
+
+# If a convoi which you are following enters a tunnel, what to do
+# 0=do not change view, 1=switch to underground mode and back, 2=switch to sliced underground mode
+#follow_convoi_underground = 2
+
+# show (default) tiles with a halt when editing a schedule
+#visualize_schedule = 1
+
+
+
+############################### Further Display settings ###############################
+#These cannot be set in the Display settings UI, so simuconf is the only way to set these
 
 # player color can be fixed for several players or set totally random
 # in the latter case each player will get unique but random coloring
@@ -468,16 +543,6 @@ citycar_level = 5
 # default is ten years
 default_citycar_life = 36
 
-# The following two options replace the pedes_and_car_info, allowing both information windows to be enabled independently of each other.
-# Use with care. Defining these will enforce 
-# Show info windows for private cars?
-# (1=on, 0=off)
-#car_info = 1
-
-# Show info windows for pedestrians?
-# (1=on, 0=off)
-#pedes_info = 0
-
 # Show infos on trees?
 # (1=on, 0=off)
 tree_info = 1
@@ -501,35 +566,9 @@ show_delete_buttons = 1
 # even if there are more objects on this tile
 #only_single_info = 1
 
-# show a tooltip on convois at several conditions
-# 0 no messages
-# 1 (default) only no_route and stuck
-# loading and waiting at signals too
-#show_vehicle_states = 1
-
-# If a convoi which you are following enters a tunnel, what to do
-# 0=do not change view, 1=switch to underground mode and back, 2=switch to sliced underground mode
-#follow_convoi_underground = 2
-
-# show (default) tiles with a halt when editing a schedule
-#visualize_schedule = 1
 
 # Should stations get numbered names? (1=yes, 0=no)
 #numbered_stations = 0
-
-# Show name signs and statistic?
-# 0 = don't show anything
-# 1 = station names
-# 2 = statistics
-# 3 = names and statistics
-# The visual style is added to this number:
-#   0 = black name in color box
-#   4 = name in player color with outline
-#   8 = box left of name in yellow outline
-show_names = 3
-
-# Show the name of depot above own depots
-#show_depot_names = 0
 
 # Color of cursor overlay, which is blended over marked ground tiles
 # The available colors and their numbers can be found on
@@ -576,9 +615,6 @@ tooltip_delay = 500
 # duration in ms during tooltip is visible (default 5000ms=5s)
 tooltip_duration = 5000
 
-# show graphs old style (right to left) or rather left to right (default)
-left_to_right_graphs  = 1
-
 # if run on a mobile device, setting hide_keyboard=1 will only show the keyboard
 # when there is text to input in a dialoge. Other than that textinput will not
 # be possible (no keyboard short cuts).
@@ -591,16 +627,6 @@ hide_keyboard = 0
 # default for minimap is 1+12=13
 compass_screen_position = 0
 compass_map_position = 13
-
-# If set to 1 (default) the numpad will always move the map.
-# if set to 0, it will always produce numbers
-numpad_always_moves_map = 1
-
-# Position of the main menu bar (0=left, 1=top, 2=right, 3=bottom)
-#menubar_position = 0
-
-# 1=selecting a tool again will close it (0=will be topped/reinit)
-#reselect_closes_tool = 1
 
 # Should either account (default) or net wealth be shown below the screen?
 player_finance_display_account = 1
@@ -1010,11 +1036,6 @@ starting_year = 1930
 # Starting month of the game for people who want to start in summer (default 1=January)
 starting_month = 1
 
-# Should month be shown in date?
-# (0=no, 1=yes, 2>=show day in japan format=2, us format=3, german=4, japanese no season=5, us no season=6, german no season = 7, hours/minutes scale = 8, japan hours/minutes scale = 9)
-# This is most useful, if you use longer months than the default length (see below)
-# The hours/minutes scale shows the time in hours/minutes as used for determining journey times and other short times. It is the recommended setting. 
-#show_month = 8
 
 # Global time multiplier (will be save with new games)
 # 2^bits_per_month = duration of a game month in milliseconds real time

--- a/simutrans/config/simuconf.tab
+++ b/simutrans/config/simuconf.tab
@@ -461,16 +461,22 @@ random_wildlife_probability = 1000
 # costs some time for the additional redraw (~1-3%)
 water_animation_ms = 250
 
-# Show info windows for private cars and pedestrians?
-# (1=on, 0=off)
-#pedes_and_car_info = 0
-
 # How much citycars will be generated
 citycar_level = 5
 
 # After how many month a citycar breaks (and will be forever gone) ...
 # default is ten years
 default_citycar_life = 36
+
+# The following two options replace the pedes_and_car_info, allowing both information windows to be enabled independently of each other.
+# Use with care. Defining these will enforce 
+# Show info windows for private cars?
+# (1=on, 0=off)
+#car_info = 1
+
+# Show info windows for pedestrians?
+# (1=on, 0=off)
+#pedes_info = 0
 
 # Show infos on trees?
 # (1=on, 0=off)
@@ -590,7 +596,7 @@ compass_map_position = 13
 # if set to 0, it will always produce numbers
 numpad_always_moves_map = 1
 
-# Position of the main menu bar (0=top, 1=left, 2=bottom, 3=right)
+# Position of the main menu bar (0=left, 1=top, 2=right, 3=bottom)
 #menubar_position = 0
 
 # 1=selecting a tool again will close it (0=will be topped/reinit)
@@ -1008,7 +1014,7 @@ starting_month = 1
 # (0=no, 1=yes, 2>=show day in japan format=2, us format=3, german=4, japanese no season=5, us no season=6, german no season = 7, hours/minutes scale = 8, japan hours/minutes scale = 9)
 # This is most useful, if you use longer months than the default length (see below)
 # The hours/minutes scale shows the time in hours/minutes as used for determining journey times and other short times. It is the recommended setting. 
-show_month = 8
+#show_month = 8
 
 # Global time multiplier (will be save with new games)
 # 2^bits_per_month = duration of a game month in milliseconds real time

--- a/simutrans/config/simuconf.tab
+++ b/simutrans/config/simuconf.tab
@@ -463,7 +463,7 @@ water_animation_ms = 250
 
 # Show info windows for private cars and pedestrians?
 # (1=on, 0=off)
-pedes_and_car_info = 0
+#pedes_and_car_info = 0
 
 # How much citycars will be generated
 citycar_level = 5

--- a/simutrans/config/simuconf.tab
+++ b/simutrans/config/simuconf.tab
@@ -419,9 +419,9 @@ auto_connect_industries_and_attractions_by_road = 4
 
 ################################# Display settings  ################################
 # Use with care
-# Settings made here will override player preferences set via the Display settings UI
-# For that reason it is not recommended for pakset authors to override these.
-# Do not set those in simuconf unless you know exactly what you are doing!
+# These settings can and should be meade in the Display settings dialogue in game.
+# Settings made here will override player preferences set in the Display settings UI.
+# Do not set these parameters in simuconf unless you know exactly what you are doing!
 
 ### GUI settings ###
 # show graphs old style (right to left) or rather left to right (default)
@@ -451,8 +451,11 @@ auto_connect_industries_and_attractions_by_road = 4
 
 
 ### Tooltips/overlays ###
-#Station name, statistics and style of the label:
-# The following three atributes replace the show_names atribute.
+
+# show_names has been deprecated. Use show_station_names, show_station_statistics and station_label_style instead
+# show_names will be ignored if either show_station_names, show_station_statistics or station_label_style is defined within the same file.
+# Across different simuconfs, show_station_names, show_station_statistics and station_label_style can override show_names as well as the other way round. 
+#
 # Show station names?
 # (1=on, 0=off)
 #show_station_names = 1
@@ -478,13 +481,18 @@ auto_connect_industries_and_attractions_by_road = 4
 
 
 ### Vehicle display settings ###
+
+# pedes_and_car_info has been deprecated. Use pedestrian_info and car_info instead
+# pedes_and_car_info will be ignored if either pedestrian_info or car_info is defined within the same file.
+# Across different simuconfs, car_info and pedestrian_info can override pedes_and_car_info as well as the other way round. 
+#
 # Show info windows for private cars?
 # (1=on, 0=off)
-#car_info = 1
+#privatecar_info = 1
 
 # Show info windows for pedestrians?
 # (1=on, 0=off)
-#pedes_info = 0
+#pedestrian_info = 0
 
 # If a convoi which you are following enters a tunnel, what to do
 # 0=do not change view, 1=switch to underground mode and back, 2=switch to sliced underground mode

--- a/simutrans/text/ja.tab
+++ b/simutrans/text/ja.tab
@@ -4113,6 +4113,20 @@ Industry overlay
 産業在庫量ツールチップ
 Display bars above the factory to show the status
 産業建築物の上部に在庫量を示すバーを表示します
+Show the private car information window
+自家用車ウィンドウを表示
+Show the pedestrian information window
+歩行者ウィンドウを表示
+can open a dedicated window by clicking on a private car.
+自家用車をクリックすると専用の情報ウィンドウを開きます
+can open a dedicated window by clicking on a pedestrian.
+歩行者をクリックすると専用の情報ウィンドウを開きます
+Date format
+日時の表示形式
+Show own depot names
+プレイヤー所有の車庫名を表示する
+Show the name of own depots in the main game window.
+メインゲーム画面上にプレイヤーの車庫の名前を表示します
 #_______________________________unnecessary_text________________________________
 #_______________________________unnecessary_text________________________________
 100 km/h = %i tiles/month

--- a/simversion.h
+++ b/simversion.h
@@ -35,7 +35,7 @@ extern "C" FILE * __cdecl __iob_func(void) { return _iob; }
 
 #define EX_VERSION_MAJOR	14
 #define EX_VERSION_MINOR	16
-#define EX_SAVE_MINOR		44
+#define EX_SAVE_MINOR		45
 
 // Do not forget to increment the save game versions in settings_stats.cc when changing this
 

--- a/vehicle/pedestrian.cc
+++ b/vehicle/pedestrian.cc
@@ -18,6 +18,9 @@
 #include "../utils/cbuffer_t.h"
 #include "../descriptor/pedestrian_desc.h"
 
+#include "../gui/simwin.h"
+#include "../gui/pedestrian_info.h"
+
 #include <cstdio>
 
 
@@ -138,7 +141,7 @@ image_id pedestrian_t::get_image() const
 void pedestrian_t::show_info()
 {
 	if (env_t::road_user_info & 2) {
-		obj_t::show_info();
+		create_win(new pedestrian_info_t(this), w_info, (ptrdiff_t)this);
 	}
 }
 
@@ -379,16 +382,5 @@ void pedestrian_t::check_timeline_pedestrians()
 		{
 			current_pedestrians.append(fd, fd->get_distribution_weight());
 		}
-	}
-}
-
-
-void pedestrian_t::info(cbuffer_t & buf) const
-{
-	char const* const owner = translator::translate("Kein Besitzer\n");
-	buf.append(owner);
-
-	if (char const* const maker = get_desc()->get_copyright()) {
-		buf.printf(translator::translate("Constructed by %s"), maker);
 	}
 }

--- a/vehicle/pedestrian.cc
+++ b/vehicle/pedestrian.cc
@@ -135,6 +135,14 @@ image_id pedestrian_t::get_image() const
 }
 
 
+void pedestrian_t::show_info()
+{
+	if (env_t::road_user_info & 2) {
+		obj_t::show_info();
+	}
+}
+
+
 void pedestrian_t::rdwr(loadsave_t *file)
 {
 	xml_tag_t f( file, "pedestrian_t" );

--- a/vehicle/pedestrian.h
+++ b/vehicle/pedestrian.h
@@ -46,6 +46,11 @@ public:
 
 	virtual ~pedestrian_t();
 
+	/**
+	 * Open a new observation window for the object.
+	 */
+	void show_info() OVERRIDE;
+
 	const pedestrian_desc_t *get_desc() const { return desc; }
 
 	const char *get_name() const OVERRIDE {return "Fussgaenger";}

--- a/vehicle/pedestrian.h
+++ b/vehicle/pedestrian.h
@@ -59,8 +59,6 @@ public:
 	typ get_typ() const OVERRIDE { return pedestrian; }
 #endif
 
-	void info(cbuffer_t & buf) const OVERRIDE;
-
 	sync_result sync_step(uint32 delta_t) OVERRIDE;
 
 	///@ returns true if pedestrian walks on the left side of the road

--- a/vehicle/simroadtraffic.cc
+++ b/vehicle/simroadtraffic.cc
@@ -134,7 +134,7 @@ road_user_t::road_user_t(grund_t* bd, uint16 random) :
  */
 void road_user_t::show_info()
 {
-	if(env_t::road_user_info) {
+	if(env_t::road_user_info&1) {
 		obj_t::show_info();
 	}
 }


### PR DESCRIPTION
This branch builds upon the latest changes of Ranran's appreciated detach-ped-info branch
On top of the changes made there, it adds the following:

- split the pedes_and_car_info simuconf attribute into pedestrian_info and privatecar_info
- split the show_names simuconf attribute into how_station_names, show_station_statistics and station_label_style
- adjust simuconf, so all settings from the display settings UI are commented out in simuconf and reside in their own category.
- removed display setting UI settings from advanced settings UI

These changes aim so solve multiple minor issues:
- More consistency in between the ingame UI and simuconf.
pedes_and_car_info as well as show_names have been split in the display settings UI whilst being combined attributes in simuconf.
- Setting any attribute from the display settings UI in simuconf will enforce the simuconf value after each (re)start of the game, overriding user preferences set in the UI.
- There has been redundancy in between the advanced settings UI and the display settings UI. It was agreed that such settings should only exist in the dislpay settings UI, so these were removed from the advanced settings UI.