### PR TITLE
FIX: possible uninitialized variable

### DIFF
--- a/gui/city_info.cc
+++ b/gui/city_info.cc
@@ -147,7 +147,7 @@ bool city_location_map_t::infowin_event(const event_t *ev)
 
 
 city_info_t::city_info_t(stadt_t* city) :
-	gui_frame_t( name, NULL ),
+	gui_frame_t( name ? name : "", NULL ),
 	city(city),
 	lb_allow_growth(""),
 	pax_map(city),


### PR DESCRIPTION
A strict compiler setting was failing on this line because name could be uninitialized.