### PR TITLE
CODE: Introduce edge_avoidance parameter for city generation. 

### DIFF
--- a/bauer/fabrikbauer.cc
+++ b/bauer/fabrikbauer.cc
@@ -137,10 +137,17 @@ public:
 				mincond = 1;
 		}
 
+		sint16 edge_avoidance = stadt_t::get_edge_avoidance();
+
 		// needs to run one tile wider than the factory on all sides
 		for (sint16 y = -1;  y <= h; y++) {
 			for (sint16 x = -1; x <= w; x++) {
 				koord k(pos + koord(x,y));
+				if ( k.x < edge_avoidance || k.y < edge_avoidance
+							|| k.x >= welt->get_size().x - edge_avoidance || k.y >= welt->get_size().y - edge_avoidance ) {
+					// too close to edge of map
+					return false;
+				}
 				grund_t *gr = welt->lookup_kartenboden(k);
 				if (!gr) {
 					// We want to keep the factory at least 1 away from the edge of the map.

--- a/simcity.cc
+++ b/simcity.cc
@@ -819,7 +819,7 @@ bool stadt_t::cityrules_init(const std::string &objfilename)
 	char buf[128];
 
 	minimum_city_distance = contents.get_int("minimum_city_distance", 16);
-	edge_avoidance = (uint32)contents.get_int("edge_avoidance", 16);
+	edge_avoidance = (uint32)contents.get_int("edge_avoidance", 8);
 	cluster_factor = (uint32)contents.get_int("cluster_factor", 100);
 	bridge_success_percentage = (uint32)contents.get_int("bridge_success_percentage", 25);
 	renovation_percentage = (uint32)contents.get_int("renovation_percentage", renovation_percentage);

--- a/simcity.cc
+++ b/simcity.cc
@@ -819,7 +819,7 @@ bool stadt_t::cityrules_init(const std::string &objfilename)
 	char buf[128];
 
 	minimum_city_distance = contents.get_int("minimum_city_distance", 16);
-	edge_avoidance = (uint32)contents.get_int("edge_avoidance", 8);
+	edge_avoidance = (uint32)contents.get_int_clamped("edge_avoidance", 8, 0, 127);
 	cluster_factor = (uint32)contents.get_int("cluster_factor", 100);
 	bridge_success_percentage = (uint32)contents.get_int("bridge_success_percentage", 25);
 	renovation_percentage = (uint32)contents.get_int("renovation_percentage", renovation_percentage);

--- a/simcity.cc
+++ b/simcity.cc
@@ -341,8 +341,9 @@ static uint32 minimum_city_distance = 16;
 
 /**
  * keep cities this many tiles away from the edge of the map
+ * sint16 because it's always added or subtracted from map koord values
  */
-static uint32 edge_avoidance = 8;
+static sint16 edge_avoidance = 8;
 
 /*
  * minimum ratio of city area to building area to allow expansion
@@ -788,12 +789,12 @@ void stadt_t::set_minimum_city_distance(uint32 s)
 	minimum_city_distance = s;
 }
 
-uint32 stadt_t::get_edge_avoidance()
+sint16 stadt_t::get_edge_avoidance()
 {
 	return edge_avoidance;
 }
 
-void stadt_t::set_edge_avoidance(uint32 s)
+void stadt_t::set_edge_avoidance(sint16 s)
 {
 	edge_avoidance = s;
 }
@@ -819,7 +820,7 @@ bool stadt_t::cityrules_init(const std::string &objfilename)
 	char buf[128];
 
 	minimum_city_distance = contents.get_int("minimum_city_distance", 16);
-	edge_avoidance = (uint32)contents.get_int_clamped("edge_avoidance", 8, 0, 127);
+	edge_avoidance = (sint16)contents.get_int_clamped("edge_avoidance", 8, 0, 127);
 	cluster_factor = (uint32)contents.get_int("cluster_factor", 100);
 	bridge_success_percentage = (uint32)contents.get_int("bridge_success_percentage", 25);
 	renovation_percentage = (uint32)contents.get_int("renovation_percentage", renovation_percentage);
@@ -1049,7 +1050,7 @@ void stadt_t::cityrules_rdwr(loadsave_t *file)
 
 	if ((file->get_extended_version() == 14 && file->get_extended_revision() >= 21) || file->get_extended_version() >= 15)
 	{
-		file->rdwr_long(edge_avoidance);
+		file->rdwr_short(edge_avoidance);
 	}
 
 	file->rdwr_short(ind_start_score);

--- a/simcity.h
+++ b/simcity.h
@@ -141,6 +141,8 @@ public:
 
 	static uint32 get_minimum_city_distance();
 	static void set_minimum_city_distance(uint32 s);
+	static uint32 get_edge_avoidance();
+	static void set_edge_avoidance(uint32 s);
 
 	/**
 	 * Reads/writes city configuration data from/to a savegame

--- a/simcity.h
+++ b/simcity.h
@@ -141,8 +141,8 @@ public:
 
 	static uint32 get_minimum_city_distance();
 	static void set_minimum_city_distance(uint32 s);
-	static uint32 get_edge_avoidance();
-	static void set_edge_avoidance(uint32 s);
+	static sint16 get_edge_avoidance();
+	static void set_edge_avoidance(sint16 s);
 
 	/**
 	 * Reads/writes city configuration data from/to a savegame

--- a/simversion.h
+++ b/simversion.h
@@ -34,7 +34,7 @@ extern "C" FILE * __cdecl __iob_func(void) { return _iob; }
 #define SIM_SERVER_MINOR    7
 
 #define EX_VERSION_MAJOR	14
-#define EX_VERSION_MINOR	20
+#define EX_VERSION_MINOR	21
 #define EX_SAVE_MINOR		60
 
 // Do not forget to increment the save game versions in settings_stats.cc when changing this

--- a/simworld.cc
+++ b/simworld.cc
@@ -8365,22 +8365,56 @@ bool karte_t::square_is_free(koord k, sint16 w, sint16 h, int *last_y, climate_b
 }
 
 
-slist_tpl<koord> *karte_t::find_squares(sint16 w, sint16 h, climate_bits cl, uint16 regions_allowed, sint16 old_x, sint16 old_y) const
+slist_tpl<koord> *karte_t::find_squares(sint16 w, sint16 h, uint32 edge_avoidance_raw, climate_bits cl, uint16 regions_allowed, sint16 old_x, sint16 old_y) const
 {
 	slist_tpl<koord> * list = new slist_tpl<koord>();
 	koord start;
 	int last_y;
 
+	// The parameter edge_avoidance is a number of tiles to keep away from the edge of the map.
+	// The entire square must not be within the "buffer zone" at the edge of the map.
+	// This is because it can be annoying to have cities crushed against the game border.
+	//
+	// Note that the parameters old_x and old_y are used only for enlarge_map (otherwise they're 0)
+	//
+	// -- Nathanael Nerode
+
+	// We need to do signed math with this.
+	sint16 edge_avoidance = 0;
+	// Note: edge_avoidance_raw is an unsigned int, so don't need to check for negatives
+	if (edge_avoidance_raw > 127) {
+		// Sanity check.  Don't want THAT much edge avoidance. 2^7 - 1 is good enough for anyone.
+		edge_avoidance = 127;
+	} else {
+		// Bounds check passed: will fit into sint16.
+		edge_avoidance = edge_avoidance_raw;
+	}
+
+	// Need to do SIGNED math.
+	// Note: may be larger than map size, this is OK, caught by the for loop condition
+	sint16 lowest_x = (sint16)0 + edge_avoidance;
+	sint16 lowest_y = (sint16)0 + edge_avoidance;
+	// Note: may be negative, this is OK, caught by the for loop condition
+	sint16 highest_x_plus_one = get_size().x - edge_avoidance - w;
+	sint16 highest_y_plus_one = get_size().y - edge_avoidance - h;
+
+	// Expansion: areas formerly avoided because at map lower/right edge, aren't at map edge any more
+	// So it's OK to add new cities to this former-edge part of the map *now*
+	// However, don't find spaces in the left/top buffer zone of the map
+	sint16 lowest_expansion_x = (sint16) max(old_x - edge_avoidance, lowest_x);
+	sint16 lowest_expansion_y = (sint16) max(old_y - edge_avoidance, lowest_y);
+
+
 DBG_DEBUG("karte_t::finde_plaetze()","for size (%i,%i) in map (%i,%i)",w,h,get_size().x,get_size().y );
-	for(start.x=0; start.x<get_size().x-w; start.x++) {
-		for(start.y=start.x<old_x?old_y:0; start.y<get_size().y-h; start.y++) {
+	for(start.x = lowest_x; start.x < highest_x_plus_one; start.x++) {
+		for(start.y = start.x < lowest_expansion_x ? lowest_expansion_y : lowest_y; start.y < highest_y_plus_one; start.y++) {
 			if(square_is_free(start, w, h, &last_y, cl, regions_allowed)) {
 				list->insert(start);
 			}
 			else {
-				// Optimiert fuer groessere Felder, hehe!
-				// Die Idee: wenn bei 2x2 die untere Reihe nicht geht, koennen
-				// wir gleich 2 tiefer weitermachen! V. Meyer
+				// Optimized for larger fields
+				// The idea: if the bottom row doesn't work in 2x2,
+				// we can continue 2 deeper - V. Meyer
 				start.y = last_y;
 			}
 		}

--- a/simworld.cc
+++ b/simworld.cc
@@ -8365,7 +8365,7 @@ bool karte_t::square_is_free(koord k, sint16 w, sint16 h, int *last_y, climate_b
 }
 
 
-slist_tpl<koord> *karte_t::find_squares(sint16 w, sint16 h, uint32 edge_avoidance_raw, climate_bits cl, uint16 regions_allowed, sint16 old_x, sint16 old_y) const
+slist_tpl<koord> *karte_t::find_squares(sint16 w, sint16 h, sint16 edge_avoidance, climate_bits cl, uint16 regions_allowed, sint16 old_x, sint16 old_y) const
 {
 	slist_tpl<koord> * list = new slist_tpl<koord>();
 	koord start;
@@ -8378,10 +8378,6 @@ slist_tpl<koord> *karte_t::find_squares(sint16 w, sint16 h, uint32 edge_avoidanc
 	// Note that the parameters old_x and old_y are used only for enlarge_map (otherwise they're 0)
 	//
 	// -- Nathanael Nerode
-
-	// We need to do signed math with this.
-	sint16 edge_avoidance = (sint16) edge_avoidance_raw;
-	// Note that edge_avoidance has been clamped to a correct size when first read from the tabfile.
 
 	// Need to do SIGNED math.
 	// Note: may be larger than map size, this is OK, caught by the for loop condition

--- a/simworld.cc
+++ b/simworld.cc
@@ -8380,15 +8380,8 @@ slist_tpl<koord> *karte_t::find_squares(sint16 w, sint16 h, uint32 edge_avoidanc
 	// -- Nathanael Nerode
 
 	// We need to do signed math with this.
-	sint16 edge_avoidance = 0;
-	// Note: edge_avoidance_raw is an unsigned int, so don't need to check for negatives
-	if (edge_avoidance_raw > 127) {
-		// Sanity check.  Don't want THAT much edge avoidance. 2^7 - 1 is good enough for anyone.
-		edge_avoidance = 127;
-	} else {
-		// Bounds check passed: will fit into sint16.
-		edge_avoidance = edge_avoidance_raw;
-	}
+	sint16 edge_avoidance = (sint16) edge_avoidance_raw;
+	// Note that edge_avoidance has been clamped to a correct size when first read from the tabfile.
 
 	// Need to do SIGNED math.
 	// Note: may be larger than map size, this is OK, caught by the for loop condition

--- a/simworld.h
+++ b/simworld.h
@@ -2442,7 +2442,7 @@ public:
 	 * @return A list of all buildable squares with size w, h.
 	 * @note Only used for town creation at the moment.
 	 */
-	slist_tpl<koord> * find_squares(sint16 w, sint16 h, uint32 edge_avoidance, climate_bits cl, uint16 regions_allowed, sint16 old_x, sint16 old_y) const;
+	slist_tpl<koord> * find_squares(sint16 w, sint16 h, sint16 edge_avoidance, climate_bits cl, uint16 regions_allowed, sint16 old_x, sint16 old_y) const;
 
 	/**
 	 * Plays the sound when the position is inside the visible region.

--- a/simworld.h
+++ b/simworld.h
@@ -2442,7 +2442,7 @@ public:
 	 * @return A list of all buildable squares with size w, h.
 	 * @note Only used for town creation at the moment.
 	 */
-	slist_tpl<koord> * find_squares(sint16 w, sint16 h, climate_bits cl, uint16 regions_allowed, sint16 old_x, sint16 old_y) const;
+	slist_tpl<koord> * find_squares(sint16 w, sint16 h, uint32 edge_avoidance, climate_bits cl, uint16 regions_allowed, sint16 old_x, sint16 old_y) const;
 
 	/**
 	 * Plays the sound when the position is inside the visible region.


### PR DESCRIPTION
 Also increase experimental minor version number to 21.
 
This prevents cities from spawning within a specified distance (specified in cityrules.tab) of the edge of the map, making for maps with fewer unrealistic and annoying "pileups" of infrastructure at the map edges.  This solves something which has been irritating me for years during map generation (and only during map generation).

Default is set to a very conservative 8 tiles, which should be fine even for 256x256 maps.  Paksets can and should set this larger, especially if they are intended for playing on larger maps.

The distance is saved in the savegame because of possible map expansion. Which requires a minor version number increase.  If it is decided that this doesn't need to be in the savefile, I can redo this without that, which would be an even simpler patch.  (Since it only affects city generation, it only affects existing games if the "expand map" action is taken.)  I thought that there might be other things for which this parameter might be used later (perhaps keeping factories and attractions off the edge of the map) and I figured saving it with the save file was safest.  But let me know.

Tested, is working.