### PR TITLE
Fix Windows resize handling under DPI scaling

### DIFF
--- a/simevent.cc
+++ b/simevent.cc
@@ -261,5 +261,23 @@ void display_poll_event(event_t* const ev)
 
 void queue_event(event_t *events)
 {
+	// A window resize is current state, not history: only the newest client
+	// size is meaningful and an older one must never be applied after it. The
+	// loading screen stores the resizes it consumes and flushes them back here
+	// when destroyed, and the next loading screen consumes and stores them
+	// again, so without this an obsolete size is replayed and can be applied
+	// after the real one, leaving the renderer smaller than the window.
+	if(  events->ev_class == EVENT_SYSTEM  &&  events->ev_code == SYSTEM_RESIZE  ) {
+		for(  slist_tpl<event_t *>::iterator i = queued_events.begin();  i != queued_events.end();  ) {
+			event_t *old_ev = *i;
+			if(  old_ev->ev_class == EVENT_SYSTEM  &&  old_ev->ev_code == SYSTEM_RESIZE  ) {
+				i = queued_events.erase(i);
+				delete old_ev;
+			}
+			else {
+				++i;
+			}
+		}
+	}
 	queued_events.append(events);
 }

--- a/sys/simsys_w.cc
+++ b/sys/simsys_w.cc
@@ -304,8 +304,14 @@ int dr_textur_resize(unsigned short** const textur, int w, int const h)
 
 	AllDib->bmiHeader.biWidth  = img_w;
 	AllDib->bmiHeader.biHeight = img_h;
-	WindowSize.right           = w;
-	WindowSize.bottom          = h;
+	// WindowSize is in physical client pixels: dr_os_open fills it that way and
+	// WM_PAINT consumes it that way, both as the blit destination and to derive
+	// the framebuffer height. w and h arrive here in logical pixels, so they have
+	// to be scaled back up. Storing them unscaled only matches at 100% scaling;
+	// above it every repaint after a resize paints into a too small rectangle and
+	// overwrites biHeight with a framebuffer height that is too small.
+	WindowSize.right           = (w * x_scale) / 32;
+	WindowSize.bottom          = (h * y_scale) / 32;
 
 #ifdef MULTI_THREAD
 	LeaveCriticalSection( &redraw_underway );
@@ -490,6 +496,16 @@ static inline unsigned int ModifierKeys()
 }
 
 
