### PR TITLE
FIX: Allow river fords on roads to industries!

### DIFF
--- a/bauer/wegbauer.cc
+++ b/bauer/wegbauer.cc
@@ -427,7 +427,8 @@ void way_builder_t::fill_menu(tool_selector_t *tool_selector, const waytype_t wt
 }
 
 
-/** allow for railroad crossing
+/**
+	allow for railroad crossing and river fords
  */
 bool way_builder_t::check_crossing(const koord zv, const grund_t *bd, waytype_t wtyp0, const player_t *player) const
 {
@@ -487,10 +488,22 @@ bool way_builder_t::check_crossing(const koord zv, const grund_t *bd, waytype_t 
 			return false;
 		}
 
-		if (forbid_crossings && !(w->get_owner() == NULL && w->is_degraded() == true))
+		if (forbid_crossings)
 		{
-			// Do not allow crossings where the forbid crossings flag has been set except where the way to be crossed is unowned and degraded.
-			return false;
+			if (w->get_waytype() == water_wt && crd->get_maxspeed(1) == 0 && w->get_max_speed() == 0)
+			{
+				// This is a ford.  Allow the crossing.
+				// [Intentionally empty code block]
+			}
+			else if (w->get_owner() == NULL && w->is_degraded() == true)
+			{
+				// Unowned AND degraded.  Allow the crossing.
+				// [Intentionally empty code block]
+			}
+			else {
+				// None of the exceptions to the forbid_crossings rule applies; forbid it.
+				return false;
+			}
 		}
 
 		ribi_t::ribi w_ribi = w->get_ribi_unmasked();

--- a/bauer/wegbauer.h
+++ b/bauer/wegbauer.h
@@ -160,8 +160,9 @@ private:
 	bool mark_way_for_upgrade_only;
 
 	/**
-	* If set, the way builder will not build crossings over
-	* ways other than unowned and fully degraded ways.
+	* If set, the way builder will not build crossings except:
+	* fords over non-navigable rivers,
+	* and crossings over ways which are both unowned and fully degraded.
 	*/
 	bool forbid_crossings = false;
 


### PR DESCRIPTION
I figured out why the roads to industries were not building river fords.  They set a flag to forbid_crossings, which is intended to avoid creating grade crossings across player railways.  But it was forbidding all crossings.  This patches it so that this flag (which is only used for this purpose) allows the creation of fords across non-navigable rivers.

With this fixed, we should stop having so many prebuilt stone bridges in 1750 maps.  Hooray!