### PR TITLE
Add behavior to prevent AI from entering intersections when they are blocked.

### DIFF
--- a/vehicle/road_vehicle.cc
+++ b/vehicle/road_vehicle.cc
@@ -857,15 +857,53 @@ bool road_vehicle_t::can_enter_tile(const grund_t *gr, sint32 &restart_speed, ui
 		const grund_t *gr = route_index_beyond_end_of_route ? NULL : welt->lookup(r.at(route_index));
 		const strasse_t *stre = gr ? (strasse_t *)gr->get_weg(road_wt) : NULL;
 		const ribi_t::ribi way_ribi = stre ? stre->get_ribi_unmasked() : ribi_t::none;
-		if(  stre  &&  stre->get_overtaking_mode() <= oneway_mode  &&  (way_ribi == ribi_t::all  ||  ribi_t::is_threeway(way_ribi))  ) {
-			if(  const vehicle_base_t* v = other_lane_blocked(true)  ) {
-				if(  road_vehicle_t const* const at = obj_cast<road_vehicle_t>(v)  ) {
-					if(  at->get_convoi()->get_akt_speed()!=0  &&  judge_lane_crossing(calc_direction(get_pos(),pos_next), calc_direction(pos_next,pos_next2), at->get_90direction(), cnv->is_overtaking(), false)  ) {
-						// vehicle must stop.
-						restart_speed = 0;
-						cnv->reset_waiting();
-						cnv->set_next_cross_lane(true);
-						return false;
+		if(stre && (way_ribi == ribi_t::all  ||  ribi_t::is_threeway(way_ribi))){
+
+			//Check to see if the tile after the intersection is occupied.
+			unsigned int intersection_offset = 1u;
+			const grund_t *next_gr = NULL;
+			const strasse_t *next_stre = NULL;
+			ribi_t::ribi next_way_ribi = ribi_t::none;
+			while(true){ //find the next non-intersection tile on our route (this has to account for multiple intersections in a row)
+				next_gr = route_index_beyond_end_of_route ? NULL : welt->lookup(r.at(route_index + intersection_offset));
+				if(!next_gr){ 
+					break; //if it's end of the route, stop
+				}
+				next_stre = next_gr ? (strasse_t *)next_gr->get_weg(road_wt) : NULL;
+				if(next_stre){
+					next_way_ribi = next_stre->get_ribi_unmasked();
+					if(!ribi_t::is_threeway(next_way_ribi)){ 
+						break; //we've found the next non-intersection tile on our route
+					}
+				}
+				intersection_offset++;
+			}
+
+			if(next_gr && next_stre){ //assuming we haven't reached the end of our route:
+				ribi_t::ribi next_90direction_2 = calc_direction(welt->lookup(r.at(route_index+intersection_offset - 1u))->get_pos(), next_gr->get_pos());
+
+				//get the direction the convoy will be facing at the end of the intersection(s)
+				vehicle_base_t *obj2 = get_blocking_vehicle(next_gr, cnv, curr_direction, next_direction, next_90direction_2, NULL, next_lane);
+				//check to see if there is someone blocking us at the end of the intersection(s)
+
+				if(obj2){//there is a blocking convoy!
+					//Vehicle must stop.
+					restart_speed = 0;
+					cnv->reset_waiting();
+					return false;
+				}
+				
+			}
+			if(stre->get_overtaking_mode() <= oneway_mode){
+				if(  const vehicle_base_t* v = other_lane_blocked(true)  ) {
+					if(  road_vehicle_t const* const at = obj_cast<road_vehicle_t>(v)  ) {
+						if(  at->get_convoi()->get_akt_speed()!=0  &&  judge_lane_crossing(calc_direction(get_pos(),pos_next), calc_direction(pos_next,pos_next2), at->get_90direction(), cnv->is_overtaking(), false)  ) {
+							// vehicle must stop.
+							restart_speed = 0;
+							cnv->reset_waiting();
+							cnv->set_next_cross_lane(true);
+							return false;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
In reference to #627 .
Currently, if a road convoy sees an intersection on its route, it will enter that intersection regardless of whether it can actually leave that intersection - if the next spot after the intersection is occupied, this frequently leads to gridlock that can only be stopped by very careful route design. This is not only aggravating but also contrary to the rules of the road in most countries.
For instance, this route where a bus goes A->B->C->D->A is crippled by a single bus entering the intersection:

![image](https://github.com/jamespetts/simutrans-extended/assets/10407111/9ab67b6c-6f7f-4b59-a97f-c6935d2145b8)
The rule added here checks for if:
- At the first non-intersection tile after an intersection,
- There is a road vehicle already in place

If there is, the convoy will wait for that tile to be clear.

![image](https://github.com/jamespetts/simutrans-extended/assets/10407111/b415e408-3b74-46a3-9c28-2a05b623b8e7)

As far as I can tell, it works fine, but in cases where a tile becomes occupied in between a convoy entering an intersection and it reaching the end, there is still a possibility of a convoy ending up blocked in an intersection. Other than that, this should solve most cases of gridlock from arising.