### PR TITLE
FIX: Enable randomness by default for the CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,7 +287,7 @@ if (SIMUTRANS_STEAM_BUILT)
 	target_compile_definitions(simutrans-extended PRIVATE STEAM_BUILT=1)
 endif ()
 
-if (NOT SIMUTRANS_ENABLE_RANDOMNESS)
+if (SIMUTRANS_DISABLE_RANDOMNESS)
 	target_compile_definitions(simutrans-extended PRIVATE DISABLE_RANDOMNESS=1)
 endif ()
 


### PR DESCRIPTION
SIMUTRANS_ENABLE_RANDOMNESS CMake flag has been replaced with SIMUTRANS_DISABLE_RANDOMNESS which is more appropriately since the default behaviour is for the randomness to be enabled.