+// The client size is state, not history. sys_event holds a single pending
+// event and one message retrieval can dispatch several messages (the sent
+// ones, WM_SIZE among them, before the posted one is returned), so a resize
+// written into the slot is lost when a later message of the same retrieval
+// overwrites it. Keep only the newest client size here and let GetEvents()
+// hand it to the slot as soon as the slot is free.
+static bool resize_pending   = false;
+static int  resize_pending_w = 0;
+static int  resize_pending_h = 0;
+
 /* Windows eventhandler: does most of the work */
 LRESULT WINAPI WindowProc(HWND this_hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
@@ -616,18 +632,20 @@ LRESULT WINAPI WindowProc(HWND this_hwnd, UINT msg, WPARAM wParam, LPARAM lParam
 
 		case WM_SIZE: // resize client area
 			if(lParam!=0) {
-				sys_event.type = SIM_SYSTEM;
-				sys_event.code = SYSTEM_RESIZE;
-
-				sys_event.new_window_size.w = (LOWORD(lParam)*32)/x_scale;
-				if (sys_event.new_window_size.w <= 0) {
-					sys_event.new_window_size.w = 4;
+				// only the newest size matters; GetEvents() delivers it
+				int w = (LOWORD(lParam)*32)/x_scale;
+				if (w <= 0) {
+					w = 4;
 				}
 
-				sys_event.new_window_size.h = (HIWORD(lParam)*32)/y_scale;
-				if (sys_event.new_window_size.h <= 1) {
-					sys_event.new_window_size.h = 64;
+				int h = (HIWORD(lParam)*32)/y_scale;
+				if (h <= 1) {
+					h = 64;
 				}
+
+				resize_pending_w = w;
+				resize_pending_h = h;
+				resize_pending   = true;
 			}
 			break;
 
@@ -942,6 +960,15 @@ static void internal_GetEvents(bool const wait)
 
 void GetEvents()
 {
+	if (sys_event.type==SIM_NOEVENT  &&  resize_pending) {
+		// the newest client size goes out before anything else is fetched
+		sys_event.type = SIM_SYSTEM;
+		sys_event.code = SYSTEM_RESIZE;
+		sys_event.new_window_size.w = resize_pending_w;
+		sys_event.new_window_size.h = resize_pending_h;
+		resize_pending = false;
+		return;
+	}
 	if (sys_event.type==SIM_NOEVENT  &&  PeekMessage(&msg, NULL, 0, 0, PM_NOREMOVE)) {
 		internal_GetEvents(false);
 	}


### PR DESCRIPTION
## Summary

This fixes two independent Windows resize problems on the GDI path:

1. a resize event could be overwritten before the new size was applied;
2. under Windows display scaling, `WindowSize` was produced in logical pixels but consumed as
   physical ones, so the window was repainted at the wrong size after a resize.

They are independent: the second one is invisible at 100 % scaling, the first one is not.

Related to the behaviour reported in forum topic
[23805](https://forum.simutrans.com/index.php/topic,23805.0.html).

## Resize event loss

`sys_event` holds a single pending event, but one message retrieval dispatches every sent message
before it returns the posted one, so `WM_SIZE` writes the slot and a later message of the same
retrieval overwrites it. Maximizing triggers it because the window grows under the mouse pointer
and Windows follows `WM_SIZE` with a `WM_MOUSEMOVE`. Separately, the loading screen stores the
resizes it consumes and flushes them back, so an obsolete size could be applied after the real one.

`WM_SIZE` now keeps only the newest client size, `GetEvents()` hands it to the slot as soon as the
slot is free, and `queue_event()` drops already queued `SYSTEM_RESIZE` events.

## DPI unit mismatch

`dr_os_open` fills `WindowSize` from `MaxSize`, which is scaled up, and `WM_PAINT` consumes it as
physical client pixels — both as the `StretchDIBits` destination and to recompute
`AllDib->bmiHeader.biHeight`. But `dr_textur_resize` stored the logical size it is passed.

At 100 % scaling the two are the same number and nothing shows. Above it, every repaint after a
resize painted into a rectangle smaller than the client area: with a 3440x1369 client at 150 %,
`WindowSize` held 2304x912.

## Extended-specific implementation

This is not a copy of the Simutrans Standard patch. `sys_event.new_window_size` is a `scr_size`
here, so the fields are `.w`/`.h`, and since `scr_coord_val` is `sint32` the pending state needs no
cast — Standard's `uint16` fields do. The change was derived and measured against this code base.

## Validation

Measured on this branch's base, at 150 % and 100 % screen scaling, with a lab-only trace of the
producer/consumer contract and negative controls that remove each half separately:

- without the DPI correction: 2/2 runs fail, `WindowSize` holding the logical size
- without the event-delivery correction: the maximize resize is lost in 1 of 4 runs (it is a race)
- with the full change at 150 %: 2/2 pass, `WindowSize` = 3456x1368 for a 3440x1369 client
- with the full change at 100 %: pass, no regression
- GDI and SDL2 both build with 0 errors, 385 objects each, and the warning set is unchanged from
  the unpatched baseline

## Scope

Only `simevent.cc` and `sys/simsys_w.cc`. `sys/simsys_w.cc` is Windows/GDI only; `simevent.cc` is
shared by every backend, which is why SDL2 is included above. No savegame format change, no pak
format change, no new dependencies, nothing unrelated.
