### PR TITLE
Added link_directories for Apple silicon Homebrew path.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ endif ()
 if (APPLE)
 	set(CMAKE_PREFIX_PATH "/usr/local/opt/readline")
 	link_directories(/usr/local/lib)
+    link_directories(/opt/homebrew/lib)
 	set(CMAKE_EXE_LINKER_FLAGS "-framework Cocoa")
 endif ()
 


### PR DESCRIPTION
Added link_directories variable so CMake knows where Homebrew libraries are located on Apple silicon Macs, as explained [here](https://www.reddit.com/r/MacOS/comments/jw9guu/why_did_homebrew_move_from_usrlocalto_opthomebrew/).

Compilation has been tested successfully:
<img width="707" alt="unknown (1)" src="https://user-images.githubusercontent.com/4592116/191920013-42f0b943-060c-4c08-b4ce-e47586669d82.png">