### PR TITLE
Find jobs (clean patch)

### DIFF
--- a/bauer/fabrikbauer.cc
+++ b/bauer/fabrikbauer.cc
@@ -675,8 +675,10 @@ int factory_builder_t::build_link(koord3d* parent, const factory_desc_t* info, s
 		return 0;
 	}
 
+	factory_desc_t::site_t site = info->get_placement();
+
 	// no cities at all?
-	if ((info->get_placement() == factory_desc_t::City || info->get_placement() == factory_desc_t::shore_city || info->get_placement() == factory_desc_t::river_city) &&  welt->get_cities().empty()) {
+	if ((site == factory_desc_t::City || site == factory_desc_t::shore_city || site == factory_desc_t::river_city) &&  welt->get_cities().empty()) {
 		return 0;
 	}
 
@@ -691,7 +693,7 @@ int factory_builder_t::build_link(koord3d* parent, const factory_desc_t* info, s
 	}
 
 	// Industries in town needs different place search
-	if (info->get_placement() == factory_desc_t::City || info->get_placement() == factory_desc_t::shore_city || info->get_placement() == factory_desc_t::river_city) {
+	if (site == factory_desc_t::City || site == factory_desc_t::shore_city || site == factory_desc_t::river_city) {
 
 		koord size=info->get_building()->get_size(0);
 
@@ -710,12 +712,12 @@ int factory_builder_t::build_link(koord3d* parent, const factory_desc_t* info, s
 		 */
 		bool is_rotate=info->get_building()->get_all_layouts()>1  &&  size.x!=size.y  &&  info->get_building()->can_rotate();
 		// first try with standard orientation
-		koord k = factory_site_searcher_t(welt, factory_desc_t::City).find_place(city->get_pos(), size.x, size.y, cl, regions_allowed);
+		koord k = factory_site_searcher_t(welt, site).find_place(city->get_pos(), size.x, size.y, cl, regions_allowed);
 
 		// second try: rotated
 		koord k1 = koord::invalid;
 		if (is_rotate  &&  (k == koord::invalid  ||  simrand(256, " factory_builder_t::build_link")<128)) {
-			k1 = factory_site_searcher_t(welt, factory_desc_t::City).find_place(city->get_pos(), size.y, size.x, cl, regions_allowed);
+			k1 = factory_site_searcher_t(welt, site).find_place(city->get_pos(), size.y, size.x, cl, regions_allowed);
 		}
 
                 int streetdir = 0;

--- a/bauer/fabrikbauer.cc
+++ b/bauer/fabrikbauer.cc
@@ -119,10 +119,12 @@ public:
 
 	bool is_area_ok(koord pos, sint16 w, sint16 h, climate_bits cl, uint16 allowed_regions) const OVERRIDE
 	{
-		if(  site != factory_desc_t::Water && !building_placefinder_t::is_area_ok(pos, w, h, cl, allowed_regions)  ) {
+		if (  site != factory_desc_t::Water  ) {
 			// If this is not a water site factory, then
-			// We need a clear space to build, first of all
-			return false;
+			if ( !building_placefinder_t::is_area_ok(pos, w, h, cl, allowed_regions)  ) {
+				// We need a clear space to build, first of all
+				return false;
+			}
 		}
 
 		// Check for runways
@@ -987,7 +989,7 @@ int factory_builder_t::build_chain_link(const fabrik_t* origin_fab, const factor
 
 			INT_CHECK("fabrikbauer 697");
 			const int max_distance_to_consumer = producer_d->get_max_distance_to_consumer() == 0 ? max_factory_spacing_general : producer_d->get_max_distance_to_consumer();
-			koord3d build_pos = find_random_construction_site(origin_fab->get_pos().get_2d(), min(max_distance_to_supplier, min(max_factory_spacing_general, max_distance_to_consumer)), producer_d->get_building()->get_size(rotate), producer_d->get_placement(), producer_d->get_building(), ignore_climates, 20000 );
+			koord3d build_pos = find_random_construction_site(origin_fab->get_pos().get_2d(), min(max_distance_to_supplier, min(max_factory_spacing_general, max_distance_to_consumer)), producer_d->get_building()->get_size(rotate), producer_d->get_placement(), producer_d->get_building(), ignore_climates, 200000 );
 			if(build_pos == koord3d::invalid  ) {
 				// this factory cannot build in the desired vincinity
 				producer.remove( producer_d );

--- a/bauer/fabrikbauer.cc
+++ b/bauer/fabrikbauer.cc
@@ -125,6 +125,13 @@ public:
 			return false;
 		}
 
+		// Check for runways
+		karte_t::runway_info ri = welt->check_nearby_runways(pos);
+		if (ri.pos != koord::invalid)
+		{
+			return false;
+		}
+
 		// Whether we've found a suitable road, shore, or river.
 		// Consider counting the number we find instead.
 		bool road_found = false;
@@ -394,13 +401,6 @@ bool factory_builder_t::check_construction_site(koord pos, koord size, factory_d
 		}
 		return welt->square_is_free(pos, size.x, size.y, NULL, cl, regions_allowed);
 	}
-	// Check for runways
-	karte_t::runway_info ri = welt->check_nearby_runways(pos);
-	if (ri.pos != koord::invalid)
-	{
-		return false;
-	}
-
 	return true;
 }
 

--- a/bauer/fabrikbauer.cc
+++ b/bauer/fabrikbauer.cc
@@ -184,7 +184,7 @@ public:
 					// we do NOT want to count a corner tile match as a match for road, shore, or river!
 					continue;
 				}
-				else if (  -1==x || x==w || -1==y || y==w  ) {
+				else if (  -1==x || x==w || -1==y || y==h  ) {
 					// border tile, and not corner (we checked corners first)
 					// check for road, shore, river
 					// short-circuit if we have already found road, shore, river

--- a/bauer/fabrikbauer.cc
+++ b/bauer/fabrikbauer.cc
@@ -137,10 +137,17 @@ public:
 				mincond = 1;
 		}
 
+		sint16 edge_avoidance = stadt_t::get_edge_avoidance();
+
 		// needs to run one tile wider than the factory on all sides
 		for (sint16 y = -1;  y <= h; y++) {
 			for (sint16 x = -1; x <= w; x++) {
 				koord k(pos + koord(x,y));
+				if ( k.x < edge_avoidance || k.y < edge_avoidance
+							|| k.x >= welt->get_size().x - edge_avoidance || k.y >= welt->get_size().y - edge_avoidance ) {
+					// too close to edge of map
+					return false;
+				}
 				grund_t *gr = welt->lookup_kartenboden(k);
 				if (!gr) {
 					// We want to keep the factory at least 1 away from the edge of the map.

--- a/bauer/fabrikbauer.cc
+++ b/bauer/fabrikbauer.cc
@@ -137,8 +137,20 @@ public:
 		// Whether we've found a suitable road, shore, or river.
 		// Consider counting the number we find instead.
 		bool road_found = false;
+		if (site != factory_desc_t::City) {
+			// Don't look for the road if we don't care.
+			road_found = true;
+		}
 		bool shore_found = false;
+		if (site != factory_desc_t::shore && site != factory_desc_t::shore_city) {
+			// Don't look for the shore if we don't care.
+			shore_found = true;
+		}
 		bool river_found = false;
+		if (site != factory_desc_t::river && site != factory_desc_t::river_city) {
+			// Don't look for the river if we don't care.
+			river_found = true;
+		}
 		if(  welt->get_settings().get_river_number() <= 0  ) {
 			// On a map with no rivers, don't restrict to spaces near rivers
 			river_found = true;
@@ -206,29 +218,29 @@ public:
 				else if (  -1==x || x==w || -1==y || y==h  ) {
 					// border tile, and not corner (we checked corners first)
 					// check for road, shore, river
-					// short-circuit if we have already found road, shore, river
+					// short-circuit if we have already found road, shore, river, or don't care
 					road_found = road_found || gr->hat_weg(road_wt);
 					shore_found = shore_found || welt->get_climate(k) == water_climate;
-					weg_t* river = gr->get_weg(water_wt);
-					river_found = river_found || (river  &&  river->get_desc()->get_styp()==type_river);
+					if (!river_found) {
+						weg_t* river = gr->get_weg(water_wt);
+						river_found = river_found || (river  &&  river->get_desc()->get_styp()==type_river);
+					}
 				}
 			}
 		}
+		// For a city building we require a pre-existing road,
+		// but for river_city and shore_city we don't, we'll build the road afterwards.
 		switch (site) {
 			case factory_desc_t::City:
 				return road_found;
 				break;
 			case factory_desc_t::shore:
+			case factory_desc_t::shore_city:
 				return shore_found;
 				break;
-			case factory_desc_t::shore_city:
-				return shore_found && road_found;
-				break;
 			case factory_desc_t::river:
-				return river_found;
-				break;
 			case factory_desc_t::river_city:
-				return river_found && road_found;
+				return river_found;
 				break;
 			case factory_desc_t::forest:
 				// Enough trees?

--- a/obj/gebaeude.cc
+++ b/obj/gebaeude.cc
@@ -1939,7 +1939,7 @@ void gebaeude_t::connect_by_road_to_nearest_city()
 	const minivec_tpl<koord>* diagonal_neighbor_koords = get_diagonal_neighbor_koords();
 	// First look for a road on a rectangular side
 	if (!start_found) {
-		FOR(const minivec_tpl<koord>, const test_pos, *rectangular_neighbor_koords) {
+		for (auto test_pos : *rectangular_neighbor_koords) {
 			// Only look for roads of the same height as building
 			const koord3d test_pos_3d = koord3d (test_pos, get_pos().z);
 			gr = welt->lookup(test_pos_3d);
@@ -1952,7 +1952,7 @@ void gebaeude_t::connect_by_road_to_nearest_city()
 	}
 	// Second: look for a road on a diagonal corner
 	if (!start_found) {
-		FOR(const minivec_tpl<koord>, const test_pos, *diagonal_neighbor_koords) {
+		for (auto test_pos : *diagonal_neighbor_koords) {
 			// Only look for roads of the same height as building
 			const koord3d test_pos_3d = koord3d (test_pos, get_pos().z);
 			gr = welt->lookup(test_pos_3d);
@@ -1978,7 +1978,7 @@ void gebaeude_t::connect_by_road_to_nearest_city()
 	// One random try failed?  Don't overwork the random number engine:
 	// search systematically through the rectangular neighors.
 	if (!start_found) {
-		FOR(const minivec_tpl<koord>, const test_pos, *rectangular_neighbor_koords) {
+		for (auto test_pos : *rectangular_neighbor_koords) {
 			// Only look for roads of the same height as building
 			const koord3d test_pos_3d = koord3d (test_pos, get_pos().z);
 			gr = welt->lookup(test_pos_3d);
@@ -1991,7 +1991,7 @@ void gebaeude_t::connect_by_road_to_nearest_city()
 	}
 	// Fourth: try the diagonal neighbors if we absolutely must.
 	if (!start_found) {
-		FOR(const minivec_tpl<koord>, const test_pos, *diagonal_neighbor_koords) {
+		for (auto test_pos : *diagonal_neighbor_koords) {
 			// Only look for roads of the same height as building
 			const koord3d test_pos_3d = koord3d (test_pos, get_pos().z);
 			gr = welt->lookup(test_pos_3d);

--- a/obj/gebaeude.h
+++ b/obj/gebaeude.h
@@ -366,6 +366,9 @@ public:
 	const minivec_tpl<const planquadrat_t*> &get_tiles() { return building_tiles; }
 	void set_building_tiles();
 
+	const minivec_tpl<koord>* get_rectangular_neighbor_koords();
+	const minivec_tpl<koord>* get_diagonal_neighbor_koords();
+
 	void connect_by_road_to_nearest_city();
 
 private:

--- a/simcity.cc
+++ b/simcity.cc
@@ -819,7 +819,7 @@ bool stadt_t::cityrules_init(const std::string &objfilename)
 	char buf[128];
 
 	minimum_city_distance = contents.get_int("minimum_city_distance", 16);
-	edge_avoidance = (uint32)contents.get_int("edge_avoidance", 16);
+	edge_avoidance = (uint32)contents.get_int("edge_avoidance", 8);
 	cluster_factor = (uint32)contents.get_int("cluster_factor", 100);
 	bridge_success_percentage = (uint32)contents.get_int("bridge_success_percentage", 25);
 	renovation_percentage = (uint32)contents.get_int("renovation_percentage", renovation_percentage);

--- a/simcity.cc
+++ b/simcity.cc
@@ -819,7 +819,7 @@ bool stadt_t::cityrules_init(const std::string &objfilename)
 	char buf[128];
 
 	minimum_city_distance = contents.get_int("minimum_city_distance", 16);
-	edge_avoidance = (uint32)contents.get_int("edge_avoidance", 8);
+	edge_avoidance = (uint32)contents.get_int_clamped("edge_avoidance", 8, 0, 127);
 	cluster_factor = (uint32)contents.get_int("cluster_factor", 100);
 	bridge_success_percentage = (uint32)contents.get_int("bridge_success_percentage", 25);
 	renovation_percentage = (uint32)contents.get_int("renovation_percentage", renovation_percentage);

--- a/simcity.cc
+++ b/simcity.cc
@@ -341,8 +341,9 @@ static uint32 minimum_city_distance = 16;
 
 /**
  * keep cities this many tiles away from the edge of the map
+ * sint16 because it's always added or subtracted from map koord values
  */
-static uint32 edge_avoidance = 8;
+static sint16 edge_avoidance = 8;
 
 /*
  * minimum ratio of city area to building area to allow expansion
@@ -788,12 +789,12 @@ void stadt_t::set_minimum_city_distance(uint32 s)
 	minimum_city_distance = s;
 }
 
-uint32 stadt_t::get_edge_avoidance()
+sint16 stadt_t::get_edge_avoidance()
 {
 	return edge_avoidance;
 }
 
-void stadt_t::set_edge_avoidance(uint32 s)
+void stadt_t::set_edge_avoidance(sint16 s)
 {
 	edge_avoidance = s;
 }
@@ -819,7 +820,7 @@ bool stadt_t::cityrules_init(const std::string &objfilename)
 	char buf[128];
 
 	minimum_city_distance = contents.get_int("minimum_city_distance", 16);
-	edge_avoidance = (uint32)contents.get_int_clamped("edge_avoidance", 8, 0, 127);
+	edge_avoidance = (sint16)contents.get_int_clamped("edge_avoidance", 8, 0, 127);
 	cluster_factor = (uint32)contents.get_int("cluster_factor", 100);
 	bridge_success_percentage = (uint32)contents.get_int("bridge_success_percentage", 25);
 	renovation_percentage = (uint32)contents.get_int("renovation_percentage", renovation_percentage);
@@ -1049,7 +1050,7 @@ void stadt_t::cityrules_rdwr(loadsave_t *file)
 
 	if ((file->get_extended_version() == 14 && file->get_extended_revision() >= 21) || file->get_extended_version() >= 15)
 	{
-		file->rdwr_long(edge_avoidance);
+		file->rdwr_short(edge_avoidance);
 	}
 
 	file->rdwr_short(ind_start_score);

--- a/simcity.h
+++ b/simcity.h
@@ -141,6 +141,8 @@ public:
 
 	static uint32 get_minimum_city_distance();
 	static void set_minimum_city_distance(uint32 s);
+	static uint32 get_edge_avoidance();
+	static void set_edge_avoidance(uint32 s);
 
 	/**
 	 * Reads/writes city configuration data from/to a savegame

--- a/simcity.h
+++ b/simcity.h
@@ -141,8 +141,8 @@ public:
 
 	static uint32 get_minimum_city_distance();
 	static void set_minimum_city_distance(uint32 s);
-	static uint32 get_edge_avoidance();
-	static void set_edge_avoidance(uint32 s);
+	static sint16 get_edge_avoidance();
+	static void set_edge_avoidance(sint16 s);
 
 	/**
 	 * Reads/writes city configuration data from/to a savegame

--- a/simfab.cc
+++ b/simfab.cc
@@ -589,6 +589,10 @@ void fabrik_t::recalc_storage_capacities()
 					// Inputs are now normalized to factory production.
 					uint32 prod_factor = welt->get_settings().using_fab_contracts() ? 256 : input->get_consumption();
 					g.max = (sint32)(welt->scale_for_distance_only((((sint64)((input->get_capacity() << precision_bits) + share) << DEFAULT_PRODUCTION_FACTOR_BITS) + (sint64)(prod_factor - 1)) / (sint64)prod_factor));
+					if (g.get_capacity(prod_factor) < 7) {
+						// No capacities less than 7 are allowed.  This allows for loading a whole (small) truck.
+						g.max = (sint32)( ( (sint64)7 << precision_bits << DEFAULT_PRODUCTION_FACTOR_BITS) / (sint64)prod_factor );
+					}
 				}
 			}
 			// then, for output goods
@@ -597,6 +601,10 @@ void fabrik_t::recalc_storage_capacities()
 					// Outputs are now normalized to factory production.
 					uint32 prod_factor = welt->get_settings().using_fab_contracts() ? 256 : output->get_factor();
 					g.max = (sint32)(welt->scale_for_distance_only((((sint64)((output->get_capacity() << precision_bits) + share) << DEFAULT_PRODUCTION_FACTOR_BITS) + (sint64)(prod_factor - 1)) / (sint64)prod_factor));
+					if (g.get_capacity(prod_factor) < 7) {
+						// No capacities less than 7 are allowed.  This allows for loading a whole (small) truck.
+						g.max = (sint32)( ( (sint64)7 << precision_bits << DEFAULT_PRODUCTION_FACTOR_BITS) / (sint64)prod_factor );
+					}
 				}
 			}
 		}
@@ -609,6 +617,10 @@ void fabrik_t::recalc_storage_capacities()
 				// Inputs are now normalized to factory production.
 				uint32 prod_factor = welt->get_settings().using_fab_contracts() ? 256 : input->get_consumption();
 				g.max = (sint32)(welt->scale_for_distance_only(((((sint64)input->get_capacity() * (sint64)prodbase) << (precision_bits + DEFAULT_PRODUCTION_FACTOR_BITS)) + (sint64)(prod_factor - 1)) / ((sint64)desc->get_productivity() * (sint64)prod_factor)));
+					if (g.get_capacity(prod_factor) < 7) {
+						// No capacities less than 7 are allowed.  This allows for loading a whole (small) truck.
+						g.max = (sint32)( ( (sint64)7 << precision_bits << DEFAULT_PRODUCTION_FACTOR_BITS) / (sint64)prod_factor );
+					}
 			}
 		}
 		// then, for output goods
@@ -617,6 +629,10 @@ void fabrik_t::recalc_storage_capacities()
 				// Outputs are now normalized to factory production.
 				uint32 prod_factor = welt->get_settings().using_fab_contracts() ? 256 : output->get_factor();
 				g.max = (sint32)(welt->scale_for_distance_only(((((sint64)output->get_capacity() * (sint64)prodbase) << (precision_bits + DEFAULT_PRODUCTION_FACTOR_BITS)) + (sint64)(prod_factor - 1)) / ((sint64)desc->get_productivity() * (sint64)prod_factor)));
+					if (g.get_capacity(prod_factor) < 7) {
+						// No capacities less than 7 are allowed.  This allows for loading a whole (small) truck.
+						g.max = (sint32)( ( (sint64)7 << precision_bits << DEFAULT_PRODUCTION_FACTOR_BITS) / (sint64)prod_factor );
+					}
 			}
 		}
 	}

--- a/simversion.h
+++ b/simversion.h
@@ -34,7 +34,7 @@ extern "C" FILE * __cdecl __iob_func(void) { return _iob; }
 #define SIM_SERVER_MINOR    7
 
 #define EX_VERSION_MAJOR	14
-#define EX_VERSION_MINOR	20
+#define EX_VERSION_MINOR	21
 #define EX_SAVE_MINOR		60
 
 // Do not forget to increment the save game versions in settings_stats.cc when changing this

--- a/simworld.cc
+++ b/simworld.cc
@@ -8365,22 +8365,56 @@ bool karte_t::square_is_free(koord k, sint16 w, sint16 h, int *last_y, climate_b
 }
 
 
-slist_tpl<koord> *karte_t::find_squares(sint16 w, sint16 h, climate_bits cl, uint16 regions_allowed, sint16 old_x, sint16 old_y) const
+slist_tpl<koord> *karte_t::find_squares(sint16 w, sint16 h, uint32 edge_avoidance_raw, climate_bits cl, uint16 regions_allowed, sint16 old_x, sint16 old_y) const
 {
 	slist_tpl<koord> * list = new slist_tpl<koord>();
 	koord start;
 	int last_y;
 
+	// The parameter edge_avoidance is a number of tiles to keep away from the edge of the map.
+	// The entire square must not be within the "buffer zone" at the edge of the map.
+	// This is because it can be annoying to have cities crushed against the game border.
+	//
+	// Note that the parameters old_x and old_y are used only for enlarge_map (otherwise they're 0)
+	//
+	// -- Nathanael Nerode
+
+	// We need to do signed math with this.
+	sint16 edge_avoidance = 0;
+	// Note: edge_avoidance_raw is an unsigned int, so don't need to check for negatives
+	if (edge_avoidance_raw > 127) {
+		// Sanity check.  Don't want THAT much edge avoidance. 2^7 - 1 is good enough for anyone.
+		edge_avoidance = 127;
+	} else {
+		// Bounds check passed: will fit into sint16.
+		edge_avoidance = edge_avoidance_raw;
+	}
+
+	// Need to do SIGNED math.
+	// Note: may be larger than map size, this is OK, caught by the for loop condition
+	sint16 lowest_x = (sint16)0 + edge_avoidance;
+	sint16 lowest_y = (sint16)0 + edge_avoidance;
+	// Note: may be negative, this is OK, caught by the for loop condition
+	sint16 highest_x_plus_one = get_size().x - edge_avoidance - w;
+	sint16 highest_y_plus_one = get_size().y - edge_avoidance - h;
+
+	// Expansion: areas formerly avoided because at map lower/right edge, aren't at map edge any more
+	// So it's OK to add new cities to this former-edge part of the map *now*
+	// However, don't find spaces in the left/top buffer zone of the map
+	sint16 lowest_expansion_x = (sint16) max(old_x - edge_avoidance, lowest_x);
+	sint16 lowest_expansion_y = (sint16) max(old_y - edge_avoidance, lowest_y);
+
+
 DBG_DEBUG("karte_t::finde_plaetze()","for size (%i,%i) in map (%i,%i)",w,h,get_size().x,get_size().y );
-	for(start.x=0; start.x<get_size().x-w; start.x++) {
-		for(start.y=start.x<old_x?old_y:0; start.y<get_size().y-h; start.y++) {
+	for(start.x = lowest_x; start.x < highest_x_plus_one; start.x++) {
+		for(start.y = start.x < lowest_expansion_x ? lowest_expansion_y : lowest_y; start.y < highest_y_plus_one; start.y++) {
 			if(square_is_free(start, w, h, &last_y, cl, regions_allowed)) {
 				list->insert(start);
 			}
 			else {
-				// Optimiert fuer groessere Felder, hehe!
-				// Die Idee: wenn bei 2x2 die untere Reihe nicht geht, koennen
-				// wir gleich 2 tiefer weitermachen! V. Meyer
+				// Optimized for larger fields
+				// The idea: if the bottom row doesn't work in 2x2,
+				// we can continue 2 deeper - V. Meyer
 				start.y = last_y;
 			}
 		}

--- a/simworld.cc
+++ b/simworld.cc
@@ -8365,7 +8365,7 @@ bool karte_t::square_is_free(koord k, sint16 w, sint16 h, int *last_y, climate_b
 }
 
 
-slist_tpl<koord> *karte_t::find_squares(sint16 w, sint16 h, uint32 edge_avoidance_raw, climate_bits cl, uint16 regions_allowed, sint16 old_x, sint16 old_y) const
+slist_tpl<koord> *karte_t::find_squares(sint16 w, sint16 h, sint16 edge_avoidance, climate_bits cl, uint16 regions_allowed, sint16 old_x, sint16 old_y) const
 {
 	slist_tpl<koord> * list = new slist_tpl<koord>();
 	koord start;
@@ -8378,10 +8378,6 @@ slist_tpl<koord> *karte_t::find_squares(sint16 w, sint16 h, uint32 edge_avoidanc
 	// Note that the parameters old_x and old_y are used only for enlarge_map (otherwise they're 0)
 	//
 	// -- Nathanael Nerode
-
-	// We need to do signed math with this.
-	sint16 edge_avoidance = (sint16) edge_avoidance_raw;
-	// Note that edge_avoidance has been clamped to a correct size when first read from the tabfile.
 
 	// Need to do SIGNED math.
 	// Note: may be larger than map size, this is OK, caught by the for loop condition

--- a/simworld.cc
+++ b/simworld.cc
@@ -8380,15 +8380,8 @@ slist_tpl<koord> *karte_t::find_squares(sint16 w, sint16 h, uint32 edge_avoidanc
 	// -- Nathanael Nerode
 
 	// We need to do signed math with this.
-	sint16 edge_avoidance = 0;
-	// Note: edge_avoidance_raw is an unsigned int, so don't need to check for negatives
-	if (edge_avoidance_raw > 127) {
-		// Sanity check.  Don't want THAT much edge avoidance. 2^7 - 1 is good enough for anyone.
-		edge_avoidance = 127;
-	} else {
-		// Bounds check passed: will fit into sint16.
-		edge_avoidance = edge_avoidance_raw;
-	}
+	sint16 edge_avoidance = (sint16) edge_avoidance_raw;
+	// Note that edge_avoidance has been clamped to a correct size when first read from the tabfile.
 
 	// Need to do SIGNED math.
 	// Note: may be larger than map size, this is OK, caught by the for loop condition

--- a/simworld.cc
+++ b/simworld.cc
@@ -6751,12 +6751,13 @@ sint32 karte_t::generate_passengers_or_mail(const goods_desc_t * wtyp)
 					/**
 					* As there are no jobs, this is not a destination for commuting
 					*/
-					if (n < destination_count - 1)
+					if (n < destination_count + extend_count - 1)
 					{
 						current_destination = find_destination(trip, pax.get_class());
-
-						if (extend_count < destination_count * 4)
+						if (extend_count < destination_count * 1024)
 						{
+							// Keep looking for jobs.  This is important in early game on large maps
+							// when towns are small, the network is disconnected, and travel times are long.
 							extend_count++;
 						}
 					}
@@ -6835,6 +6836,13 @@ sint32 karte_t::generate_passengers_or_mail(const goods_desc_t * wtyp)
 				if (n < destination_count + extend_count - 1)
 				{
 					current_destination = find_destination(trip, pax.get_class());
+					if (trip == commuting_trip && extend_count < destination_count * 1024)
+					{
+						// Keep looking for jobs in the case of a commuting trip.
+						// This is critically important in early game on a large map
+						// with a disconnected network and slow travel times.
+						extend_count++;
+					}
 				}
 				continue;
 			}

--- a/simworld.h
+++ b/simworld.h
@@ -2442,7 +2442,7 @@ public:
 	 * @return A list of all buildable squares with size w, h.
 	 * @note Only used for town creation at the moment.
 	 */
-	slist_tpl<koord> * find_squares(sint16 w, sint16 h, uint32 edge_avoidance, climate_bits cl, uint16 regions_allowed, sint16 old_x, sint16 old_y) const;
+	slist_tpl<koord> * find_squares(sint16 w, sint16 h, sint16 edge_avoidance, climate_bits cl, uint16 regions_allowed, sint16 old_x, sint16 old_y) const;
 
 	/**
 	 * Plays the sound when the position is inside the visible region.

--- a/simworld.h
+++ b/simworld.h
@@ -2442,7 +2442,7 @@ public:
 	 * @return A list of all buildable squares with size w, h.
 	 * @note Only used for town creation at the moment.
 	 */
-	slist_tpl<koord> * find_squares(sint16 w, sint16 h, climate_bits cl, uint16 regions_allowed, sint16 old_x, sint16 old_y) const;
+	slist_tpl<koord> * find_squares(sint16 w, sint16 h, uint32 edge_avoidance, climate_bits cl, uint16 regions_allowed, sint16 old_x, sint16 old_y) const;
 
 	/**
 	 * Plays the sound when the position is inside the visible region.


### PR DESCRIPTION
This is built on top of my previous patches.  Please review those first.  I can break this out separately if needed, though.

This is the result of a lot of testing to figure out what was causing staff shortages in the early game.  This patch makes the engine try a lot harder to find an actual building, with jobs, within possible commuting range.  

My extensive testing shows that in pak128.britain, this resolves the problem with villages with multiple factories, except for the market, which needs to have its job capacity reduced (done with a patch to pak128.britain, elsewhere).

The problem was that the commuters in the village (a) could not reach any other village within the required time for commuting, and (b) were, at random, only looking for destinations in other villages.  By looking for destinations until a possible destination which can actually be reached is actually found, the passengers will actually start going to the factories which are next door.

A logic bug was fixed at the same time: commuters were supposed to try again if they targeted a factory with no available jobs, but the counting was incorrect.