### PR TITLE
Permit selling houses; reform company sale calculation

### DIFF
--- a/obj/gebaeude.cc
+++ b/obj/gebaeude.cc
@@ -1025,13 +1025,12 @@ void gebaeude_t::info(cbuffer_t & buf) const
 			buf.printf("%s%u", translator::translate("\nBauzeit bis"), h.get_retire_year_month() / 12);
 		}
 		buf.append("\n");
-		if (get_owner() == NULL) {
-			buf.append(translator::translate("Wert"));
-			buf.append(": ");
-			// The land value calculation below will need modifying if multi-tile city buildings are ever introduced.
-			buf.append(-(welt->get_land_value(get_pos())*(tile->get_desc()->get_level()) / 100) * 5);
-			buf.append("$\n");
-		}
+
+		buf.append(translator::translate("Wert"));
+		buf.append(": ");
+		// The land value calculation below will need modifying if multi-tile city buildings are ever introduced.
+		buf.append(-(welt->get_land_value(get_pos())*(tile->get_desc()->get_level()) / 100) * 5);
+		buf.append("$\n");
 
 		if (char const* const maker = tile->get_desc()->get_copyright()) {
 			buf.printf(translator::translate("Constructed by %s"), maker);


### PR DESCRIPTION
- Attempting to purchase a house already owned, will sell it back (it will again be "unowned") and the purchase price will be refunded.  This opens the eventual possibility that if the house or land value has changed, the value recouped may be above or below the original purchase price.  
- Houses are still not tracked as part of a company's assets, which will have to be done for the "Assets" figure on the financial report to be correct, or for completely proper company takeover prices.  Perhaps a future pull request might do this.
- Reform asset and liability computation for company sale, as being the higher of known assets or known liabilities. Liabilities include original starting cash, plus any short-term loans (negative cash account balances).