### PR TITLE
FIX: pax and seat km graph labels deduped

### DIFF
--- a/gui/components/gui_chart.cc
+++ b/gui/components/gui_chart.cc
@@ -79,6 +79,7 @@ uint32 gui_chart_t::add_curve(PIXVAL color, const sint64 *values, int size, int 
 		case FORCE:    new_curve.suffix = "kN";   break;
 		case KMPH:     new_curve.suffix = "km/h"; break;
 		case PAX_KM:   new_curve.suffix = translator::translate("pkm");  break;
+		case SEAT_KM:  new_curve.suffix = translator::translate("skm");  break;
 		case KG_KM:    new_curve.suffix = translator::translate("kgkm"); break;
 		case TON_KM:
 		case TON_KM_MAIL:

--- a/gui/components/gui_chart.h
+++ b/gui/components/gui_chart.h
@@ -21,7 +21,7 @@ public:
 	enum chart_marker_t { square = 0, cross, diamond, round_box, none };
 	// NOTE: KMPH and FORCE hacks drawing accuracy and should not be mixed with other types
 	// CURVE TYPES
-	enum chart_suffix_t { STANDARD = 0, MONEY, PERCENT, DISTANCE, KMPH, FORCE, PAX_KM, KG_KM, TON_KM, TON_KM_MAIL, KW,/* WATT,*/ TONNEN, TIME };
+	enum chart_suffix_t { STANDARD = 0, MONEY, PERCENT, DISTANCE, KMPH, FORCE, PAX_KM, SEAT_KM, KG_KM, TON_KM, TON_KM_MAIL, KW,/* WATT,*/ TONNEN, TIME };
 
 	/**
 	 * Set background color. -1 means no background

--- a/gui/convoi_info_t.cc
+++ b/gui/convoi_info_t.cc
@@ -72,7 +72,7 @@ static const uint8 cost_type_color[BUTTON_COUNT] =
 
 static const uint8 cost_type_money[BUTTON_COUNT] =
 {
-	gui_chart_t::PAX_KM,
+	gui_chart_t::SEAT_KM,
 	gui_chart_t::PAX_KM,
 	gui_chart_t::KG_KM,
 	gui_chart_t::TON_KM,

--- a/gui/schedule_list.cc
+++ b/gui/schedule_list.cc
@@ -103,7 +103,7 @@ static uint8 statistic[MAX_LINE_COST]={
 };
 
 static uint8 statistic_type[MAX_LINE_COST]={
-	gui_chart_t::PAX_KM, gui_chart_t::PAX_KM, gui_chart_t::KG_KM, gui_chart_t::TON_KM,
+	gui_chart_t::SEAT_KM, gui_chart_t::PAX_KM, gui_chart_t::KG_KM, gui_chart_t::TON_KM,
 	gui_chart_t::DISTANCE, gui_chart_t::STANDARD, gui_chart_t::STANDARD, gui_chart_t::MONEY,
 	gui_chart_t::MONEY, gui_chart_t::MONEY, gui_chart_t::MONEY, gui_chart_t::MONEY, gui_chart_t::STANDARD, gui_chart_t::STANDARD, gui_chart_t::STANDARD
 };

--- a/simutrans/text/en.tab
+++ b/simutrans/text/en.tab
@@ -6260,6 +6260,8 @@ Bridges cannot be built over large buildings.
 Bridges cannot be built over these buildings.
 Cannot build pier on large buildings
 Elevated way supports cannot be built over these buildings.
+Seat-km
+Seat-km
 Pax-km
 Passenger km
 Mail-km
@@ -6268,6 +6270,8 @@ Freight-km
 Freight tonne km
 pkm
  pass. km
+skm
+ seat km
 kgkm
  kg km
 tkm

--- a/simutrans/text/ja.tab
+++ b/simutrans/text/ja.tab
@@ -4345,6 +4345,8 @@ Freight-km
 貨物輸送量
 pkm
 人km
+skm
+座席km
 kgkm
 kg・km
 tkm


### PR DESCRIPTION
Adds a case for seat-km in the line and convoy graph curves, adds missing localization