### PR TITLE
For commute trips: find additional jobs if

### DIFF
--- a/simworld.cc
+++ b/simworld.cc
@@ -6129,12 +6129,13 @@ sint32 karte_t::generate_passengers_or_mail(const goods_desc_t * wtyp)
 					/**
 					* As there are no jobs, this is not a destination for commuting
 					*/
-					if (n < destination_count - 1)
+					if (n < destination_count + extend_count - 1)
 					{
 						current_destination = find_destination(trip, pax.get_class());
-
-						if (extend_count < destination_count * 4)
+						if (extend_count < destination_count * 1024)
 						{
+							// Keep looking for jobs.  This is important in early game on large maps
+							// when towns are small, the network is disconnected, and travel times are long.
 							extend_count++;
 						}
 					}
@@ -6213,6 +6214,13 @@ sint32 karte_t::generate_passengers_or_mail(const goods_desc_t * wtyp)
 				if (n < destination_count + extend_count - 1)
 				{
 					current_destination = find_destination(trip, pax.get_class());
+					if (trip == commuting_trip && extend_count < destination_count * 1024)
+					{
+						// Keep looking for jobs in the case of a commuting trip.
+						// This is critically important in early game on a large map
+						// with a disconnected network and slow travel times.
+						extend_count++;
+					}
 				}
 				continue;
 			}


### PR DESCRIPTION
the buildings found so far are either too far away to get to by any means, or has no jobs or no supply.  Also fix a preexisting logic error in the count.

This is the result of a lot of testing to figure out what was causing staff shortages in the early game. This patch makes the engine try a lot harder to find an actual building, with jobs, within possible commuting range.  Importantly, it doesn't increase compute time in the case where actual buildings with jobs within commuting range were already being found.

My extensive testing shows that in pak128.britain, this resolves the problem with villages with multiple factories not sending any workers to them -- except for the market, which needs to have its job capacity reduced (done with a patch to pak128.britain, elsewhere).

The problem was that the commuters in the village (a) could not reach any other village within the required time for commuting, and (b) were, at random, only looking for destinations in other villages. By looking for destinations until a possible destination which can actually be reached is actually found, the passengers will actually start going to the factories which are next door.

A logic bug was fixed at the same time: commuters were supposed to try again if they targeted a factory with no available jobs, but the counting was incorrect.

I have refactored this so it applies cleanly without applying the minimum factory capacity patch.