### PR TITLE
CHG: announce the player's foundation and name change.

### DIFF
--- a/player/simplay.cc
+++ b/player/simplay.cc
@@ -253,6 +253,12 @@ const char* player_t::get_name() const
 
 void player_t::set_name(const char *new_name)
 {
+	if( env_t::networkmode ) {
+		cbuffer_t buf;
+		buf.printf(translator::translate("%s now known as %s."), player_name_buf, new_name);
+		welt->get_message()->add_message(buf, koord::invalid, message_t::ai, color_idx_to_rgb(player_color_1));
+	}
+
 	tstrncpy( player_name_buf, new_name, lengthof(player_name_buf) );
 
 	// update player window

--- a/simworld.cc
+++ b/simworld.cc
@@ -10255,11 +10255,29 @@ const char *karte_t::init_new_player(uint8 new_player_in, uint8 type)
 	if(  new_player_in>=PLAYER_UNOWNED  ||  get_player(new_player_in)!=NULL  ) {
 		return "Id invalid/already in use!";
 	}
+	cbuffer_t buf;
 	switch( type ) {
 		case player_t::EMPTY: break;
-		case player_t::HUMAN: players[new_player_in] = new player_t(new_player_in); break;
-		case player_t::AI_GOODS: players[new_player_in] = new ai_goods_t(new_player_in); break;
-		case player_t::AI_PASSENGER: players[new_player_in] = new ai_passenger_t(new_player_in); break;
+		case player_t::HUMAN:
+			players[new_player_in] = new player_t(new_player_in);
+			if( env_t::networkmode ){
+				buf.printf(translator::translate("%s founded new company %s."), env_t::nickname.c_str(), players[new_player_in]->get_name());
+			}
+			else{
+				buf.printf(translator::translate("Now %s was founded."), players[new_player_in]->get_name());
+			}
+			msg->add_message(buf, koord::invalid, message_t::ai, PLAYER_FLAG | new_player_in, IMG_EMPTY);
+			break;
+		case player_t::AI_GOODS:
+			players[new_player_in] = new ai_goods_t(new_player_in);
+			buf.printf(translator::translate("Now %s was founded. (Operating by Goods-AI)"), players[new_player_in]->get_name());
+			msg->add_message(buf, koord::invalid, message_t::ai, PLAYER_FLAG | new_player_in, IMG_EMPTY);
+			break;
+		case player_t::AI_PASSENGER:
+			players[new_player_in] = new ai_passenger_t(new_player_in);
+			buf.printf(translator::translate("Now %s was founded. (Operating by Passenger-AI)"), players[new_player_in]->get_name());
+			msg->add_message(buf, koord::invalid, message_t::ai, PLAYER_FLAG | new_player_in, IMG_EMPTY);
+			break;
 		default: return "Unknown AI type!";
 	}
 	settings.set_player_type(new_player_in, type);


### PR DESCRIPTION
This patch was mentioned in the standard forum a while ago, and since it's a small change I thought I'd create and post a patch before it fades into oblivion.

Although notification messages are provided when a company is taken over or player nickname is changed, there are no notifications when a company is founded or company name is changed, resulting in inconsistent behavior and delaying the opportunity for uninvolved players to become aware of the facts.